### PR TITLE
Create MathMentor AI interface for math-focused assistant

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,49 +2,61 @@
 <html lang="tr">
 <head>
   <meta charset="UTF-8">
-  <title>MemTube</title>
+  <title>MathMentor AI</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
-  <!-- Kayıt Ekranı -->
-  <div id="girisEkrani">
-    <h2>MemTube'e Giriş</h2>
-    <input type="text" id="kullaniciAdi" placeholder="Takma Ad (zorunlu)">
-    <input type="file" id="profilResmi" accept="image/*">
-    <button onclick="girisYap()">Giriş Yap</button>
-  </div>
-
-  <!-- Ana Ekran -->
-  <div id="anaEkran" class="gizli">
-    <header>
-      <h1>📺 MemTube</h1>
-      <input type="text" id="arama" placeholder="Ara...">
+  <div class="app-shell">
+    <header class="top-bar">
+      <div class="brand">
+        <div class="brand-mark">MM</div>
+        <div class="brand-text">
+          <span class="brand-name">MathMentor AI</span>
+          <small class="brand-tag">Mavi & beyaz matematik asistanı</small>
+        </div>
+      </div>
+      <div class="user-actions">
+        <span id="selamlama" class="greeting" aria-live="polite"></span>
+        <button id="oturumAcBtn" class="primary" type="button">Oturum Aç</button>
+      </div>
     </header>
 
-    <!-- Ana Sayfa -->
-    <main id="anaSayfa">
-      <div id="videoListe" class="video-galeri"></div>
+    <main class="content">
+      <section class="hero">
+        <h1>Matematiğin her seviyesine hazır</h1>
+        <p>Toplama, çıkarma, kesirler, üslüler, kökler, sözel problemler ve çok daha fazlası için mavi-beyaz bir yapay zeka.</p>
+      </section>
+
+      <section class="chat-panel" aria-live="polite">
+        <div id="sohbet" class="chat-window" aria-label="Sohbet geçmişi"></div>
+        <div class="chat-actions">
+          <button id="temizleBtn" class="ghost" type="button">Sohbeti temizle</button>
+        </div>
+      </section>
     </main>
 
-    <!-- Hesabım Sayfası -->
-    <section id="hesabim" class="gizli">
-      <div id="profil">
-        <img id="profilGorsel" alt="Profil Resmi">
-        <h3 id="kAdi"></h3>
-      </div>
-      <h4>Videolarım</h4>
-      <input type="file" id="videoDosyasi" accept="video/*">
-      <input type="text" id="videoBaslik" placeholder="Video Başlığı">
-      <button onclick="videoYukle()">+ Yükle</button>
-      <div id="videolar" class="video-galeri"></div>
-    </section>
+    <footer class="prompt-bar">
+      <form id="soruFormu" class="prompt-form">
+        <label class="sr-only" for="soruGirdisi">Soru sor</label>
+        <input id="soruGirdisi" type="text" placeholder="Matematik sorunu yaz (örn. 3.(5+4) veya 4'te 3 artı 4'te 1)" autocomplete="off" required>
+        <button type="submit" class="primary">Sor</button>
+      </form>
+    </footer>
+  </div>
 
-    <!-- Alt Menü -->
-    <nav id="altMenu">
-      <button onclick="goAnaSayfa()">🏠</button>
-      <button onclick="goHesabim()">👤</button>
-    </nav>
+  <div id="modalKaplama" class="modal hidden" role="dialog" aria-modal="true">
+    <div class="modal-card">
+      <h2>Oturum Aç</h2>
+      <p>İsmini ve soyismini gir, sana o şekilde hitap edelim.</p>
+      <label for="isim">İsim</label>
+      <input id="isim" type="text" placeholder="Adın">
+      <label for="soyisim">Soyisim</label>
+      <input id="soyisim" type="text" placeholder="Soyadın">
+      <div class="modal-actions">
+        <button id="modalKapat" type="button" class="ghost">İptal</button>
+        <button id="modalKaydet" type="button" class="primary">Kaydet</button>
+      </div>
+    </div>
   </div>
 
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,97 +1,177 @@
-window.onload = () => {
-  const k = localStorage.getItem("kullaniciAdi");
-  const p = localStorage.getItem("profilResmi");
+const sohbet = document.getElementById("sohbet");
+const soruFormu = document.getElementById("soruFormu");
+const soruGirdisi = document.getElementById("soruGirdisi");
+const temizleBtn = document.getElementById("temizleBtn");
+const oturumAcBtn = document.getElementById("oturumAcBtn");
+const selamlama = document.getElementById("selamlama");
+const modalKaplama = document.getElementById("modalKaplama");
+const modalKaydet = document.getElementById("modalKaydet");
+const modalKapat = document.getElementById("modalKapat");
+const isimInput = document.getElementById("isim");
+const soyisimInput = document.getElementById("soyisim");
 
-  if (k && p) {
-    document.getElementById("girisEkrani").style.display = "none";
-    document.getElementById("anaEkran").classList.remove("gizli");
-    document.getElementById("kAdi").innerText = k;
-    document.getElementById("profilGorsel").src = p;
-    videolariYukle();
-  }
+const state = {
+  kullanici: null,
 };
 
-function girisYap() {
-  const k = document.getElementById("kullaniciAdi").value.trim();
-  const p = document.getElementById("profilResmi").files[0];
-
-  if (!k || !p) {
-    alert("Ad ve profil resmi gerekli kaptan!");
-    return;
+function yukleKullanici() {
+  const kayitli = localStorage.getItem("mathmentor-kullanici");
+  if (kayitli) {
+    state.kullanici = JSON.parse(kayitli);
+    selamlama.textContent = `Merhaba ${state.kullanici.ad}!`;
+    oturumAcBtn.textContent = "Hesap";
   }
-
-  const reader = new FileReader();
-  reader.onload = () => {
-    localStorage.setItem("kullaniciAdi", k);
-    localStorage.setItem("profilResmi", reader.result);
-    location.reload();
-  };
-  reader.readAsDataURL(p);
 }
 
-function goAnaSayfa() {
-  document.getElementById("hesabim").classList.add("gizli");
-  document.getElementById("anaSayfa").style.display = "block";
+function kaydetKullanici(ad, soyad) {
+  state.kullanici = { ad, soyad };
+  localStorage.setItem("mathmentor-kullanici", JSON.stringify(state.kullanici));
+  selamlama.textContent = `Merhaba ${ad}!`;
+  oturumAcBtn.textContent = "Hesap";
 }
 
-function goHesabim() {
-  document.getElementById("anaSayfa").style.display = "none";
-  document.getElementById("hesabim").classList.remove("gizli");
+function modalAc() {
+  modalKaplama.classList.remove("hidden");
+  isimInput.focus();
 }
 
-function videoYukle() {
-  const dosya = document.getElementById("videoDosyasi").files[0];
-  const baslik = document.getElementById("videoBaslik").value;
-  const kullanici = localStorage.getItem("kullaniciAdi");
-
-  if (!dosya || !baslik) {
-    alert("Video ve başlık eksik!");
-    return;
-  }
-
-  const videoURL = URL.createObjectURL(dosya);
-  const video = { baslik: baslik, url: videoURL, sahip: kullanici };
-
-  const mevcut = JSON.parse(localStorage.getItem("videolar") || "[]");
-  mevcut.push(video);
-  localStorage.setItem("videolar", JSON.stringify(mevcut));
-  videolariYukle();
-
-  document.getElementById("videoDosyasi").value = "";
-  document.getElementById("videoBaslik").value = "";
+function modalKapatFn() {
+  modalKaplama.classList.add("hidden");
+  isimInput.value = "";
+  soyisimInput.value = "";
 }
 
-function videolariYukle() {
-  const videolar = JSON.parse(localStorage.getItem("videolar") || "[]");
-  const liste = document.getElementById("videoListe");
-  const hesap = document.getElementById("videolar");
-  const kullanici = localStorage.getItem("kullaniciAdi");
+function mesajEkle(metin, kim = "asistan") {
+  const div = document.createElement("div");
+  div.className = `mesaj ${kim}`;
 
-  liste.innerHTML = "";
-  hesap.innerHTML = "";
+  const avatar = document.createElement("div");
+  avatar.className = "avatar";
+  avatar.textContent = kim === "kullanici" ? (state.kullanici?.ad?.[0] || "S") : "AI";
 
-  videolar.forEach((v, i) => {
-    const div = document.createElement("div");
-    div.className = "video";
-    div.innerHTML = `
-      <video src="${v.url}" controls></video>
-      <p>${v.baslik}</p>
-    `;
-    // Ana sayfaya herkesin videoları
-    liste.appendChild(div.cloneNode(true));
+  const icerik = document.createElement("div");
+  icerik.className = "icerik";
+  icerik.textContent = metin;
 
-    // Sadece kendi videolarına silme butonu
-    if (v.sahip === kullanici) {
-      const divHesap = div.cloneNode(true);
-      const silBtn = document.createElement("button");
-      silBtn.innerText = "❌";
-      silBtn.onclick = () => {
-        videolar.splice(i, 1);
-        localStorage.setItem("videolar", JSON.stringify(videolar));
-        videolariYukle();
-      };
-      divHesap.appendChild(silBtn);
-      hesap.appendChild(divHesap);
+  div.appendChild(avatar);
+  div.appendChild(icerik);
+  sohbet.appendChild(div);
+  sohbet.scrollTop = sohbet.scrollHeight;
+}
+
+function temizleSohbet() {
+  sohbet.innerHTML = "";
+  mesajEkle("Merhaba! MathMentor AI burada. Her seviye matematik sorusunu sorabilirsin.");
+}
+
+function isGreeting(metin) {
+  return /(merhaba|selam|naber|nasılsın|nasilsin|hello|hi)/i.test(metin);
+}
+
+function parseFractionWords(text) {
+  return text.replace(/(\d+)'?(?:te|ta|de|da)\s*(\d+)/gi, (_, payda, pay) => `(${pay}/${payda})`);
+}
+
+function parseArithmeticWords(text) {
+  return text
+    .replace(/çarpı|carpi|x|×/gi, "*")
+    .replace(/bölü|bolu|÷/gi, "/")
+    .replace(/artı|arti/gi, "+")
+    .replace(/eksi/gi, "-")
+    .replace(/üzeri|kare|kuvveti/gi, "**")
+    .replace(/,/g, ".");
+}
+
+function cozumleSozelProblem(soru) {
+  const sayilar = [...soru.matchAll(/-?\d+(?:,\d+)?/g)].map((m) => parseFloat(m[0].replace(",", ".")));
+  if (sayilar.length >= 2) {
+    const [ilkg, ikinci, ucuncu] = sayilar;
+    if (/yedi|harcadi|kaldı|kaldı\?|kac kald/i.test(soru)) {
+      return ilkg - (ucuncu ?? ikinci);
     }
-  });
+    if (/aldı|ekledi|kazandı|daha aldı|toplam/i.test(soru)) {
+      return ilkg + (ucuncu ?? ikinci);
+    }
+  }
+  if (/kaç tane 1/.test(soru) && sayilar.length) {
+    return sayilar[0];
+  }
+  if (/katı/.test(soru) && sayilar.length >= 2) {
+    return sayilar[0] * sayilar[1];
+  }
+  return null;
 }
+
+function evaluateExpression(input) {
+  const temiz = parseArithmeticWords(parseFractionWords(input));
+  const replaced = temiz.replace(/(\d)\.\(/g, "$1*(");
+  if (!/^[0-9+\-*/().^\s]*$/.test(replaced)) {
+    return null;
+  }
+  try {
+    // eslint-disable-next-line no-new-func
+    const sonuc = new Function(`return ${replaced}`)();
+    if (Number.isFinite(sonuc)) {
+      return sonuc;
+    }
+  } catch (e) {
+    return null;
+  }
+  return null;
+}
+
+function yanitOlustur(soruHam) {
+  const soru = soruHam.trim();
+  if (!soru) return "";
+
+  if (isGreeting(soru)) {
+    const ad = state.kullanici?.ad ? `, ${state.kullanici.ad}` : "";
+    return `Selam${ad}! Matematikle ilgili neyi merak ediyorsun?`;
+  }
+
+  const problemSonucu = cozumleSozelProblem(soru.toLowerCase());
+  if (problemSonucu !== null) {
+    return `Sonuç: ${problemSonucu}`;
+  }
+
+  const hesapSonucu = evaluateExpression(soru.toLowerCase());
+  if (hesapSonucu !== null) {
+    return `İşlemin cevabı: ${hesapSonucu}`;
+  }
+
+  return "Bu soruyu tam anlayamadım. Lütfen matematik sorunu biraz daha net yaz.";
+}
+
+soruFormu.addEventListener("submit", (e) => {
+  e.preventDefault();
+  const soru = soruGirdisi.value.trim();
+  if (!soru) return;
+
+  mesajEkle(soru, "kullanici");
+  const yanit = yanitOlustur(soru);
+  mesajEkle(yanit, "asistan");
+  soruGirdisi.value = "";
+  soruGirdisi.focus();
+});
+
+temizleBtn.addEventListener("click", temizleSohbet);
+
+oturumAcBtn.addEventListener("click", modalAc);
+modalKapat.addEventListener("click", modalKapatFn);
+modalKaplama.addEventListener("click", (e) => {
+  if (e.target === modalKaplama) modalKapatFn();
+});
+
+modalKaydet.addEventListener("click", () => {
+  const ad = isimInput.value.trim();
+  const soyad = soyisimInput.value.trim();
+  if (!ad || !soyad) {
+    alert("Lütfen ad ve soyad gir.");
+    return;
+  }
+  kaydetKullanici(ad, soyad);
+  modalKapatFn();
+});
+
+yukleKullanici();
+temizleSohbet();

--- a/style.css
+++ b/style.css
@@ -1,108 +1,276 @@
+:root {
+  --mavi: #0d6efd;
+  --mavi-acik: #e7f1ff;
+  --beyaz: #ffffff;
+  --gri: #f2f4f7;
+  --metin: #0f172a;
+  --ikincil: #64748b;
+  --cerceve: #d8e2ef;
+  --golge: 0 10px 30px rgba(0, 56, 135, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
-  background-color: #0d0d0d;
-  color: white;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: linear-gradient(135deg, #f7fbff 0%, #e8f1ff 50%, #ffffff 100%);
+  color: var(--metin);
 }
 
-.gizli {
-  display: none;
-}
-
-#girisEkrani {
-  text-align: center;
-  padding: 40px;
-}
-
-#girisEkrani input, #girisEkrani button {
-  display: block;
-  margin: 10px auto;
-  padding: 10px;
-  width: 80%;
-}
-
-header {
-  background-color: #1a1a1a;
-  padding: 10px;
+.app-shell {
+  min-height: 100vh;
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+}
+
+.top-bar {
+  display: flex;
   align-items: center;
+  justify-content: space-between;
+  padding: 16px 24px;
+  background: var(--beyaz);
+  border-bottom: 1px solid var(--cerceve);
+  box-shadow: var(--golge);
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
-#arama {
-  padding: 8px;
-  border-radius: 5px;
-  border: none;
-}
-
-.video-galeri {
+.brand {
   display: flex;
-  flex-wrap: wrap;
-  gap: 15px;
-  justify-content: center;
-  padding: 20px;
+  align-items: center;
+  gap: 12px;
 }
 
-.video {
-  background: #1a1a1a;
-  padding: 10px;
+.brand-mark {
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, var(--mavi), #0b4fb0);
+  color: var(--beyaz);
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  letter-spacing: 0.5px;
+}
+
+.brand-name {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.brand-tag {
+  color: var(--ikincil);
+}
+
+.user-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.greeting {
+  color: var(--ikincil);
+  min-height: 24px;
+}
+
+.content {
+  flex: 1;
+  width: min(1100px, 95%);
+  margin: 24px auto 120px auto;
+  display: grid;
+  gap: 16px;
+}
+
+.hero {
+  background: var(--beyaz);
+  border: 1px solid var(--cerceve);
+  border-radius: 18px;
+  padding: 18px 20px;
+  box-shadow: var(--golge);
+}
+
+.hero h1 {
+  margin: 0 0 6px 0;
+  font-size: 1.8rem;
+}
+
+.hero p {
+  margin: 0;
+  color: var(--ikincil);
+}
+
+.chat-panel {
+  background: var(--beyaz);
+  border: 1px solid var(--cerceve);
+  border-radius: 18px;
+  padding: 12px 16px 0 16px;
+  box-shadow: var(--golge);
+  display: flex;
+  flex-direction: column;
+}
+
+.chat-window {
+  min-height: 360px;
+  max-height: 520px;
+  overflow-y: auto;
+  padding: 12px 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mesaj {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 12px;
+  align-items: start;
+}
+
+.mesaj .avatar {
+  width: 36px;
+  height: 36px;
   border-radius: 10px;
-  width: 200px;
-  text-align: center;
-  position: relative;
+  background: var(--mavi-acik);
+  color: #0b3e86;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
 }
 
-.video video {
-  width: 100%;
-  border-radius: 5px;
+.mesaj .icerik {
+  background: var(--gri);
+  padding: 10px 12px;
+  border-radius: 12px;
+  line-height: 1.5;
+  color: #0b1f44;
 }
 
-.video button {
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  background: red;
-  color: white;
-  border: none;
-  border-radius: 50%;
-  padding: 5px;
-  cursor: pointer;
+.mesaj.asistan .icerik {
+  background: #e7f1ff;
+  border: 1px solid #c9dcff;
 }
 
-#profil {
-  text-align: center;
-  margin-top: 20px;
+.chat-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 0;
 }
 
-#profil img {
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  object-fit: cover;
-  background-color: white;
-}
-
-#videoDosyasi, #videoBaslik {
-  display: block;
-  margin: 10px auto;
-  padding: 8px;
-  width: 80%;
-}
-
-nav#altMenu {
+.prompt-bar {
   position: fixed;
   bottom: 0;
   width: 100%;
-  background: #111;
-  display: flex;
-  justify-content: space-around;
-  padding: 10px 0;
+  background: rgba(255, 255, 255, 0.96);
+  border-top: 1px solid var(--cerceve);
+  box-shadow: 0 -8px 30px rgba(0, 62, 136, 0.08);
+  padding: 14px 0;
 }
 
-nav button {
-  background: none;
+.prompt-form {
+  width: min(1100px, 95%);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+}
+
+.prompt-form input {
+  padding: 14px 16px;
+  border-radius: 14px;
+  border: 1px solid var(--cerceve);
+  font-size: 1rem;
+  box-shadow: var(--golge);
+}
+
+.prompt-form input:focus {
+  outline: 2px solid var(--mavi);
+  border-color: var(--mavi);
+}
+
+.primary {
+  background: var(--mavi);
+  color: var(--beyaz);
   border: none;
-  color: white;
-  font-size: 24px;
+  border-radius: 12px;
+  padding: 12px 18px;
+  font-weight: 700;
   cursor: pointer;
+  box-shadow: 0 8px 20px rgba(13, 110, 253, 0.25);
+  transition: transform 0.1s ease, box-shadow 0.2s ease;
+}
+
+.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(13, 110, 253, 0.3);
+}
+
+.ghost {
+  background: transparent;
+  border: 1px solid var(--cerceve);
+  color: var(--metin);
+  border-radius: 12px;
+  padding: 10px 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 22, 48, 0.45);
+  display: grid;
+  place-items: center;
+  z-index: 20;
+}
+
+.modal-card {
+  width: min(420px, 92%);
+  background: var(--beyaz);
+  border-radius: 18px;
+  padding: 20px;
+  box-shadow: 0 20px 50px rgba(0, 25, 73, 0.25);
+  display: grid;
+  gap: 10px;
+}
+
+.modal-card label {
+  font-weight: 600;
+  color: var(--ikincil);
+}
+
+.modal-card input {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--cerceve);
+  font-size: 1rem;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.hidden {
+  display: none;
+}
+
+.sr-only {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+@media (max-width: 640px) {
+  .brand-tag { display: none; }
+  .prompt-form { grid-template-columns: 1fr; }
+  .primary { width: 100%; }
+  .chat-window { min-height: 260px; }
 }


### PR DESCRIPTION
## Summary
- rebuild the app as a MathMentor AI chat experience with branding, greeting, and sign-in modal
- style the page with a blue-white AI-inspired theme and fixed prompt bar
- add JavaScript logic to handle greetings and diverse math questions, plus session-aware naming and chat reset

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c8c27cc14832c9c2ff3c1a76e4032)