### PR TITLE
Add math-focused AI assistant interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,50 +2,91 @@
 <html lang="tr">
 <head>
   <meta charset="UTF-8">
-  <title>MemTube</title>
+  <title>Matematik AI</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
-  <!-- Kayıt Ekranı -->
-  <div id="girisEkrani">
-    <h2>MemTube'e Giriş</h2>
-    <input type="text" id="kullaniciAdi" placeholder="Takma Ad (zorunlu)">
-    <input type="file" id="profilResmi" accept="image/*">
-    <button onclick="girisYap()">Giriş Yap</button>
-  </div>
-
-  <!-- Ana Ekran -->
-  <div id="anaEkran" class="gizli">
-    <header>
-      <h1>📺 MemTube</h1>
-      <input type="text" id="arama" placeholder="Ara...">
-    </header>
-
-    <!-- Ana Sayfa -->
-    <main id="anaSayfa">
-      <div id="videoListe" class="video-galeri"></div>
-    </main>
-
-    <!-- Hesabım Sayfası -->
-    <section id="hesabim" class="gizli">
-      <div id="profil">
-        <img id="profilGorsel" alt="Profil Resmi">
-        <h3 id="kAdi"></h3>
+  <header class="hero">
+    <div>
+      <p class="eyebrow">Matematik odaklı yardımcı</p>
+      <h1>Matematik AI</h1>
+      <p class="lede">Temel 4 işlemden 9-12. sınıf konularına kadar sadece matematik bilen bir asistan. Sorunu yaz, hemen çözüme odaklan.</p>
+      <div class="tags">
+        <span>4 İşlem</span>
+        <span>Cebir</span>
+        <span>Trigonometri</span>
+        <span>Limit & Türev</span>
+        <span>İntegral</span>
       </div>
-      <h4>Videolarım</h4>
-      <input type="file" id="videoDosyasi" accept="video/*">
-      <input type="text" id="videoBaslik" placeholder="Video Başlığı">
-      <button onclick="videoYukle()">+ Yükle</button>
-      <div id="videolar" class="video-galeri"></div>
+    </div>
+    <div class="pill">
+      Matematik bilgisi dışında yanıt vermez.
+    </div>
+  </header>
+
+  <main class="grid">
+    <section class="panel sohbet">
+      <div class="panel-baslik">
+        <div>
+          <p class="eyebrow">Soru Sor</p>
+          <h2>Matematik Sohbeti</h2>
+          <p class="panel-lede">Dört işlem, cebirsel ifadeler, rasyonel sayılar ve lise konuları için sorunu yaz.</p>
+        </div>
+        <button class="temizle" id="temizle">Temizle</button>
+      </div>
+      <div id="konusma" class="konusma"></div>
+      <div class="giris">
+        <input type="text" id="soru" placeholder="Örn: 2x + 3 = 11 çöz veya 14 + 67 kaç eder?">
+        <button id="gonder">Gönder</button>
+      </div>
+      <div class="ornekler" id="ornekler"></div>
     </section>
 
-    <!-- Alt Menü -->
-    <nav id="altMenu">
-      <button onclick="goAnaSayfa()">🏠</button>
-      <button onclick="goHesabim()">👤</button>
-    </nav>
-  </div>
+    <section class="panel bilgi">
+      <p class="eyebrow">Kapsam</p>
+      <h2>Bildikleri</h2>
+      <div class="bilgi-icerik">
+        <div>
+          <h3>Temel & Cebir</h3>
+          <ul>
+            <li>Toplama, çıkarma, çarpma, bölme</li>
+            <li>Rasyonel sayılar ve kesirler</li>
+            <li>Cebirsel ifadeler (değişken atama, sadeleştirme)</li>
+            <li>Birinci dereceden denklemler ve eşitsizlikler</li>
+          </ul>
+        </div>
+        <div>
+          <h3>9-10. Sınıf</h3>
+          <ul>
+            <li>Üslü ve köklü sayılar, çarpanlar-katlar</li>
+            <li>Oran-orantı, mutlak değer, kümeler</li>
+            <li>Polinomlar, ikinci dereceden denklemler</li>
+            <li>Fonksiyonlar, permütasyon-kombinasyon, olasılık</li>
+          </ul>
+        </div>
+        <div>
+          <h3>11-12. Sınıf</h3>
+          <ul>
+            <li>Trigonometri, analitik geometri</li>
+            <li>Logaritma, üstel fonksiyonlar, diziler</li>
+            <li>Limit, türev ve uygulamaları</li>
+            <li>İntegral ve alan-hacim uygulamaları</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel ipucu">
+      <p class="eyebrow">Kullanım İpuçları</p>
+      <h2>Hızlı komutlar</h2>
+      <ul>
+        <li><strong>Atama:</strong> <code>x = 4</code> yazarak değişken tanımla, ardından <code>x + 3</code> gibi işlemler yap.</li>
+        <li><strong>Denklem çözümü:</strong> <code>2x + 5 = 17</code> gibi birinci dereceden denklemler için <code>x</code> değerini hesaplar.</li>
+        <li><strong>İşlem:</strong> <code>(3/4 + 5/6) · 2</code> veya <code>14 + 67</code> gibi dört işlem soruları sor.</li>
+        <li><strong>Konu isteği:</strong> "10. sınıf polinom" veya "türev uygulamaları" yazarak özet bilgi al.</li>
+      </ul>
+    </section>
+  </main>
 
   <script src="script.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -6,87 +6,65 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <header class="hero">
-    <div>
-      <p class="eyebrow">Matematik odaklı yardımcı</p>
-      <h1>Matematik AI</h1>
-      <p class="lede">Temel 4 işlemden 9-12. sınıf konularına kadar sadece matematik bilen bir asistan. Sorunu yaz, hemen çözüme odaklan.</p>
-      <div class="tags">
-        <span>4 İşlem</span>
-        <span>Cebir</span>
-        <span>Trigonometri</span>
-        <span>Limit & Türev</span>
-        <span>İntegral</span>
+  <header class="ust">
+    <div class="logo">GAI - 1.0</div>
+    <div class="ust-aksiyon">
+      <button id="bilgiButon" aria-label="Bilgiler" title="Bilgiler">?</button>
+      <button id="temizle" class="metin-btn">Sohbeti Sıfırla</button>
+      <div class="profil" aria-label="Profil">
+        <span>👤</span>
       </div>
-    </div>
-    <div class="pill">
-      Matematik bilgisi dışında yanıt vermez.
     </div>
   </header>
 
-  <main class="grid">
-    <section class="panel sohbet">
-      <div class="panel-baslik">
-        <div>
-          <p class="eyebrow">Soru Sor</p>
-          <h2>Matematik Sohbeti</h2>
-          <p class="panel-lede">Dört işlem, cebirsel ifadeler, rasyonel sayılar ve lise konuları için sorunu yaz.</p>
-        </div>
-        <button class="temizle" id="temizle">Temizle</button>
-      </div>
+  <main class="sayfa">
+    <section class="sohbet-kapsayici">
       <div id="konusma" class="konusma"></div>
       <div class="giris">
-        <input type="text" id="soru" placeholder="Örn: 2x + 3 = 11 çöz veya 14 + 67 kaç eder?">
-        <button id="gonder">Gönder</button>
+        <input type="text" id="soru" placeholder="Sorunu yaz... Örn: 2x + 5 = 17 veya 14 + 67">
+        <button id="gonder">➤</button>
       </div>
       <div class="ornekler" id="ornekler"></div>
     </section>
-
-    <section class="panel bilgi">
-      <p class="eyebrow">Kapsam</p>
-      <h2>Bildikleri</h2>
-      <div class="bilgi-icerik">
-        <div>
-          <h3>Temel & Cebir</h3>
-          <ul>
-            <li>Toplama, çıkarma, çarpma, bölme</li>
-            <li>Rasyonel sayılar ve kesirler</li>
-            <li>Cebirsel ifadeler (değişken atama, sadeleştirme)</li>
-            <li>Birinci dereceden denklemler ve eşitsizlikler</li>
-          </ul>
-        </div>
-        <div>
-          <h3>9-10. Sınıf</h3>
-          <ul>
-            <li>Üslü ve köklü sayılar, çarpanlar-katlar</li>
-            <li>Oran-orantı, mutlak değer, kümeler</li>
-            <li>Polinomlar, ikinci dereceden denklemler</li>
-            <li>Fonksiyonlar, permütasyon-kombinasyon, olasılık</li>
-          </ul>
-        </div>
-        <div>
-          <h3>11-12. Sınıf</h3>
-          <ul>
-            <li>Trigonometri, analitik geometri</li>
-            <li>Logaritma, üstel fonksiyonlar, diziler</li>
-            <li>Limit, türev ve uygulamaları</li>
-            <li>İntegral ve alan-hacim uygulamaları</li>
-          </ul>
-        </div>
-      </div>
-    </section>
-
-    <section class="panel ipucu">
-      <p class="eyebrow">Kullanım İpuçları</p>
-      <h2>Hızlı komutlar</h2>
-      <ul>
-        <li><strong>Atama:</strong> <code>x = 4</code> yazarak değişken tanımla, ardından <code>x + 3</code> gibi işlemler yap.</li>
-        <li><strong>Denklem çözümü:</strong> <code>2x + 5 = 17</code> gibi birinci dereceden denklemler için <code>x</code> değerini hesaplar.</li>
-        <li><strong>İşlem:</strong> <code>(3/4 + 5/6) · 2</code> veya <code>14 + 67</code> gibi dört işlem soruları sor.</li>
-        <li><strong>Konu isteği:</strong> "10. sınıf polinom" veya "türev uygulamaları" yazarak özet bilgi al.</li>
-      </ul>
-    </section>
   </main>
+
+  <div id="modal" class="modal gizli" role="dialog" aria-modal="true" aria-labelledby="modalBaslik">
+    <div class="modal-icerik">
+      <div class="modal-ust">
+        <h2 id="modalBaslik">Matematik Bilgi Kapsamı</h2>
+        <button id="modalKapat" aria-label="Kapat">✕</button>
+      </div>
+      <div class="modal-govde">
+        <h3>4 İşlem & Cebir</h3>
+        <ul>
+          <li>Toplama, çıkarma, çarpma, bölme</li>
+          <li>Rasyonel sayılar ve kesirler</li>
+          <li>Değişken atama: <code>x = 4</code>, <code>x + 3</code></li>
+          <li>Birinci dereceden denklemler ve basit eşitsizlikler</li>
+        </ul>
+        <h3>9-10. Sınıf</h3>
+        <ul>
+          <li>Sayılar, üslü-köklü sayılar, çarpanlar-katlar</li>
+          <li>Oran-orantı, mutlak değer, kümeler</li>
+          <li>Polinomlar, ikinci dereceden denklemler</li>
+          <li>Fonksiyonlar, permütasyon-kombinasyon, olasılık</li>
+        </ul>
+        <h3>11-12. Sınıf</h3>
+        <ul>
+          <li>Trigonometri, analitik geometri</li>
+          <li>Logaritma, üstel fonksiyonlar, diziler</li>
+          <li>Limit, türev ve uygulamaları</li>
+          <li>İntegral ve alan-hacim uygulamaları</li>
+        </ul>
+        <h3>Hızlı İpuçları</h3>
+        <ul>
+          <li><code>2x + 5 = 17</code> → x değerini bulur.</li>
+          <li><code>(3/4 + 5/6) * 2</code> → kesirli işlemler.</li>
+          <li>“10. sınıf polinom” → özet bilgi.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,97 +1,184 @@
-window.onload = () => {
-  const k = localStorage.getItem("kullaniciAdi");
-  const p = localStorage.getItem("profilResmi");
-
-  if (k && p) {
-    document.getElementById("girisEkrani").style.display = "none";
-    document.getElementById("anaEkran").classList.remove("gizli");
-    document.getElementById("kAdi").innerText = k;
-    document.getElementById("profilGorsel").src = p;
-    videolariYukle();
-  }
+const konuOzetleri = {
+  "9": [
+    "Sayılar: doğal, tam, rasyonel, irrasyonel, reel sayılar.",
+    "Üslü ve köklü sayılar, çarpanlar ve katlar.",
+    "Oran-orantı, mutlak değer, kümeler, Kartezyen çarpım.",
+    "Birinci dereceden denklemler ve basit eşitsizlikler.",
+    "Mantık, veri analizi (tablo, grafik, ortalama).",
+  ],
+  "10": [
+    "Polinomlar ve ikinci dereceden denklemler.",
+    "Fonksiyonlar: tanım, değer, grafik yorumlama.",
+    "Permütasyon, kombinasyon, binom ve olasılık.",
+    "İstatistik: ortalama, medyan, mod.",
+    "Üçgenler, dörtgenler, çokgenler, çember ve daire.",
+  ],
+  "11": [
+    "Trigonometrik oranlar, denklemler ve grafikler.",
+    "Analitik geometri: doğrunun ve dairenin analitiği.",
+    "Fonksiyonlarda dönüşümler, üstel fonksiyonlar, logaritma.",
+    "Diziler, limit, türev ve artan-azalan incelemeleri.",
+  ],
+  "12": [
+    "İntegral ve alan-hacim uygulamaları.",
+    "Türev, limit, trigonometri ve logaritma tekrarları.",
+    "Olasılık ve analitik geometri tekrarları.",
+    "Çember, daire, katı cisimler ve karma problemler (YKS).",
+  ],
 };
 
-function girisYap() {
-  const k = document.getElementById("kullaniciAdi").value.trim();
-  const p = document.getElementById("profilResmi").files[0];
+const ornekSorular = [
+  "14 + 67",
+  "23 + 213",
+  "x = 4, x + 3 nedir?",
+  "2x + 5 = 17",
+  "3/4 + 5/6",
+  "10. sınıf polinom",
+  "12. sınıf integral uygulamaları",
+];
 
-  if (!k || !p) {
-    alert("Ad ve profil resmi gerekli kaptan!");
-    return;
-  }
+const degiskenler = {};
 
-  const reader = new FileReader();
-  reader.onload = () => {
-    localStorage.setItem("kullaniciAdi", k);
-    localStorage.setItem("profilResmi", reader.result);
-    location.reload();
-  };
-  reader.readAsDataURL(p);
+const konusmaAlani = document.getElementById("konusma");
+const soruInput = document.getElementById("soru");
+const gonderBtn = document.getElementById("gonder");
+const temizleBtn = document.getElementById("temizle");
+const orneklerAlani = document.getElementById("ornekler");
+
+function temizleMetin(text) {
+  return text.replace(/,/g, ".").replace(/\s+/g, " ").trim();
 }
 
-function goAnaSayfa() {
-  document.getElementById("hesabim").classList.add("gizli");
-  document.getElementById("anaSayfa").style.display = "block";
-}
-
-function goHesabim() {
-  document.getElementById("anaSayfa").style.display = "none";
-  document.getElementById("hesabim").classList.remove("gizli");
-}
-
-function videoYukle() {
-  const dosya = document.getElementById("videoDosyasi").files[0];
-  const baslik = document.getElementById("videoBaslik").value;
-  const kullanici = localStorage.getItem("kullaniciAdi");
-
-  if (!dosya || !baslik) {
-    alert("Video ve başlık eksik!");
-    return;
-  }
-
-  const videoURL = URL.createObjectURL(dosya);
-  const video = { baslik: baslik, url: videoURL, sahip: kullanici };
-
-  const mevcut = JSON.parse(localStorage.getItem("videolar") || "[]");
-  mevcut.push(video);
-  localStorage.setItem("videolar", JSON.stringify(mevcut));
-  videolariYukle();
-
-  document.getElementById("videoDosyasi").value = "";
-  document.getElementById("videoBaslik").value = "";
-}
-
-function videolariYukle() {
-  const videolar = JSON.parse(localStorage.getItem("videolar") || "[]");
-  const liste = document.getElementById("videoListe");
-  const hesap = document.getElementById("videolar");
-  const kullanici = localStorage.getItem("kullaniciAdi");
-
-  liste.innerHTML = "";
-  hesap.innerHTML = "";
-
-  videolar.forEach((v, i) => {
-    const div = document.createElement("div");
-    div.className = "video";
-    div.innerHTML = `
-      <video src="${v.url}" controls></video>
-      <p>${v.baslik}</p>
-    `;
-    // Ana sayfaya herkesin videoları
-    liste.appendChild(div.cloneNode(true));
-
-    // Sadece kendi videolarına silme butonu
-    if (v.sahip === kullanici) {
-      const divHesap = div.cloneNode(true);
-      const silBtn = document.createElement("button");
-      silBtn.innerText = "❌";
-      silBtn.onclick = () => {
-        videolar.splice(i, 1);
-        localStorage.setItem("videolar", JSON.stringify(videolar));
-        videolariYukle();
-      };
-      divHesap.appendChild(silBtn);
-      hesap.appendChild(divHesap);
+function parseSayi(deger) {
+  if (deger.includes("/")) {
+    const [a, b] = deger.split("/").map(Number);
+    if (!isFinite(a) || !isFinite(b) || b === 0) {
+      throw new Error("Geçersiz kesir");
     }
+    return a / b;
+  }
+  const n = Number(deger);
+  if (!isFinite(n)) {
+    throw new Error("Geçersiz sayı");
+  }
+  return n;
+}
+
+function guvenliIfadeDeger(ifade) {
+  const izinli = /^[0-9+\-*/(). x]+$/i;
+  if (!izinli.test(ifade)) {
+    throw new Error("Sadece matematiksel karakterler kullanılabilir.");
+  }
+
+  const degisenIfade = ifade.replace(/[a-z]+/gi, (eslesme) => {
+    const anahtar = eslesme.toLowerCase();
+    if (!(anahtar in degiskenler)) {
+      throw new Error(`${anahtar} değişkeni tanımlı değil.`);
+    }
+    return degiskenler[anahtar];
+  });
+
+  // eslint-disable-next-line no-new-func
+  return Function(`"use strict"; return (${degisenIfade});`)();
+}
+
+function dogrusalDenklemCoz(ifade) {
+  const desen = /^([+-]?[0-9./]*)x\s*([+-]\s*[0-9./]+)?\s*=\s*([+-]?[0-9./]+)$/i;
+  const eslesme = temizleMetin(ifade).match(desen);
+  if (!eslesme) return null;
+
+  const [, katsayiStr, sabitStr = "+0", sonucStr] = eslesme;
+  const a = katsayiStr === "" || katsayiStr === "+" ? 1 : katsayiStr === "-" ? -1 : parseSayi(katsayiStr);
+  const b = parseSayi(sabitStr.replace(/\s+/g, ""));
+  const c = parseSayi(sonucStr);
+
+  if (a === 0) {
+    return b === c ? "Sonsuz çözüm (her x sağlar)." : "Çözüm yok (tutarsız denklem).";
+  }
+
+  const x = (c - b) / a;
+  return `x = ${x}`;
+}
+
+function konuYaniti(soru) {
+  const sinifDesen = /(\b9\b|\b10\b|\b11\b|\b12\b)\.? sınıf/i;
+  const sinifEslesme = soru.match(sinifDesen);
+  if (!sinifEslesme) return null;
+  const sinif = sinifEslesme[1];
+  const ozet = konuOzetleri[sinif];
+  if (!ozet) return null;
+
+  return `${sinif}. sınıf konuları:\n- ${ozet.join("\n- ")}`;
+}
+
+function yanitOlustur(soru) {
+  const temiz = temizleMetin(soru.toLowerCase());
+
+  if (!temiz) return "Lütfen bir matematik sorusu yaz.";
+
+  const konu = konuYaniti(temiz);
+  if (konu) return konu;
+
+  const atamaDesen = /^([a-z]+)\s*=\s*([-+0-9./ ()]+)$/i;
+  const atama = temiz.match(atamaDesen);
+  if (atama) {
+    const [, isim, degerIfade] = atama;
+    const sonuc = guvenliIfadeDeger(degerIfade);
+    degiskenler[isim.toLowerCase()] = sonuc;
+    return `${isim} = ${sonuc} olarak kaydedildi.`;
+  }
+
+  const dogrusal = dogrusalDenklemCoz(temiz);
+  if (dogrusal) return dogrusal;
+
+  try {
+    const sonuc = guvenliIfadeDeger(temiz);
+    if (!isFinite(sonuc)) throw new Error("Geçersiz ifade");
+    return `Sonuç: ${sonuc}`;
+  } catch (e) {
+    return `Sadece matematik yanıtları veririm. Hata: ${e.message}`;
+  }
+}
+
+function mesajEkle(icerik, tip = "bot") {
+  const kart = document.createElement("div");
+  kart.className = `mesaj ${tip}`;
+  kart.textContent = icerik;
+  konusmaAlani.appendChild(kart);
+  konusmaAlani.scrollTop = konusmaAlani.scrollHeight;
+}
+
+function soruyuIsle() {
+  const soru = soruInput.value.trim();
+  if (!soru) return;
+  mesajEkle(soru, "kullanici");
+  const yanit = yanitOlustur(soru);
+  mesajEkle(yanit, "bot");
+  soruInput.value = "";
+}
+
+function ornekleriYukle() {
+  ornekSorular.forEach((s) => {
+    const btn = document.createElement("button");
+    btn.className = "ornek";
+    btn.textContent = s;
+    btn.onclick = () => {
+      soruInput.value = s;
+      soruInput.focus();
+    };
+    orneklerAlani.appendChild(btn);
   });
 }
+
+gonderBtn.addEventListener("click", soruyuIsle);
+soruInput.addEventListener("keydown", (e) => {
+  if (e.key === "Enter") soruyuIsle();
+});
+
+temizleBtn.addEventListener("click", () => {
+  konusmaAlani.innerHTML = "";
+  Object.keys(degiskenler).forEach((k) => delete degiskenler[k]);
+});
+
+ornekleriYukle();
+mesajEkle("Merhaba! Matematik sorularını yaz, sadece matematik yanıtları veririm.");

--- a/script.js
+++ b/script.js
@@ -115,12 +115,32 @@ function konuYaniti(soru) {
 }
 
 function yanitOlustur(soru) {
-  const temiz = temizleMetin(soru.toLowerCase());
+  const temiz = temizleMetin(soru.toLowerCase().replace(/=\s*$/, ""));
 
   if (!temiz) return "Lütfen bir matematik sorusu yaz.";
 
   const konu = konuYaniti(temiz);
   if (konu) return konu;
+
+  const cokluAtamaDesen = /([a-z]+)\s*=\s*([-+0-9./ ()]+)/gi;
+  const atamaEslesmeleri = [...temiz.matchAll(cokluAtamaDesen)];
+  if (atamaEslesmeleri.length) {
+    const temizlenmis = temiz
+      .replace(cokluAtamaDesen, "")
+      .replace(/[,;]+/g, "")
+      .replace(/\s+/g, "");
+    if (temizlenmis === "") {
+      const bildir = [];
+      atamaEslesmeleri.forEach((m) => {
+        const isim = m[1];
+        const ifade = m[2];
+        const sonuc = guvenliIfadeDeger(ifade);
+        degiskenler[isim.toLowerCase()] = sonuc;
+        bildir.push(`${isim} = ${sonuc}`);
+      });
+      return `Kaydedildi: ${bildir.join(", ")}`;
+    }
+  }
 
   const atamaDesen = /^([a-z]+)\s*=\s*([-+0-9./ ()]+)$/i;
   const atama = temiz.match(atamaDesen);

--- a/script.js
+++ b/script.js
@@ -44,6 +44,9 @@ const soruInput = document.getElementById("soru");
 const gonderBtn = document.getElementById("gonder");
 const temizleBtn = document.getElementById("temizle");
 const orneklerAlani = document.getElementById("ornekler");
+const modal = document.getElementById("modal");
+const modalKapat = document.getElementById("modalKapat");
+const bilgiButon = document.getElementById("bilgiButon");
 
 function temizleMetin(text) {
   return text.replace(/,/g, ".").replace(/\s+/g, " ").trim();
@@ -178,6 +181,18 @@ soruInput.addEventListener("keydown", (e) => {
 temizleBtn.addEventListener("click", () => {
   konusmaAlani.innerHTML = "";
   Object.keys(degiskenler).forEach((k) => delete degiskenler[k]);
+});
+
+bilgiButon.addEventListener("click", () => {
+  modal.classList.remove("gizli");
+});
+
+modalKapat.addEventListener("click", () => {
+  modal.classList.add("gizli");
+});
+
+modal.addEventListener("click", (e) => {
+  if (e.target === modal) modal.classList.add("gizli");
 });
 
 ornekleriYukle();

--- a/style.css
+++ b/style.css
@@ -1,108 +1,265 @@
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
-  background-color: #0d0d0d;
-  color: white;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: #0a0c10;
+  color: #f8fafc;
+  line-height: 1.6;
 }
 
-.gizli {
-  display: none;
+:root {
+  --panel: #11141b;
+  --accent: #4f46e5;
+  --muted: #cbd5e1;
+  --border: #1f2937;
 }
 
-#girisEkrani {
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 48px min(8vw, 72px);
+  border-bottom: 1px solid var(--border);
+  background: radial-gradient(circle at 20% 20%, rgba(79, 70, 229, 0.08), transparent 35%),
+    radial-gradient(circle at 80% 0%, rgba(59, 130, 246, 0.08), transparent 30%),
+    #0a0c10;
+}
+
+.hero h1 {
+  font-size: clamp(32px, 5vw, 48px);
+  margin: 4px 0 12px;
+}
+
+.hero .lede {
+  max-width: 640px;
+  color: #dbeafe;
+  margin: 0 0 16px;
+}
+
+.eyebrow {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 12px;
+  color: #94a3b8;
+  margin: 0;
+}
+
+.lede {
+  color: var(--muted);
+}
+
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tags span {
+  border: 1px solid var(--border);
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.04);
+  color: #e2e8f0;
+  font-size: 14px;
+}
+
+.pill {
+  border: 1px solid rgba(79, 70, 229, 0.4);
+  background: rgba(79, 70, 229, 0.08);
+  color: #c7d2fe;
+  padding: 12px 16px;
+  border-radius: 12px;
+  max-width: 280px;
   text-align: center;
-  padding: 40px;
+  font-weight: 600;
 }
 
-#girisEkrani input, #girisEkrani button {
-  display: block;
-  margin: 10px auto;
-  padding: 10px;
-  width: 80%;
+.grid {
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  gap: 20px;
+  padding: 24px min(8vw, 72px) 48px;
 }
 
-header {
-  background-color: #1a1a1a;
-  padding: 10px;
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 20px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+}
+
+.panel h2 {
+  margin: 4px 0 8px;
+}
+
+.panel-lede {
+  margin: 0;
+  color: var(--muted);
+}
+
+.panel-baslik {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 12px;
 }
 
-#arama {
-  padding: 8px;
-  border-radius: 5px;
+.temizle {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: #e2e8f0;
+  padding: 10px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.temizle:hover {
+  border-color: #475569;
+  color: #fff;
+}
+
+.konusma {
+  background: #0f131a;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px;
+  height: 320px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 14px 0;
+}
+
+.mesaj {
+  padding: 12px 14px;
+  border-radius: 12px;
+  max-width: 90%;
+  white-space: pre-line;
+  word-break: break-word;
+}
+
+.mesaj.bot {
+  background: rgba(79, 70, 229, 0.12);
+  border: 1px solid rgba(79, 70, 229, 0.3);
+  align-self: flex-start;
+}
+
+.mesaj.kullanici {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  align-self: flex-end;
+}
+
+.giris {
+  display: grid;
+  grid-template-columns: 1fr 120px;
+  gap: 12px;
+}
+
+input[type="text"] {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: #0f131a;
+  color: #f8fafc;
+  font-size: 16px;
+}
+
+input[type="text"]::placeholder {
+  color: #64748b;
+}
+
+button#gonder {
+  background: linear-gradient(135deg, #4f46e5, #7c3aed);
   border: none;
+  color: #fff;
+  font-weight: 700;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-.video-galeri {
+button#gonder:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(79, 70, 229, 0.4);
+}
+
+.ornekler {
+  margin-top: 14px;
   display: flex;
   flex-wrap: wrap;
-  gap: 15px;
-  justify-content: center;
-  padding: 20px;
+  gap: 10px;
 }
 
-.video {
-  background: #1a1a1a;
-  padding: 10px;
+.ornek {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  color: #e2e8f0;
+  padding: 10px 12px;
   border-radius: 10px;
-  width: 200px;
-  text-align: center;
-  position: relative;
-}
-
-.video video {
-  width: 100%;
-  border-radius: 5px;
-}
-
-.video button {
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  background: red;
-  color: white;
-  border: none;
-  border-radius: 50%;
-  padding: 5px;
   cursor: pointer;
+  font-size: 14px;
 }
 
-#profil {
-  text-align: center;
-  margin-top: 20px;
+.ornek:hover {
+  border-color: #475569;
 }
 
-#profil img {
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  object-fit: cover;
-  background-color: white;
+.bilgi-icerik {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-top: 12px;
 }
 
-#videoDosyasi, #videoBaslik {
-  display: block;
-  margin: 10px auto;
-  padding: 8px;
-  width: 80%;
+.bilgi ul {
+  padding-left: 18px;
+  margin: 8px 0 0;
+  color: var(--muted);
 }
 
-nav#altMenu {
-  position: fixed;
-  bottom: 0;
-  width: 100%;
-  background: #111;
-  display: flex;
-  justify-content: space-around;
-  padding: 10px 0;
+.ipucu ul {
+  padding-left: 20px;
+  color: var(--muted);
+  margin: 8px 0 0;
 }
 
-nav button {
-  background: none;
-  border: none;
-  color: white;
-  font-size: 24px;
-  cursor: pointer;
+code {
+  background: rgba(255, 255, 255, 0.06);
+  padding: 3px 6px;
+  border-radius: 6px;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  color: #cbd5e1;
+}
+
+@media (max-width: 960px) {
+  .hero {
+    flex-direction: column;
+    gap: 16px;
+    text-align: center;
+  }
+
+  .pill {
+    max-width: none;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .giris {
+    grid-template-columns: 1fr;
+  }
 }

--- a/style.css
+++ b/style.css
@@ -3,17 +3,21 @@
 }
 
 :root {
-  --zemin: #f7f7f5;
+  --zemin: #f4f7ff;
   --panel: #ffffff;
-  --cerceve: #dcdcdc;
-  --yazi: #0f172a;
-  --yardim: #2563eb;
+  --cerceve: #d6e0ff;
+  --yazi: #0b1b38;
+  --yardim: #1d4ed8;
+  --aksan: #1e3a8a;
+  --golge: 0 20px 60px rgba(30, 58, 138, 0.18);
 }
 
 body {
   margin: 0;
   font-family: "Inter", system-ui, -apple-system, sans-serif;
-  background: var(--zemin);
+  background: radial-gradient(circle at 15% 20%, rgba(59, 130, 246, 0.12), transparent 30%),
+    radial-gradient(circle at 80% 0%, rgba(79, 70, 229, 0.1), transparent 28%),
+    var(--zemin);
   color: var(--yazi);
   min-height: 100vh;
 }
@@ -22,26 +26,29 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 18px;
+  padding: 16px 22px;
   border-bottom: 1px solid var(--cerceve);
-  background: var(--panel);
+  background: linear-gradient(120deg, #eef2ff, #e0e7ff);
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.08);
 }
 
 .logo {
-  font-weight: 700;
+  font-weight: 800;
   letter-spacing: 0.08em;
+  font-size: 18px;
+  color: var(--aksan);
 }
 
 .ust-aksiyon {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
 }
 
 .ust-aksiyon button,
 .profil {
-  height: 36px;
-  min-width: 36px;
+  height: 38px;
+  min-width: 38px;
   border-radius: 18px;
   border: 1px solid var(--cerceve);
   background: #fff;
@@ -49,13 +56,16 @@ body {
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  padding: 0 12px;
-  font-weight: 600;
+  padding: 0 13px;
+  font-weight: 700;
+  color: var(--yazi);
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.1);
 }
 
 .ust-aksiyon button:hover,
 .profil:hover {
-  border-color: #b7b7b7;
+  border-color: #b6c5ff;
+  transform: translateY(-1px);
 }
 
 .metin-btn {
@@ -63,59 +73,62 @@ body {
 }
 
 .sayfa {
-  padding: 24px 18px 32px;
+  padding: 28px 22px 40px;
 }
 
 .sohbet-kapsayici {
   background: var(--panel);
   border: 1px solid var(--cerceve);
-  border-radius: 16px;
-  padding: 16px;
+  border-radius: 18px;
+  padding: 18px;
   display: flex;
   flex-direction: column;
-  min-height: calc(100vh - 140px);
+  min-height: calc(100vh - 160px);
+  box-shadow: var(--golge);
 }
 
 .konusma {
   flex: 1;
   border: 1px solid var(--cerceve);
-  border-radius: 12px;
-  padding: 12px;
-  background: #fafafa;
+  border-radius: 14px;
+  padding: 14px;
+  background: linear-gradient(180deg, #f8fbff, #f2f6ff);
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
 }
 
 .mesaj {
-  padding: 10px 12px;
+  padding: 11px 13px;
   border-radius: 12px;
   max-width: 85%;
   white-space: pre-line;
   word-break: break-word;
   border: 1px solid var(--cerceve);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.07);
 }
 
 .mesaj.bot {
-  background: #eef2ff;
+  background: #e0ebff;
   align-self: flex-start;
 }
 
 .mesaj.kullanici {
-  background: #e5e7eb;
+  background: #e6ecff;
   align-self: flex-end;
 }
 
 .giris {
-  margin-top: 12px;
+  margin-top: 14px;
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 10px;
+  gap: 12px;
+  padding: 10px 12px;
   border: 1px solid var(--cerceve);
   border-radius: 999px;
   background: #fff;
+  box-shadow: 0 14px 32px rgba(30, 64, 175, 0.12);
 }
 
 input[type="text"] {
@@ -129,25 +142,26 @@ input[type="text"] {
 }
 
 input[type="text"]::placeholder {
-  color: #9ca3af;
+  color: #8aa2d5;
 }
 
 button#gonder {
-  width: 44px;
-  height: 44px;
+  width: 46px;
+  height: 46px;
   border-radius: 50%;
   border: 1px solid var(--cerceve);
-  background: #0f172a;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
   color: #fff;
   cursor: pointer;
   font-size: 18px;
+  box-shadow: 0 12px 28px rgba(37, 99, 235, 0.35);
 }
 
 .ornekler {
   margin-top: 12px;
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 10px;
 }
 
 .ornek {
@@ -155,19 +169,20 @@ button#gonder {
   background: #fff;
   color: var(--yazi);
   border-radius: 12px;
-  padding: 8px 12px;
+  padding: 9px 12px;
   cursor: pointer;
   font-size: 14px;
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.06);
 }
 
 .ornek:hover {
-  border-color: #b7b7b7;
+  border-color: #b6c5ff;
 }
 
 .modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.35);
+  background: rgba(15, 23, 42, 0.35);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -183,9 +198,9 @@ button#gonder {
   background: #fff;
   border-radius: 14px;
   padding: 16px;
-  width: min(520px, 90vw);
+  width: min(540px, 90vw);
   border: 1px solid var(--cerceve);
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 24px 64px rgba(15, 23, 42, 0.25);
 }
 
 .modal-ust {
@@ -206,6 +221,7 @@ button#gonder {
 
 .modal-govde h3 {
   margin: 10px 0 6px;
+  color: var(--aksan);
 }
 
 .modal-govde ul {
@@ -214,7 +230,7 @@ button#gonder {
 }
 
 code {
-  background: #f1f5f9;
+  background: #eef2ff;
   border: 1px solid var(--cerceve);
   padding: 2px 6px;
   border-radius: 6px;

--- a/style.css
+++ b/style.css
@@ -2,264 +2,237 @@
   box-sizing: border-box;
 }
 
+:root {
+  --zemin: #f7f7f5;
+  --panel: #ffffff;
+  --cerceve: #dcdcdc;
+  --yazi: #0f172a;
+  --yardim: #2563eb;
+}
+
 body {
   margin: 0;
   font-family: "Inter", system-ui, -apple-system, sans-serif;
-  background: #0a0c10;
-  color: #f8fafc;
-  line-height: 1.6;
+  background: var(--zemin);
+  color: var(--yazi);
+  min-height: 100vh;
 }
 
-:root {
-  --panel: #11141b;
-  --accent: #4f46e5;
-  --muted: #cbd5e1;
-  --border: #1f2937;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-.hero {
+.ust {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 48px min(8vw, 72px);
-  border-bottom: 1px solid var(--border);
-  background: radial-gradient(circle at 20% 20%, rgba(79, 70, 229, 0.08), transparent 35%),
-    radial-gradient(circle at 80% 0%, rgba(59, 130, 246, 0.08), transparent 30%),
-    #0a0c10;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--cerceve);
+  background: var(--panel);
 }
 
-.hero h1 {
-  font-size: clamp(32px, 5vw, 48px);
-  margin: 4px 0 12px;
-}
-
-.hero .lede {
-  max-width: 640px;
-  color: #dbeafe;
-  margin: 0 0 16px;
-}
-
-.eyebrow {
+.logo {
+  font-weight: 700;
   letter-spacing: 0.08em;
-  text-transform: uppercase;
-  font-size: 12px;
-  color: #94a3b8;
-  margin: 0;
 }
 
-.lede {
-  color: var(--muted);
+.ust-aksiyon {
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
-.tags {
+.ust-aksiyon button,
+.profil {
+  height: 36px;
+  min-width: 36px;
+  border-radius: 18px;
+  border: 1px solid var(--cerceve);
+  background: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0 12px;
+  font-weight: 600;
+}
+
+.ust-aksiyon button:hover,
+.profil:hover {
+  border-color: #b7b7b7;
+}
+
+.metin-btn {
+  font-size: 14px;
+}
+
+.sayfa {
+  padding: 24px 18px 32px;
+}
+
+.sohbet-kapsayici {
+  background: var(--panel);
+  border: 1px solid var(--cerceve);
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - 140px);
+}
+
+.konusma {
+  flex: 1;
+  border: 1px solid var(--cerceve);
+  border-radius: 12px;
+  padding: 12px;
+  background: #fafafa;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.mesaj {
+  padding: 10px 12px;
+  border-radius: 12px;
+  max-width: 85%;
+  white-space: pre-line;
+  word-break: break-word;
+  border: 1px solid var(--cerceve);
+}
+
+.mesaj.bot {
+  background: #eef2ff;
+  align-self: flex-start;
+}
+
+.mesaj.kullanici {
+  background: #e5e7eb;
+  align-self: flex-end;
+}
+
+.giris {
+  margin-top: 12px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--cerceve);
+  border-radius: 999px;
+  background: #fff;
+}
+
+input[type="text"] {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 16px;
+  color: var(--yazi);
+  background: transparent;
+  padding: 10px 6px;
+}
+
+input[type="text"]::placeholder {
+  color: #9ca3af;
+}
+
+button#gonder {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid var(--cerceve);
+  background: #0f172a;
+  color: #fff;
+  cursor: pointer;
+  font-size: 18px;
+}
+
+.ornekler {
+  margin-top: 12px;
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
 }
 
-.tags span {
-  border: 1px solid var(--border);
-  padding: 6px 12px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.04);
-  color: #e2e8f0;
-  font-size: 14px;
-}
-
-.pill {
-  border: 1px solid rgba(79, 70, 229, 0.4);
-  background: rgba(79, 70, 229, 0.08);
-  color: #c7d2fe;
-  padding: 12px 16px;
-  border-radius: 12px;
-  max-width: 280px;
-  text-align: center;
-  font-weight: 600;
-}
-
-.grid {
-  display: grid;
-  grid-template-columns: 1.3fr 1fr;
-  gap: 20px;
-  padding: 24px min(8vw, 72px) 48px;
-}
-
-.panel {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 16px;
-  padding: 20px;
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
-}
-
-.panel h2 {
-  margin: 4px 0 8px;
-}
-
-.panel-lede {
-  margin: 0;
-  color: var(--muted);
-}
-
-.panel-baslik {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-}
-
-.temizle {
-  background: transparent;
-  border: 1px solid var(--border);
-  color: #e2e8f0;
-  padding: 10px 14px;
-  border-radius: 10px;
-  cursor: pointer;
-  transition: border-color 0.2s, color 0.2s;
-}
-
-.temizle:hover {
-  border-color: #475569;
-  color: #fff;
-}
-
-.konusma {
-  background: #0f131a;
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 14px;
-  height: 320px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  margin: 14px 0;
-}
-
-.mesaj {
-  padding: 12px 14px;
-  border-radius: 12px;
-  max-width: 90%;
-  white-space: pre-line;
-  word-break: break-word;
-}
-
-.mesaj.bot {
-  background: rgba(79, 70, 229, 0.12);
-  border: 1px solid rgba(79, 70, 229, 0.3);
-  align-self: flex-start;
-}
-
-.mesaj.kullanici {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid var(--border);
-  align-self: flex-end;
-}
-
-.giris {
-  display: grid;
-  grid-template-columns: 1fr 120px;
-  gap: 12px;
-}
-
-input[type="text"] {
-  width: 100%;
-  padding: 12px 14px;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  background: #0f131a;
-  color: #f8fafc;
-  font-size: 16px;
-}
-
-input[type="text"]::placeholder {
-  color: #64748b;
-}
-
-button#gonder {
-  background: linear-gradient(135deg, #4f46e5, #7c3aed);
-  border: none;
-  color: #fff;
-  font-weight: 700;
-  border-radius: 10px;
-  cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
-}
-
-button#gonder:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 25px rgba(79, 70, 229, 0.4);
-}
-
-.ornekler {
-  margin-top: 14px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
 .ornek {
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid var(--border);
-  color: #e2e8f0;
-  padding: 10px 12px;
-  border-radius: 10px;
+  border: 1px solid var(--cerceve);
+  background: #fff;
+  color: var(--yazi);
+  border-radius: 12px;
+  padding: 8px 12px;
   cursor: pointer;
   font-size: 14px;
 }
 
 .ornek:hover {
-  border-color: #475569;
+  border-color: #b7b7b7;
 }
 
-.bilgi-icerik {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 18px;
+  z-index: 20;
+}
+
+.modal.gizli {
+  display: none;
+}
+
+.modal-icerik {
+  background: #fff;
+  border-radius: 14px;
+  padding: 16px;
+  width: min(520px, 90vw);
+  border: 1px solid var(--cerceve);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.25);
+}
+
+.modal-ust {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   gap: 12px;
-  margin-top: 12px;
+  margin-bottom: 10px;
 }
 
-.bilgi ul {
-  padding-left: 18px;
-  margin: 8px 0 0;
-  color: var(--muted);
+.modal-ust button {
+  border: 1px solid var(--cerceve);
+  background: #fff;
+  border-radius: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
 }
 
-.ipucu ul {
-  padding-left: 20px;
-  color: var(--muted);
-  margin: 8px 0 0;
+.modal-govde h3 {
+  margin: 10px 0 6px;
+}
+
+.modal-govde ul {
+  margin: 0 0 6px 18px;
+  color: #4b5563;
 }
 
 code {
-  background: rgba(255, 255, 255, 0.06);
-  padding: 3px 6px;
+  background: #f1f5f9;
+  border: 1px solid var(--cerceve);
+  padding: 2px 6px;
   border-radius: 6px;
   font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
-  color: #cbd5e1;
 }
 
-@media (max-width: 960px) {
-  .hero {
+@media (max-width: 720px) {
+  .ust {
     flex-direction: column;
-    gap: 16px;
-    text-align: center;
+    align-items: flex-start;
+    gap: 8px;
   }
 
-  .pill {
-    max-width: none;
-  }
-
-  .grid {
-    grid-template-columns: 1fr;
+  .sohbet-kapsayici {
+    min-height: calc(100vh - 190px);
   }
 
   .giris {
-    grid-template-columns: 1fr;
+    border-radius: 18px;
   }
 }


### PR DESCRIPTION
## Summary
- replace previous video UI with a dedicated Matematik AI landing layout
- implement math-only chat logic handling basic operations, variables, linear equations, and topic summaries
- refresh styling with modern panels, tags, and responsive layout plus quick example prompts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d58610ac8832c9a16210514b26e6b)