### PR TITLE
Add Gai chat UI with persistent state and decision logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,17 +3,23 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Gai</title>
+  <title>Gai 1.0</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <div class="app">
     <header class="app-header">
-      <div>
-        <h1>Gai</h1>
-        <p>Minimal, bağlamsal yapay zekâ</p>
+      <div class="brand">
+        <span class="brand-chip">Gai-1.0</span>
+        <div>
+          <h1>Gai</h1>
+          <p>Bağlamsal, hızlı ve net yanıtlar</p>
+        </div>
       </div>
-      <div class="status" id="durum">Hazır</div>
+      <div class="actions">
+        <div class="status" id="durum">Hazır</div>
+        <button type="button" class="secondary" id="temizle">Sohbeti temizle</button>
+      </div>
     </header>
 
     <main class="chat" id="sohbet">
@@ -26,7 +32,7 @@
       <input
         type="text"
         id="girdi"
-        placeholder="Mesajınızı yazın..."
+        placeholder="Bir şey sor..."
         autocomplete="off"
         required
       />

--- a/index.html
+++ b/index.html
@@ -2,49 +2,36 @@
 <html lang="tr">
 <head>
   <meta charset="UTF-8">
-  <title>MemTube</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Gai</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
-  <!-- Kayıt Ekranı -->
-  <div id="girisEkrani">
-    <h2>MemTube'e Giriş</h2>
-    <input type="text" id="kullaniciAdi" placeholder="Takma Ad (zorunlu)">
-    <input type="file" id="profilResmi" accept="image/*">
-    <button onclick="girisYap()">Giriş Yap</button>
-  </div>
-
-  <!-- Ana Ekran -->
-  <div id="anaEkran" class="gizli">
-    <header>
-      <h1>📺 MemTube</h1>
-      <input type="text" id="arama" placeholder="Ara...">
+  <div class="app">
+    <header class="app-header">
+      <div>
+        <h1>Gai</h1>
+        <p>Minimal, bağlamsal yapay zekâ</p>
+      </div>
+      <div class="status" id="durum">Hazır</div>
     </header>
 
-    <!-- Ana Sayfa -->
-    <main id="anaSayfa">
-      <div id="videoListe" class="video-galeri"></div>
+    <main class="chat" id="sohbet">
+      <div class="message bot">
+        Merhaba. Gai burada.
+      </div>
     </main>
 
-    <!-- Hesabım Sayfası -->
-    <section id="hesabim" class="gizli">
-      <div id="profil">
-        <img id="profilGorsel" alt="Profil Resmi">
-        <h3 id="kAdi"></h3>
-      </div>
-      <h4>Videolarım</h4>
-      <input type="file" id="videoDosyasi" accept="video/*">
-      <input type="text" id="videoBaslik" placeholder="Video Başlığı">
-      <button onclick="videoYukle()">+ Yükle</button>
-      <div id="videolar" class="video-galeri"></div>
-    </section>
-
-    <!-- Alt Menü -->
-    <nav id="altMenu">
-      <button onclick="goAnaSayfa()">🏠</button>
-      <button onclick="goHesabim()">👤</button>
-    </nav>
+    <form class="composer" id="gaiForm">
+      <input
+        type="text"
+        id="girdi"
+        placeholder="Mesajınızı yazın..."
+        autocomplete="off"
+        required
+      />
+      <button type="submit">Gönder</button>
+    </form>
   </div>
 
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,97 +1,207 @@
-window.onload = () => {
-  const k = localStorage.getItem("kullaniciAdi");
-  const p = localStorage.getItem("profilResmi");
+const STORAGE_KEY = "gaiState";
+const sohbet = document.getElementById("sohbet");
+const durum = document.getElementById("durum");
+const form = document.getElementById("gaiForm");
+const girdi = document.getElementById("girdi");
 
-  if (k && p) {
-    document.getElementById("girisEkrani").style.display = "none";
-    document.getElementById("anaEkran").classList.remove("gizli");
-    document.getElementById("kAdi").innerText = k;
-    document.getElementById("profilGorsel").src = p;
-    videolariYukle();
-  }
+const varsayilanDurum = {
+  history: [],
+  decisions: [],
+  outcomes: [],
+  weights: {
+    clarity: 0.6,
+    context: 0.4
+  },
+  lastTopic: null,
+  successPatterns: [],
+  failurePatterns: []
 };
 
-function girisYap() {
-  const k = document.getElementById("kullaniciAdi").value.trim();
-  const p = document.getElementById("profilResmi").files[0];
+const anahtarSozluk = {
+  risk: ["şifre", "hack", "zararlı", "dolandır", "suistimal"],
+  acil: ["acil", "hemen", "şimdi"],
+  duygu: ["üzgün", "mutlu", "kızgın", "heyecan"],
+  onceki: ["önce", "az önce", "değiştir", "devam", "bağla"]
+};
 
-  if (!k || !p) {
-    alert("Ad ve profil resmi gerekli kaptan!");
-    return;
+const niyetHaritasi = [
+  { etiket: "bilgi", ipucu: ["nedir", "nasıl", "neden", "ne zaman", "hangi"] },
+  { etiket: "talep", ipucu: ["oluştur", "yap", "yaz", "özetle", "planla"] },
+  { etiket: "duygu", ipucu: ["hissediyorum", "benim için", "zor", "stres"] }
+];
+
+const cevapHavuzu = {
+  bilgi: ["Kısa cevap: {cevap}.", "Özet: {cevap}.", "Net: {cevap}."] ,
+  talep: ["Tamam. {cevap}.", "Şu şekilde: {cevap}.", "Hemen: {cevap}."] ,
+  duygu: ["Anlıyorum. {cevap}.", "Not ettim. {cevap}.", "Duydum. {cevap}."] ,
+  risk: ["Bu konuda yardımcı olamam.", "Bu istek riskli.", "Bunu yapamam."] ,
+  belirsiz: ["Netleştir: {cevap}.", "Kısa odak: {cevap}.", "Tek bir hedef belirt."]
+};
+
+function yukleDurum() {
+  const sakli = localStorage.getItem(STORAGE_KEY);
+  if (!sakli) {
+    return structuredClone(varsayilanDurum);
   }
-
-  const reader = new FileReader();
-  reader.onload = () => {
-    localStorage.setItem("kullaniciAdi", k);
-    localStorage.setItem("profilResmi", reader.result);
-    location.reload();
-  };
-  reader.readAsDataURL(p);
-}
-
-function goAnaSayfa() {
-  document.getElementById("hesabim").classList.add("gizli");
-  document.getElementById("anaSayfa").style.display = "block";
-}
-
-function goHesabim() {
-  document.getElementById("anaSayfa").style.display = "none";
-  document.getElementById("hesabim").classList.remove("gizli");
-}
-
-function videoYukle() {
-  const dosya = document.getElementById("videoDosyasi").files[0];
-  const baslik = document.getElementById("videoBaslik").value;
-  const kullanici = localStorage.getItem("kullaniciAdi");
-
-  if (!dosya || !baslik) {
-    alert("Video ve başlık eksik!");
-    return;
+  try {
+    return JSON.parse(sakli);
+  } catch (err) {
+    return structuredClone(varsayilanDurum);
   }
-
-  const videoURL = URL.createObjectURL(dosya);
-  const video = { baslik: baslik, url: videoURL, sahip: kullanici };
-
-  const mevcut = JSON.parse(localStorage.getItem("videolar") || "[]");
-  mevcut.push(video);
-  localStorage.setItem("videolar", JSON.stringify(mevcut));
-  videolariYukle();
-
-  document.getElementById("videoDosyasi").value = "";
-  document.getElementById("videoBaslik").value = "";
 }
 
-function videolariYukle() {
-  const videolar = JSON.parse(localStorage.getItem("videolar") || "[]");
-  const liste = document.getElementById("videoListe");
-  const hesap = document.getElementById("videolar");
-  const kullanici = localStorage.getItem("kullaniciAdi");
+function kaydetDurum(state) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
 
-  liste.innerHTML = "";
-  hesap.innerHTML = "";
+function normalize(text) {
+  return text.toLowerCase().trim();
+}
 
-  videolar.forEach((v, i) => {
-    const div = document.createElement("div");
-    div.className = "video";
-    div.innerHTML = `
-      <video src="${v.url}" controls></video>
-      <p>${v.baslik}</p>
-    `;
-    // Ana sayfaya herkesin videoları
-    liste.appendChild(div.cloneNode(true));
+function kelimeVarMi(text, kelimeler) {
+  return kelimeler.some((kelime) => text.includes(kelime));
+}
 
-    // Sadece kendi videolarına silme butonu
-    if (v.sahip === kullanici) {
-      const divHesap = div.cloneNode(true);
-      const silBtn = document.createElement("button");
-      silBtn.innerText = "❌";
-      silBtn.onclick = () => {
-        videolar.splice(i, 1);
-        localStorage.setItem("videolar", JSON.stringify(videolar));
-        videolariYukle();
-      };
-      divHesap.appendChild(silBtn);
-      hesap.appendChild(divHesap);
+function niyetBul(text) {
+  for (const niyet of niyetHaritasi) {
+    if (kelimeVarMi(text, niyet.ipucu)) {
+      return niyet.etiket;
+    }
+  }
+  return "belirsiz";
+}
+
+function konuBul(text) {
+  const kelimeler = text.split(" ").filter(Boolean);
+  return kelimeler.length ? kelimeler[0] : null;
+}
+
+function agirlikliSecim(skorlar) {
+  return skorlar.sort((a, b) => b.skor - a.skor)[0]?.etiket || "belirsiz";
+}
+
+function oncekiBasariliMi(state, cevap) {
+  return state.successPatterns.some((p) => cevap.includes(p));
+}
+
+function guncelleUyum(state, cevap, basarili) {
+  if (basarili) {
+    state.successPatterns.push(cevap);
+    state.failurePatterns = state.failurePatterns.filter((p) => p !== cevap);
+  } else {
+    state.failurePatterns.push(cevap);
+    state.successPatterns = state.successPatterns.filter((p) => p !== cevap);
+  }
+}
+
+function kararVer(state, input) {
+  const text = normalize(input);
+  const riskli = kelimeVarMi(text, anahtarSozluk.risk);
+  const acil = kelimeVarMi(text, anahtarSozluk.acil);
+  const oncekiBag = kelimeVarMi(text, anahtarSozluk.onceki);
+  const niyet = niyetBul(text);
+  const konu = konuBul(text);
+
+  const skorlar = [
+    { etiket: "risk", skor: riskli ? 1 : 0 },
+    { etiket: "belirsiz", skor: niyet === "belirsiz" ? 0.55 : 0.1 },
+    { etiket: niyet, skor: niyet !== "belirsiz" ? 0.7 : 0.2 }
+  ];
+
+  const bagSkoru = oncekiBag && state.lastTopic ? 0.3 : 0;
+  const acilSkoru = acil ? 0.2 : 0;
+  skorlar.forEach((s) => {
+    if (s.etiket !== "risk") {
+      s.skor += bagSkoru + acilSkoru;
     }
   });
+
+  const karar = agirlikliSecim(skorlar);
+
+  return {
+    karar,
+    niyet,
+    konu,
+    riskli,
+    oncekiBag
+  };
 }
+
+function cevapUret(state, input) {
+  const sonuc = kararVer(state, input);
+  const text = normalize(input);
+  const onceki = state.history[state.history.length - 1];
+  const bag = sonuc.oncekiBag && onceki ? `Önceki: ${onceki.input}` : "";
+
+  if (sonuc.riskli) {
+    return {
+      cevap: cevapHavuzu.risk[Math.floor(Math.random() * cevapHavuzu.risk.length)],
+      karar: sonuc
+    };
+  }
+
+  let kisaCevap = "";
+  if (sonuc.karar === "belirsiz") {
+    kisaCevap = "Tek bir niyet belirt";
+  } else if (sonuc.karar === "bilgi") {
+    kisaCevap = `${bag ? bag + ". " : ""}Kısa bilgi veriyorum`;
+  } else if (sonuc.karar === "talep") {
+    kisaCevap = `${bag ? bag + ". " : ""}İstediğini daralt`;
+  } else if (sonuc.karar === "duygu") {
+    kisaCevap = "Buradayım";
+  } else {
+    kisaCevap = "Devam et";
+  }
+
+  const havuz = cevapHavuzu[sonuc.karar] || cevapHavuzu.belirsiz;
+  const secilen = havuz[Math.floor(Math.random() * havuz.length)];
+  const cevap = secilen.replace("{cevap}", kisaCevap);
+
+  const basarili = !oncekiBasariliMi(state, cevap);
+  guncelleUyum(state, cevap, basarili);
+
+  return {
+    cevap,
+    karar: sonuc
+  };
+}
+
+function mesajEkle(icerik, tip) {
+  const div = document.createElement("div");
+  div.className = `message ${tip}`;
+  div.textContent = icerik;
+  sohbet.appendChild(div);
+  sohbet.scrollTop = sohbet.scrollHeight;
+}
+
+form.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const deger = girdi.value.trim();
+  if (!deger) return;
+
+  mesajEkle(deger, "user");
+  girdi.value = "";
+
+  const state = yukleDurum();
+  const sonuc = cevapUret(state, deger);
+
+  state.history.push({
+    input: deger,
+    karar: sonuc.karar.karar,
+    niyet: sonuc.karar.niyet,
+    risk: sonuc.karar.riskli,
+    outcome: sonuc.cevap
+  });
+  state.decisions.push(sonuc.karar);
+  state.outcomes.push(sonuc.cevap);
+  state.lastTopic = sonuc.karar.konu || state.lastTopic;
+  state.weights.context = Math.min(0.8, state.weights.context + 0.02);
+  state.weights.clarity = Math.max(0.2, state.weights.clarity - 0.01);
+
+  kaydetDurum(state);
+
+  durum.textContent = sonuc.karar.riskli ? "Kısıtlı" : "Aktif";
+  setTimeout(() => {
+    mesajEkle(sonuc.cevap, "bot");
+  }, 200);
+});

--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@ const sohbet = document.getElementById("sohbet");
 const durum = document.getElementById("durum");
 const form = document.getElementById("gaiForm");
 const girdi = document.getElementById("girdi");
+const temizleBtn = document.getElementById("temizle");
 
 const varsayilanDurum = {
   history: [],
@@ -13,29 +14,44 @@ const varsayilanDurum = {
     context: 0.4
   },
   lastTopic: null,
+  lastAction: null,
+  pendingAction: null,
+  variationIndex: 0,
   successPatterns: [],
   failurePatterns: []
 };
 
-const anahtarSozluk = {
+const sozluk = {
   risk: ["şifre", "hack", "zararlı", "dolandır", "suistimal"],
   acil: ["acil", "hemen", "şimdi"],
-  duygu: ["üzgün", "mutlu", "kızgın", "heyecan"],
-  onceki: ["önce", "az önce", "değiştir", "devam", "bağla"]
+  duygu: ["üzgün", "mutlu", "kızgın", "heyecan", "stres"],
+  onceki: ["önce", "az önce", "değiştir", "devam", "bağla", "daha"],
+  selam: ["merhaba", "selam", "hey", "hi", "hello", "günaydın", "iyi akşamlar"],
+  onay: ["evet", "olur", "tamam", "ok"],
+  red: ["hayır", "yok", "istemem"],
+  yetenek: ["neler yaparsın", "ne yapabilirsin", "yetenek", "yapabildiklerin"],
+  matematik: ["matematik", "hesapla", "işlem"],
+  siir: ["şiir", "siir"],
+  mantik: ["mantık", "mantik"],
+  oneri: ["buna", "şuna", "böyle", "şöyle"]
 };
 
 const niyetHaritasi = [
   { etiket: "bilgi", ipucu: ["nedir", "nasıl", "neden", "ne zaman", "hangi"] },
-  { etiket: "talep", ipucu: ["oluştur", "yap", "yaz", "özetle", "planla"] },
+  { etiket: "talep", ipucu: ["oluştur", "yap", "yaz", "özetle", "planla", "hazırla"] },
   { etiket: "duygu", ipucu: ["hissediyorum", "benim için", "zor", "stres"] }
 ];
 
 const cevapHavuzu = {
+  selam: ["Merhaba! Nasıl yardımcı olayım?", "Selam! Ne yapalım?", "Merhaba! Kısa bir istek yaz."] ,
   bilgi: ["Kısa cevap: {cevap}.", "Özet: {cevap}.", "Net: {cevap}."] ,
-  talep: ["Tamam. {cevap}.", "Şu şekilde: {cevap}.", "Hemen: {cevap}."] ,
-  duygu: ["Anlıyorum. {cevap}.", "Not ettim. {cevap}.", "Duydum. {cevap}."] ,
+  talep: ["Hemen: {cevap}.", "Tamam: {cevap}.", "Şu şekilde: {cevap}."] ,
+  duygu: ["Anlıyorum. {cevap}.", "Not ettim. {cevap}.", "Buradayım. {cevap}."] ,
   risk: ["Bu konuda yardımcı olamam.", "Bu istek riskli.", "Bunu yapamam."] ,
-  belirsiz: ["Netleştir: {cevap}.", "Kısa odak: {cevap}.", "Tek bir hedef belirt."]
+  belirsiz: ["Netleştir: {cevap}.", "Kısa odak: {cevap}.", "Tek bir hedef belirt."] ,
+  matematik: ["Cevap: {cevap}.", "Hemen: {cevap}.", "Sonuç: {cevap}."] ,
+  siir: ["Şiir: {cevap}", "Kısa şiir: {cevap}", "İşte şiir: {cevap}"] ,
+  model: ["GPT-5.2-Codex, OpenAI tarafından geliştirildi.", "Modelim: GPT-5.2-Codex (OpenAI).", "OpenAI tarafından üretilen GPT-5.2-Codex."]
 };
 
 function yukleDurum() {
@@ -94,11 +110,46 @@ function guncelleUyum(state, cevap, basarili) {
   }
 }
 
-function kararVer(state, input) {
+function seciliCevap(state, kategori, degisken) {
+  const havuz = cevapHavuzu[kategori] || cevapHavuzu.belirsiz;
+  const secim = havuz[state.variationIndex % havuz.length];
+  state.variationIndex += 1;
+  return degisken ? secim.replace("{cevap}", degisken) : secim;
+}
+
+function matematikCoz(text) {
+  const temiz = text.replace(/[^0-9+\-*/(). ]/g, "");
+  if (!/[0-9]/.test(temiz)) return null;
+  if (/[*+\-/.]{3,}/.test(temiz)) return null;
+  try {
+    const sonuc = Function(`"use strict"; return (${temiz})`)();
+    if (!Number.isFinite(sonuc)) return null;
+    return sonuc;
+  } catch (err) {
+    return null;
+  }
+}
+
+function siirUret(theme, index) {
+  const temalar = [theme || "mavi-beyaz", "gece", "deniz", "ışık"];
+  const secili = temalar[index % temalar.length];
+  const satirlar = [
+    `Maviye açılır ${secili} bir kapı`,
+    `Beyaz bir çizgi, sessiz bir akı`,
+    `Zihnimde dolaşır kısa bir rüzgar`,
+    `Gai söyler: ${secili} kadar saf bir karar`
+  ];
+  return satirlar.join(" / ");
+}
+
+function niyetAnaliz(state, input) {
   const text = normalize(input);
-  const riskli = kelimeVarMi(text, anahtarSozluk.risk);
-  const acil = kelimeVarMi(text, anahtarSozluk.acil);
-  const oncekiBag = kelimeVarMi(text, anahtarSozluk.onceki);
+  const riskli = kelimeVarMi(text, sozluk.risk);
+  const acil = kelimeVarMi(text, sozluk.acil);
+  const oncekiBag = kelimeVarMi(text, sozluk.onceki);
+  const selam = kelimeVarMi(text, sozluk.selam);
+  const onay = kelimeVarMi(text, sozluk.onay);
+  const red = kelimeVarMi(text, sozluk.red);
   const niyet = niyetBul(text);
   const konu = konuBul(text);
 
@@ -116,53 +167,131 @@ function kararVer(state, input) {
     }
   });
 
-  const karar = agirlikliSecim(skorlar);
-
   return {
-    karar,
+    karar: agirlikliSecim(skorlar),
     niyet,
     konu,
     riskli,
-    oncekiBag
+    oncekiBag,
+    selam,
+    onay,
+    red,
+    text
   };
 }
 
 function cevapUret(state, input) {
-  const sonuc = kararVer(state, input);
-  const text = normalize(input);
-  const onceki = state.history[state.history.length - 1];
-  const bag = sonuc.oncekiBag && onceki ? `Önceki: ${onceki.input}` : "";
+  const analiz = niyetAnaliz(state, input);
 
-  if (sonuc.riskli) {
+  if (analiz.riskli) {
     return {
-      cevap: cevapHavuzu.risk[Math.floor(Math.random() * cevapHavuzu.risk.length)],
-      karar: sonuc
+      cevap: seciliCevap(state, "risk"),
+      karar: analiz
     };
   }
 
-  let kisaCevap = "";
-  if (sonuc.karar === "belirsiz") {
-    kisaCevap = "Tek bir niyet belirt";
-  } else if (sonuc.karar === "bilgi") {
-    kisaCevap = `${bag ? bag + ". " : ""}Kısa bilgi veriyorum`;
-  } else if (sonuc.karar === "talep") {
-    kisaCevap = `${bag ? bag + ". " : ""}İstediğini daralt`;
-  } else if (sonuc.karar === "duygu") {
-    kisaCevap = "Buradayım";
-  } else {
-    kisaCevap = "Devam et";
+  if (analiz.onay && state.pendingAction) {
+    const sonuc = state.pendingAction.handler();
+    state.pendingAction = null;
+    return sonuc;
   }
 
-  const havuz = cevapHavuzu[sonuc.karar] || cevapHavuzu.belirsiz;
-  const secilen = havuz[Math.floor(Math.random() * havuz.length)];
-  const cevap = secilen.replace("{cevap}", kisaCevap);
+  if (analiz.red && state.pendingAction) {
+    state.pendingAction = null;
+    return { cevap: "Tamam, başka bir şey iste.", karar: analiz };
+  }
 
-  const basarili = !oncekiBasariliMi(state, cevap);
-  guncelleUyum(state, cevap, basarili);
+  if (analiz.selam) {
+    return {
+      cevap: seciliCevap(state, "selam"),
+      karar: analiz
+    };
+  }
+
+  const modelSorusu = [
+    "seni kim yaptı",
+    "hangi model",
+    "kullandığın dil modeli",
+    "modelin ne",
+    "hangi dil modeli"
+  ];
+
+  if (modelSorusu.some((kalip) => analiz.text.includes(kalip))) {
+    return {
+      cevap: seciliCevap(state, "model"),
+      karar: analiz
+    };
+  }
+
+  if (kelimeVarMi(analiz.text, sozluk.yetenek)) {
+    return {
+      cevap: "Matematik çözebilirim, şiir yazabilirim, özet/plan çıkarabilirim, mantık sorusu çözebilirim.",
+      karar: { ...analiz, karar: "bilgi" }
+    };
+  }
+
+  if (kelimeVarMi(analiz.text, sozluk.siir)) {
+    const tema = analiz.text.includes("mavi") || analiz.text.includes("beyaz") ? "mavi-beyaz" : null;
+    const siir = siirUret(tema, state.variationIndex);
+    return {
+      cevap: seciliCevap(state, "siir", siir),
+      karar: { ...analiz, karar: "talep" }
+    };
+  }
+
+  const math = matematikCoz(analiz.text);
+  if (math !== null) {
+    return {
+      cevap: seciliCevap(state, "matematik", math.toString()),
+      karar: { ...analiz, karar: "bilgi" }
+    };
+  }
+
+  if (kelimeVarMi(analiz.text, sozluk.matematik)) {
+    return {
+      cevap: "Hangi işlemi çözeyim? Örn: 12*(3+2)",
+      karar: { ...analiz, karar: "talep" }
+    };
+  }
+
+  if (kelimeVarMi(analiz.text, sozluk.mantik)) {
+    return {
+      cevap: "Mantık sorunu yaz, kısa ve net çözerim.",
+      karar: { ...analiz, karar: "talep" }
+    };
+  }
+
+  if (analiz.oncekiBag && state.lastAction) {
+    const sonuc = state.lastAction();
+    return {
+      ...sonuc,
+      karar: { ...analiz, karar: "talep" }
+    };
+  }
+
+  if (analiz.karar === "belirsiz") {
+    if (state.lastAction && kelimeVarMi(analiz.text, sozluk.oneri)) {
+      state.pendingAction = { handler: state.lastAction };
+      return {
+        cevap: "Önceki işi devam ettireyim mi? (Evet/Hayır)",
+        karar: analiz
+      };
+    }
+    state.pendingAction = {
+      handler: () => ({
+        cevap: "Ne üretmemi istersin: şiir, matematik, özet, plan?",
+        karar: analiz
+      })
+    };
+    return {
+      cevap: "Ne yapmamı istersin? (şiir / matematik / özet / plan)",
+      karar: analiz
+    };
+  }
 
   return {
-    cevap,
-    karar: sonuc
+    cevap: seciliCevap(state, analiz.karar, "Bunu kısa yapabilirim"),
+    karar: analiz
   };
 }
 
@@ -174,6 +303,37 @@ function mesajEkle(icerik, tip) {
   sohbet.scrollTop = sohbet.scrollHeight;
 }
 
+function sohbetiYukle() {
+  const state = yukleDurum();
+  if (!state.history.length) return;
+  sohbet.innerHTML = "";
+  state.history.forEach((item) => {
+    mesajEkle(item.text, item.role);
+  });
+}
+
+function sohbeteEkle(state, role, text, meta = {}) {
+  state.history.push({ role, text, meta });
+  if (state.history.length > 60) {
+    state.history.shift();
+  }
+}
+
+function durumGuncelle(text) {
+  durum.textContent = text;
+}
+
+window.addEventListener("load", () => {
+  sohbetiYukle();
+});
+
+temizleBtn.addEventListener("click", () => {
+  localStorage.removeItem(STORAGE_KEY);
+  sohbet.innerHTML = "";
+  mesajEkle("Sohbet temizlendi.", "bot");
+  durumGuncelle("Hazır");
+});
+
 form.addEventListener("submit", (event) => {
   event.preventDefault();
   const deger = girdi.value.trim();
@@ -183,25 +343,30 @@ form.addEventListener("submit", (event) => {
   girdi.value = "";
 
   const state = yukleDurum();
-  const sonuc = cevapUret(state, deger);
+  sohbeteEkle(state, "user", deger);
 
-  state.history.push({
-    input: deger,
-    karar: sonuc.karar.karar,
-    niyet: sonuc.karar.niyet,
-    risk: sonuc.karar.riskli,
-    outcome: sonuc.cevap
-  });
+  const sonuc = cevapUret(state, deger);
+  const botCevap = sonuc.cevap;
+
   state.decisions.push(sonuc.karar);
-  state.outcomes.push(sonuc.cevap);
+  state.outcomes.push(botCevap);
   state.lastTopic = sonuc.karar.konu || state.lastTopic;
   state.weights.context = Math.min(0.8, state.weights.context + 0.02);
   state.weights.clarity = Math.max(0.2, state.weights.clarity - 0.01);
 
+  state.lastAction = () => ({
+    cevap: botCevap,
+    karar: sonuc.karar
+  });
+
+  const basarili = !oncekiBasariliMi(state, botCevap);
+  guncelleUyum(state, botCevap, basarili);
+
+  sohbeteEkle(state, "bot", botCevap, { karar: sonuc.karar });
   kaydetDurum(state);
 
-  durum.textContent = sonuc.karar.riskli ? "Kısıtlı" : "Aktif";
+  durumGuncelle(sonuc.karar.riskli ? "Kısıtlı" : "Aktif");
   setTimeout(() => {
-    mesajEkle(sonuc.cevap, "bot");
-  }, 200);
+    mesajEkle(botCevap, "bot");
+  }, 160);
 });

--- a/style.css
+++ b/style.css
@@ -1,11 +1,14 @@
 :root {
   color-scheme: light;
+  --mavi-950: #0a1630;
   --mavi-900: #0b1e3a;
   --mavi-700: #1e3a8a;
   --mavi-500: #3b82f6;
+  --mavi-200: #bfdbfe;
   --mavi-100: #e0f2fe;
   --beyaz: #ffffff;
   --gri-100: #f8fafc;
+  --gri-200: #e2e8f0;
   --gri-300: #cbd5f5;
 }
 
@@ -17,44 +20,62 @@
 }
 
 body {
-  background: linear-gradient(160deg, var(--mavi-100), var(--beyaz));
+  background: radial-gradient(circle at top, var(--mavi-100), var(--beyaz) 55%);
   color: var(--mavi-900);
   min-height: 100vh;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 24px;
 }
 
 .app {
-  width: min(720px, 100%);
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  min-height: 100vh;
   background: var(--beyaz);
-  border-radius: 20px;
-  box-shadow: 0 24px 60px rgba(30, 58, 138, 0.15);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  box-shadow: 0 24px 60px rgba(30, 58, 138, 0.12);
 }
 
 .app-header {
-  background: var(--mavi-700);
+  background: linear-gradient(130deg, var(--mavi-700), var(--mavi-900));
   color: var(--beyaz);
   padding: 24px 28px;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 20px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
   gap: 16px;
+}
+
+.brand-chip {
+  background: rgba(255, 255, 255, 0.18);
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.5px;
 }
 
 .app-header h1 {
   font-size: 28px;
-  letter-spacing: 0.5px;
+  letter-spacing: 0.4px;
 }
 
 .app-header p {
   font-size: 14px;
   opacity: 0.9;
   margin-top: 6px;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .status {
@@ -66,14 +87,27 @@ body {
   letter-spacing: 1px;
 }
 
+button {
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  border-radius: 999px;
+  padding: 10px 18px;
+}
+
+button.secondary {
+  background: rgba(255, 255, 255, 0.2);
+  color: var(--beyaz);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
 .chat {
-  padding: 24px 28px;
+  padding: 28px;
   background: var(--gri-100);
   display: flex;
   flex-direction: column;
   gap: 16px;
-  min-height: 360px;
-  max-height: 460px;
+  flex: 1;
   overflow-y: auto;
 }
 
@@ -81,7 +115,7 @@ body {
   padding: 12px 16px;
   border-radius: 16px;
   width: fit-content;
-  max-width: 80%;
+  max-width: 70%;
   line-height: 1.5;
   font-size: 15px;
 }
@@ -97,21 +131,21 @@ body {
   align-self: flex-start;
   background: var(--beyaz);
   color: var(--mavi-900);
-  border: 1px solid var(--gri-300);
+  border: 1px solid var(--gri-200);
   border-bottom-left-radius: 4px;
 }
 
 .composer {
-  padding: 20px 24px 26px;
+  padding: 18px 24px 24px;
   display: flex;
   gap: 12px;
-  border-top: 1px solid var(--gri-300);
+  border-top: 1px solid var(--gri-200);
   background: var(--beyaz);
 }
 
 .composer input {
   flex: 1;
-  padding: 12px 16px;
+  padding: 12px 18px;
   border-radius: 999px;
   border: 1px solid var(--gri-300);
   font-size: 15px;
@@ -126,30 +160,36 @@ body {
 .composer button {
   background: var(--mavi-700);
   color: var(--beyaz);
-  border: none;
-  padding: 12px 22px;
-  border-radius: 999px;
-  font-size: 15px;
-  cursor: pointer;
   transition: transform 0.2s ease, background 0.2s ease;
 }
 
 .composer button:hover {
-  background: var(--mavi-900);
+  background: var(--mavi-950);
   transform: translateY(-1px);
 }
 
-@media (max-width: 600px) {
+@media (max-width: 900px) {
+  .app {
+    width: 100%;
+  }
+
   .app-header {
     flex-direction: column;
     align-items: flex-start;
   }
 
-  .chat {
-    max-height: 360px;
+  .actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 600px) {
+  .message {
+    max-width: 85%;
   }
 
-  .message {
-    max-width: 90%;
+  .composer {
+    padding: 16px;
   }
 }

--- a/style.css
+++ b/style.css
@@ -1,108 +1,155 @@
-body {
+:root {
+  color-scheme: light;
+  --mavi-900: #0b1e3a;
+  --mavi-700: #1e3a8a;
+  --mavi-500: #3b82f6;
+  --mavi-100: #e0f2fe;
+  --beyaz: #ffffff;
+  --gri-100: #f8fafc;
+  --gri-300: #cbd5f5;
+}
+
+* {
+  box-sizing: border-box;
   margin: 0;
-  font-family: Arial, sans-serif;
-  background-color: #0d0d0d;
-  color: white;
+  padding: 0;
+  font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
 }
 
-.gizli {
-  display: none;
-}
-
-#girisEkrani {
-  text-align: center;
-  padding: 40px;
-}
-
-#girisEkrani input, #girisEkrani button {
-  display: block;
-  margin: 10px auto;
-  padding: 10px;
-  width: 80%;
-}
-
-header {
-  background-color: #1a1a1a;
-  padding: 10px;
+body {
+  background: linear-gradient(160deg, var(--mavi-100), var(--beyaz));
+  color: var(--mavi-900);
+  min-height: 100vh;
   display: flex;
-  justify-content: space-between;
   align-items: center;
-}
-
-#arama {
-  padding: 8px;
-  border-radius: 5px;
-  border: none;
-}
-
-.video-galeri {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 15px;
   justify-content: center;
-  padding: 20px;
+  padding: 24px;
 }
 
-.video {
-  background: #1a1a1a;
-  padding: 10px;
-  border-radius: 10px;
-  width: 200px;
-  text-align: center;
-  position: relative;
-}
-
-.video video {
-  width: 100%;
-  border-radius: 5px;
-}
-
-.video button {
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  background: red;
-  color: white;
-  border: none;
-  border-radius: 50%;
-  padding: 5px;
-  cursor: pointer;
-}
-
-#profil {
-  text-align: center;
-  margin-top: 20px;
-}
-
-#profil img {
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  object-fit: cover;
-  background-color: white;
-}
-
-#videoDosyasi, #videoBaslik {
-  display: block;
-  margin: 10px auto;
-  padding: 8px;
-  width: 80%;
-}
-
-nav#altMenu {
-  position: fixed;
-  bottom: 0;
-  width: 100%;
-  background: #111;
+.app {
+  width: min(720px, 100%);
+  background: var(--beyaz);
+  border-radius: 20px;
+  box-shadow: 0 24px 60px rgba(30, 58, 138, 0.15);
   display: flex;
-  justify-content: space-around;
-  padding: 10px 0;
+  flex-direction: column;
+  overflow: hidden;
 }
 
-nav button {
-  background: none;
+.app-header {
+  background: var(--mavi-700);
+  color: var(--beyaz);
+  padding: 24px 28px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.app-header h1 {
+  font-size: 28px;
+  letter-spacing: 0.5px;
+}
+
+.app-header p {
+  font-size: 14px;
+  opacity: 0.9;
+  margin-top: 6px;
+}
+
+.status {
+  background: rgba(255, 255, 255, 0.18);
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.chat {
+  padding: 24px 28px;
+  background: var(--gri-100);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 360px;
+  max-height: 460px;
+  overflow-y: auto;
+}
+
+.message {
+  padding: 12px 16px;
+  border-radius: 16px;
+  width: fit-content;
+  max-width: 80%;
+  line-height: 1.5;
+  font-size: 15px;
+}
+
+.message.user {
+  align-self: flex-end;
+  background: var(--mavi-500);
+  color: var(--beyaz);
+  border-bottom-right-radius: 4px;
+}
+
+.message.bot {
+  align-self: flex-start;
+  background: var(--beyaz);
+  color: var(--mavi-900);
+  border: 1px solid var(--gri-300);
+  border-bottom-left-radius: 4px;
+}
+
+.composer {
+  padding: 20px 24px 26px;
+  display: flex;
+  gap: 12px;
+  border-top: 1px solid var(--gri-300);
+  background: var(--beyaz);
+}
+
+.composer input {
+  flex: 1;
+  padding: 12px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--gri-300);
+  font-size: 15px;
+}
+
+.composer input:focus {
+  outline: none;
+  border-color: var(--mavi-500);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.composer button {
+  background: var(--mavi-700);
+  color: var(--beyaz);
   border: none;
-  color: white;
-  font-size: 24px;
+  padding: 12px 22px;
+  border-radius: 999px;
+  font-size: 15px;
   cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.composer button:hover {
+  background: var(--mavi-900);
+  transform: translateY(-1px);
+}
+
+@media (max-width: 600px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .chat {
+    max-height: 360px;
+  }
+
+  .message {
+    max-width: 90%;
+  }
 }


### PR DESCRIPTION
### Motivation
- Replace the previous video app layout with a minimal conversational UI for an assistant named Gai.
- Provide a persistent internal state so inputs, decisions, and outcomes are evaluated across turns using `localStorage`.
- Implement hybrid decision-making (if/else + weighted scoring + context linking) to choose concise responses.
- Restyle the app with a blue-white (mavi-beyaz) theme and a compact composer interface.

### Description
- Replaced the page structure in `index.html` with a chat layout and form-based composer for Gai.
- Implemented persistent state and decision pipeline in `script.js`, including `yukleDurum`, `kaydetDurum`, `niyetBul`, `kararVer`, and `cevapUret` to detect intent, risk, and context and update adaptive weights and success/failure patterns.
- Added simple response pools and risk filtering to ensure risky requests return safe canned replies and concise outputs.
- Updated `style.css` to a responsive blue-white theme and message/composer styles with CSS variables for the color scheme.

### Testing
- Started a development server with `python -m http.server 8000`, which served the site successfully.
- Ran a Playwright script to capture a screenshot, which completed successfully and produced `artifacts/gai-ui.png`.
- No unit tests or automated behavior tests were run against the decision logic itself.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966823b7090832c985af67b9eb25e6c)