### PR TITLE
Add GAI-1.0 rule-based Turkish chat UI with theme, animations and logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,49 +2,51 @@
 <html lang="tr">
 <head>
   <meta charset="UTF-8">
-  <title>MemTube</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GAI-1.0</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
-  <!-- Kayıt Ekranı -->
-  <div id="girisEkrani">
-    <h2>MemTube'e Giriş</h2>
-    <input type="text" id="kullaniciAdi" placeholder="Takma Ad (zorunlu)">
-    <input type="file" id="profilResmi" accept="image/*">
-    <button onclick="girisYap()">Giriş Yap</button>
-  </div>
-
-  <!-- Ana Ekran -->
-  <div id="anaEkran" class="gizli">
-    <header>
-      <h1>📺 MemTube</h1>
-      <input type="text" id="arama" placeholder="Ara...">
+  <div class="app">
+    <header class="app-header">
+      <div class="brand">
+        <div class="brand-logo" id="gaiLogo">GAI</div>
+        <div class="brand-text">
+          <span class="brand-name">GAI-1.0</span>
+          <span class="brand-sub">Türkçe mini zeka</span>
+        </div>
+      </div>
+      <div class="header-actions">
+        <button class="ghost-button" id="resetChat">Sohbeti Sıfırla</button>
+        <div class="profile-chip">
+          <span class="profile-icon">👤</span>
+        </div>
+      </div>
     </header>
 
-    <!-- Ana Sayfa -->
-    <main id="anaSayfa">
-      <div id="videoListe" class="video-galeri"></div>
-    </main>
-
-    <!-- Hesabım Sayfası -->
-    <section id="hesabim" class="gizli">
-      <div id="profil">
-        <img id="profilGorsel" alt="Profil Resmi">
-        <h3 id="kAdi"></h3>
+    <section class="hero">
+      <div class="hero-card">
+        <h1>Merhaba! Ben GAI-1.0 👋</h1>
+        <p>İf/else + küçük beyin + string matching ile çalışan, sadece Türkçe konuşan mini asistan.</p>
       </div>
-      <h4>Videolarım</h4>
-      <input type="file" id="videoDosyasi" accept="video/*">
-      <input type="text" id="videoBaslik" placeholder="Video Başlığı">
-      <button onclick="videoYukle()">+ Yükle</button>
-      <div id="videolar" class="video-galeri"></div>
+      <button class="plus-button" id="plusButton" aria-label="Yeni Özellik">+</button>
     </section>
 
-    <!-- Alt Menü -->
-    <nav id="altMenu">
-      <button onclick="goAnaSayfa()">🏠</button>
-      <button onclick="goHesabim()">👤</button>
-    </nav>
+    <main class="chat-area" id="chatArea">
+      <div class="message gai">
+        <div class="bubble">
+          Merhaba! Bana her şeyi sorabilirsin. Bugün nasıl hissediyorsun?
+        </div>
+      </div>
+    </main>
+
+    <footer class="composer">
+      <div class="input-wrapper">
+        <input type="text" id="userInput" placeholder="Bir şey yaz... örn: merhaba, nasılsın, elma, kaç, yedi">
+        <button id="sendButton">Gönder</button>
+      </div>
+      <p class="composer-hint">GAI-1.0 cevapları çeşitlendirir ve 3 saniye düşünür.</p>
+    </footer>
   </div>
 
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,97 +1,300 @@
-window.onload = () => {
-  const k = localStorage.getItem("kullaniciAdi");
-  const p = localStorage.getItem("profilResmi");
+const chatArea = document.getElementById("chatArea");
+const userInput = document.getElementById("userInput");
+const sendButton = document.getElementById("sendButton");
+const resetChat = document.getElementById("resetChat");
+const gaiLogo = document.getElementById("gaiLogo");
 
-  if (k && p) {
-    document.getElementById("girisEkrani").style.display = "none";
-    document.getElementById("anaEkran").classList.remove("gizli");
-    document.getElementById("kAdi").innerText = k;
-    document.getElementById("profilGorsel").src = p;
-    videolariYukle();
+let conversationHistory = [];
+let lastUserMessage = "";
+let lastGaiResponse = "";
+let chatMemory = [];
+let mathModeActive = false;
+
+const randomPick = (items) => items[Math.floor(Math.random() * items.length)];
+
+const includesAny = (words, text) => words.some((word) => text.includes(word));
+
+const kelimeHavuzu = [
+  "merhaba", "selam", "selamlar", "selamun", "günaydın", "iyi", "gece", "akşam", "nasılsın", "naber",
+  "iyiyim", "kötüyüm", "mutluyum", "üzgünüm", "heyecanlı", "yorgunum", "sıkıldım", "sinirliyim", "neşeliyim", "keyifliyim",
+  "teşekkür", "sağol", "sağolun", "rica", "lütfen", "tamam", "evet", "hayır", "belki", "olur",
+  "elma", "armut", "muz", "çilek", "kiraz", "karpuz", "kavun", "portakal", "mandalina", "üzüm",
+  "domates", "salatalık", "patates", "biber", "patlıcan", "soğan", "sarımsak", "marul", "ıspanak", "brokoli",
+  "pizza", "hamburger", "kebap", "döner", "mantı", "börek", "çorba", "pilav", "makarna", "salata",
+  "çay", "kahve", "su", "ayran", "limonata", "meşrubat", "soda", "şerbet", "süt", "kola",
+  "hava", "yağmur", "güneş", "bulut", "rüzgar", "kar", "fırtına", "sis", "sıcak", "soğuk",
+  "mevsim", "bahar", "yaz", "kış", "sonbahar", "pazartesi", "salı", "çarşamba", "perşembe", "cuma",
+  "cumartesi", "pazar", "saat", "dakika", "saniye", "zaman", "takvim", "bugün", "yarın", "dün",
+  "şehir", "istanbul", "ankara", "izmir", "bursa", "adana", "antalya", "trabzon", "samsun", "konya",
+  "okul", "ders", "ödev", "sınav", "kitap", "defter", "kalem", "silgi", "matematik", "fen",
+  "tarih", "coğrafya", "felsefe", "edebiyat", "şiir", "roman", "hikaye", "yazar", "okumak", "yazmak",
+  "spor", "futbol", "basketbol", "voleybol", "tenis", "yüzme", "koşu", "bisiklet", "yoga", "dans",
+  "müzik", "şarkı", "melodi", "ritim", "gitar", "piyano", "keman", "davul", "konser", "kulaklık",
+  "film", "dizi", "sinema", "oyuncu", "yönetmen", "sahne", "kahraman", "komedi", "dram", "aksiyon",
+  "teknoloji", "bilgisayar", "telefon", "tablet", "internet", "uygulama", "oyun", "kod", "program", "yapay",
+  "zeka", "robot", "algoritma", "veri", "bulut", "sunucu", "tarayıcı", "ekran", "klavye", "fare",
+  "ev", "oda", "mutfak", "salon", "balkon", "bahçe", "yatak", "koltuk", "masa", "sandalye",
+  "aile", "anne", "baba", "kardeş", "abla", "ağabey", "dede", "nine", "amca", "teyze",
+  "arkadaş", "dost", "komşu", "öğretmen", "öğrenci", "çocuk", "bebek", "genç", "yetişkin", "yaşlı",
+  "sevgi", "saygı", "umut", "mutluluk", "başarı", "hedef", "hayal", "motivasyon", "sabır", "cesaret",
+  "renk", "mavi", "beyaz", "kırmızı", "yeşil", "sarı", "mor", "turuncu", "pembe", "gri",
+  "siyah", "ışık", "parlak", "gölge", "desen", "tasarım", "tema", "stil", "estetik", "minimal",
+  "soru", "cevap", "neden", "nasıl", "ne", "nerede", "kim", "hangi", "kaç", "yedi",
+  "sayı", "hesap", "topla", "çıkar", "çarp", "böl", "eşit", "sonuç", "problem", "mantık",
+  "kural", "if", "else", "koşul", "döngü", "değişken", "fonksiyon", "liste", "dizi", "hafıza",
+  "hatırla", "unutma", "tekrar", "özet", "detay", "açıkla", "anlat", "kısaca", "uzun", "yavaş",
+  "hızlı", "nazik", "samimi", "resmi", "şaka", "ciddi", "güven", "gizli", "açık", "net",
+  "yardım", "destek", "öneri", "tavsiye", "ipuç", "rehber", "plan", "listele", "sırala", "seç",
+  "başla", "dur", "devam", "bitir", "yeniden", "sıfırla", "temizle", "kapat", "aç", "göster",
+  "gizle", "yükle", "indir", "ekle", "sil", "düzenle", "kontrol", "bak", "incele", "ara",
+  "bul", "yap", "hazırla", "süsle", "parla", "dön", "bekle", "düşün", "yazdır", "dinle",
+  "gör", "oku", "anla", "öğren", "çalış", "oyna", "dinlen", "gül", "ağla", "çiz",
+  "boya", "hareket", "animasyon", "parlama", "ışılda", "yumuşak", "sert", "hafif", "yoğun", "derin",
+  "uzay", "dünya", "gezegen", "güneş", "ay", "yıldız", "galaksi", "evren", "bulutsu", "meteor",
+  "deniz", "okyanus", "göl", "nehir", "şelale", "dağ", "orman", "çöl", "ada", "kıyı",
+  "hayvan", "kedi", "köpek", "kuş", "balık", "aslan", "kaplan", "at", "tavşan", "kaplumbağa",
+  "araba", "otobüs", "uçak", "tren", "gemi", "bisiklet", "motor", "yol", "köprü", "tünel",
+  "para", "ekonomi", "pazar", "alışveriş", "mağaza", "fiyat", "indirim", "bütçe", "maliyet", "kazanç",
+  "sağlık", "spor", "egzersiz", "doktor", "hastane", "ilaç", "vitamin", "uyku", "diyet", "enerji",
+  "program", "planla", "takip", "hatırlat", "not", "liste", "görev", "hedef", "akış", "süreç",
+  "cümle", "kelime", "harf", "ses", "hece", "nokta", "virgül", "soru", "ünlem", "yazı",
+  "çözüm", "problem", "konu", "başlık", "özet", "soru", "cevap", "fikir", "yorum", "tahmin",
+  "keyif", "mutlu", "mutluluk", "üzüntü", "korku", "heyecan", "şaşkın", "gurur", "sevgi", "nefret",
+  "basit", "zor", "kolay", "karmaşık", "sade", "hız", "tempo", "akış", "denge", "uyum",
+  "sistem", "model", "taslak", "şema", "harita", "plan", "çerçeve", "yapı", "katman", "düzen",
+  "başarı", "ilerleme", "gelişim", "öğrenme", "deneme", "tecrübe", "çaba", "emek", "sonuç", "performans",
+  "sakin", "rahat", "huzur", "ferah", "heyecan", "enerji", "moral", "motivasyon", "istek", "odak",
+  "şans", "risk", "fırsat", "karar", "seçim", "tercih", "kriter", "değer", "kalite", "ölçü",
+  "kültür", "sanat", "mimari", "tasarım", "moda", "tarih", "miras", "gelenek", "adet", "kutlama",
+  "bayram", "tatil", "gezi", "seyahat", "yolculuk", "rota", "harita", "rehber", "konaklama", "uçuş",
+  "hobi", "koleksiyon", "fotoğraf", "resim", "heykel", "el işi", "bahçe", "balıkçılık", "kamp", "doğa",
+  "bilgi", "veri", "istatistik", "sayı", "grafik", "tablo", "analiz", "sonuç", "çıkarım", "yorum",
+  "dil", "türkçe", "ingilizce", "almanca", "fransızca", "italyanca", "ispanyolca", "japonca", "korece", "arapça",
+  "teknik", "pratik", "örnek", "deney", "araştırma", "keşif", "bulgu", "hipotez", "teori", "kanıt",
+  "çevre", "doğa", "iklim", "kirlilik", "geri dönüşüm", "enerji", "tasarruf", "su", "hava", "toprak",
+  "güvenlik", "parola", "şifre", "gizlilik", "koruma", "risk", "tehdit", "önlem", "kilit", "kalkan",
+  "hayat", "yaşam", "rüya", "hedef", "plan", "yol", "denge", "ritim", "alışkanlık", "rutine",
+  "öğle", "sabah", "akşam", "gece", "günün", "hafta", "ay", "yıl", "takvim", "süre",
+  "mutfak", "tarif", "yemek", "lezzet", "tat", "tuz", "şeker", "baharat", "sos", "fırın",
+  "alışkanlık", "davranış", "tutum", "düşünce", "zihin", "beyin", "hafıza", "odak", "dikkat", "algı",
+  "güzellik", "estetik", "renk", "uyum", "kontrast", "çizgi", "doku", "ışık", "gölge", "form",
+  "kritik", "analiz", "değerlendirme", "inceleme", "yorumlama", "anlam", "önem", "seviye", "başlangıç", "bitiş",
+  "ciddiyet", "eğlence", "şakalaş", "gülümse", "pozitif", "negatif", "denge", "ölçü", "tasarruf", "sadakat",
+  "özgür", "bağımsız", "sorumluluk", "görev", "hak", "adalet", "kural", "düzen", "disiplin", "saygı",
+  "devam", "başla", "dur", "bekle", "sabret", "acele", "planla", "program", "süre", "zaman",
+  "iş", "kariyer", "meslek", "çalışan", "takım", "lider", "toplantı", "rapor", "proje", "sunum",
+  "pazar", "müşteri", "satış", "pazarlama", "reklam", "marka", "logo", "kimlik", "strateji", "hedef",
+  "kütüphane", "ansiklopedi", "sözlük", "kelime", "anlam", "tanım", "örnek", "metin", "paragraf", "başlık",
+  "giriş", "gelişme", "sonuç", "özet", "not", "fikir", "anahtar", "tema", "başlık", "madde",
+  "yön", "kuzey", "güney", "doğu", "batı", "harita", "pusula", "rota", "mesafe", "hedef",
+  "sev", "sevin", "gül", "güler", "şen", "moral", "enerji", "coşku", "ilham", "heves",
+  "kısmet", "nasip", "talih", "şans", "fırsat", "umut", "çaba", "emek", "düş", "hayal",
+  "haber", "güncel", "son", "trend", "popüler", "viral", "gündem", "manşet", "duyuru", "bildirim",
+  "öner", "tavsiye", "plan", "listele", "sırala", "seç", "seçenek", "alternatif", "kriter", "değer"
+];
+
+const greetingWords = ["merhaba", "selam", "selamlar", "günaydın", "iyi akşamlar", "iyi geceler", "selamun"];
+const moodWords = ["nasılsın", "naber", "ne haber", "nasılsınız", "nasıl gidiyor", "keyifler", "iyi misin"];
+const thanksWords = ["teşekkür", "sağol", "sağ ol", "eyvallah", "minnettar", "çok sağol", "tşk"];
+const byeWords = ["görüşürüz", "bay bay", "hoşça kal", "güle güle", "bye", "kendine iyi bak"];
+const appleWords = ["elma", "elmanın", "elmalar", "elmacık", "apple"];
+const mathKeywords = ["matematik", "hesap", "topla", "çıkar", "çarp", "böl", "işlem", "kaç", "sonuç"];
+
+const responsePools = {
+  greeting: [
+    "Merhaba! GAI-1.0 burada, nasıl yardımcı olabilirim?",
+    "Selam! Bugün hangi konuda konuşalım?",
+    "Hey! Seni görmek güzel. Bir soru sorabilirsin.",
+    "Merhaba, mavi-beyaz dünyama hoş geldin!"
+  ],
+  mood: [
+    "Ben iyiyim! Sen nasılsın?",
+    "Gayet iyi gidiyor. Senin günün nasıl?",
+    "Modum yüksek! Senin enerjin nasıl?",
+    "İyiyim, teşekkürler! Sen neler yapıyorsun?"
+  ],
+  thanks: [
+    "Rica ederim! Her zaman buradayım.",
+    "Ne demek, yardımcı olmak hoşuma gidiyor.",
+    "Memnun oldum! Başka bir şey ister misin?",
+    "Ben teşekkür ederim!"
+  ],
+  bye: [
+    "Görüşmek üzere! Güzel bir gün dilerim.",
+    "Hoşça kal! Tekrar beklerim.",
+    "Bay bay! Kendine iyi bak.",
+    "Sonra görüşürüz!"
+  ],
+  apple: [
+    "Elma deyince aklıma tazelik geliyor. Bir de kırmızı elma mı, yeşil elma mı?",
+    "Elma güzeldir! Tatlı mı ekşi mi seversin?",
+    "Elma hakkında sohbet etmek hoş. İstersen tarif öneririm.",
+    "Elma kelimesini yakaladım. Meyve sohbeti başlasın!"
+  ],
+  fallback: [
+    "Bunu anladım ama biraz daha detay verir misin?",
+    "İlginç! Bir örnekle anlatırsan daha iyi olur.",
+    "Bu konuda konuşabiliriz. Neyi hedefliyorsun?",
+    "Konu güzel, biraz daha açar mısın?"
+  ]
+};
+
+const mathResponses = [
+  "Hesapladım, sonuç bu gibi görünüyor:",
+  "Matematik modu aktif! İşlem sonucu:",
+  "Sayılarla konuştuk, cevap:",
+  "İşte işlem sonucu:"
+];
+
+const addMessage = (text, type, isTyping = false) => {
+  const wrapper = document.createElement("div");
+  wrapper.className = `message ${type}`;
+  const bubble = document.createElement("div");
+  bubble.className = "bubble";
+  if (isTyping) {
+    bubble.classList.add("typing");
+  }
+  bubble.textContent = text;
+  wrapper.appendChild(bubble);
+  chatArea.appendChild(wrapper);
+  chatArea.scrollTop = chatArea.scrollHeight;
+  return bubble;
+};
+
+const updateMemory = (message, response) => {
+  lastUserMessage = message;
+  lastGaiResponse = response;
+  conversationHistory.push({ user: message, gai: response });
+  const tokens = message.split(/\s+/).map((word) => word.toLowerCase());
+  chatMemory = [...new Set([...chatMemory, ...tokens])].slice(-120);
+};
+
+const detectMathExpression = (text) => {
+  const normalized = text
+    .replace(/artı|plus/gi, "+")
+    .replace(/eksi|minus/gi, "-")
+    .replace(/çarpı|x|carp/gi, "*")
+    .replace(/bölü|bol/gi, "/")
+    .replace(/[^0-9+\-*/(). ]/g, " ");
+  const hasNumbers = /\d/.test(normalized);
+  return hasNumbers ? normalized : null;
+};
+
+const evaluateMath = (expression) => {
+  try {
+    const safeExpression = expression.replace(/\s+/g, "");
+    if (!/^[0-9+\-*/().]+$/.test(safeExpression)) {
+      return null;
+    }
+    const result = Function(`"use strict"; return (${safeExpression})`)();
+    if (Number.isFinite(result)) {
+      return result;
+    }
+    return null;
+  } catch {
+    return null;
   }
 };
 
-function girisYap() {
-  const k = document.getElementById("kullaniciAdi").value.trim();
-  const p = document.getElementById("profilResmi").files[0];
+const buildResponse = (message) => {
+  const soru = message.toLowerCase();
+  let response = "";
 
-  if (!k || !p) {
-    alert("Ad ve profil resmi gerekli kaptan!");
-    return;
-  }
-
-  const reader = new FileReader();
-  reader.onload = () => {
-    localStorage.setItem("kullaniciAdi", k);
-    localStorage.setItem("profilResmi", reader.result);
-    location.reload();
-  };
-  reader.readAsDataURL(p);
-}
-
-function goAnaSayfa() {
-  document.getElementById("hesabim").classList.add("gizli");
-  document.getElementById("anaSayfa").style.display = "block";
-}
-
-function goHesabim() {
-  document.getElementById("anaSayfa").style.display = "none";
-  document.getElementById("hesabim").classList.remove("gizli");
-}
-
-function videoYukle() {
-  const dosya = document.getElementById("videoDosyasi").files[0];
-  const baslik = document.getElementById("videoBaslik").value;
-  const kullanici = localStorage.getItem("kullaniciAdi");
-
-  if (!dosya || !baslik) {
-    alert("Video ve başlık eksik!");
-    return;
-  }
-
-  const videoURL = URL.createObjectURL(dosya);
-  const video = { baslik: baslik, url: videoURL, sahip: kullanici };
-
-  const mevcut = JSON.parse(localStorage.getItem("videolar") || "[]");
-  mevcut.push(video);
-  localStorage.setItem("videolar", JSON.stringify(mevcut));
-  videolariYukle();
-
-  document.getElementById("videoDosyasi").value = "";
-  document.getElementById("videoBaslik").value = "";
-}
-
-function videolariYukle() {
-  const videolar = JSON.parse(localStorage.getItem("videolar") || "[]");
-  const liste = document.getElementById("videoListe");
-  const hesap = document.getElementById("videolar");
-  const kullanici = localStorage.getItem("kullaniciAdi");
-
-  liste.innerHTML = "";
-  hesap.innerHTML = "";
-
-  videolar.forEach((v, i) => {
-    const div = document.createElement("div");
-    div.className = "video";
-    div.innerHTML = `
-      <video src="${v.url}" controls></video>
-      <p>${v.baslik}</p>
-    `;
-    // Ana sayfaya herkesin videoları
-    liste.appendChild(div.cloneNode(true));
-
-    // Sadece kendi videolarına silme butonu
-    if (v.sahip === kullanici) {
-      const divHesap = div.cloneNode(true);
-      const silBtn = document.createElement("button");
-      silBtn.innerText = "❌";
-      silBtn.onclick = () => {
-        videolar.splice(i, 1);
-        localStorage.setItem("videolar", JSON.stringify(videolar));
-        videolariYukle();
-      };
-      divHesap.appendChild(silBtn);
-      hesap.appendChild(divHesap);
+  if (soru.includes("matematik modu") || soru.includes("math mode")) {
+    mathModeActive = true;
+    response = "Matematik modu açık! Artık sayıları daha hızlı çözerim.";
+  } else if (soru.includes("matematik modu kapat") || soru.includes("math off")) {
+    mathModeActive = false;
+    response = "Matematik modunu kapattım. Normal sohbet moduna döndüm.";
+  } else if (includesAny(greetingWords, soru)) {
+    response = randomPick(responsePools.greeting);
+  } else if (includesAny(moodWords, soru)) {
+    response = randomPick(responsePools.mood);
+  } else if (includesAny(thanksWords, soru)) {
+    response = randomPick(responsePools.thanks);
+  } else if (includesAny(byeWords, soru)) {
+    response = randomPick(responsePools.bye);
+  } else if (includesAny(appleWords, soru)) {
+    response = randomPick(responsePools.apple);
+  } else if (soru.includes("hatırla") || soru.includes("hafıza")) {
+    if (conversationHistory.length === 0) {
+      response = "Henüz bir şey hatırlamıyorum ama şimdi başlayabiliriz.";
+    } else {
+      response = `En son şunu söyledin: "${lastUserMessage}" ve ben de "${lastGaiResponse}" demiştim.`;
     }
-  });
-}
+  } else if (soru.includes("son mesaj") || soru.includes("son cevap")) {
+    response = `Son kullanıcı mesajı: "${lastUserMessage}". Son GAI cevabı: "${lastGaiResponse}".`;
+  } else if (soru.includes("ne biliyorsun") || soru.includes("hafızanda ne var")) {
+    response = `Şu an hafızamda ${chatMemory.length} kelime var: ${chatMemory.slice(-15).join(", ")}.`;
+  } else if (includesAny(mathKeywords, soru) || mathModeActive) {
+    const expression = detectMathExpression(soru);
+    const result = expression ? evaluateMath(expression) : null;
+    if (result !== null) {
+      response = `${randomPick(mathResponses)} ${result}`;
+    } else {
+      response = "Bir matematik ifadesi yakaladım ama net değil. Örnek: 12 + 4 * 2";
+    }
+  } else if (soru.includes("renk") || soru.includes("mavi") || soru.includes("beyaz")) {
+    response = "Mavi-beyaz temayı seviyorum. İstersen daha açık mavi tonlar ekleyebiliriz.";
+  } else if (soru.includes("animasyon") || soru.includes("parla") || soru.includes("dön")) {
+    response = "Animasyonlar aktif! Logo parlıyor, artı butonu ışıldıyor ve düşünürken dönüyorum.";
+  } else if (includesAny(kelimeHavuzu, soru)) {
+    response = `"${message}" hakkında konuşabiliriz. Daha fazla detay verirsen daha iyi yanıtlarım.`;
+  } else {
+    response = randomPick(responsePools.fallback);
+  }
+
+  return response;
+};
+
+const typeResponse = (bubble, text) => {
+  bubble.textContent = "";
+  bubble.classList.add("typing");
+  let index = 0;
+  const interval = setInterval(() => {
+    bubble.textContent += text[index];
+    index += 1;
+    chatArea.scrollTop = chatArea.scrollHeight;
+    if (index >= text.length) {
+      clearInterval(interval);
+      bubble.classList.remove("typing");
+    }
+  }, 24);
+};
+
+const handleSend = () => {
+  const message = userInput.value.trim();
+  if (!message) {
+    return;
+  }
+  addMessage(message, "user");
+  userInput.value = "";
+  gaiLogo.classList.add("thinking");
+
+  const thinkingBubble = addMessage("Düşünüyorum...", "gai", true);
+  const response = buildResponse(message);
+
+  setTimeout(() => {
+    gaiLogo.classList.remove("thinking");
+    thinkingBubble.textContent = "";
+    typeResponse(thinkingBubble, response);
+    updateMemory(message, response);
+  }, 3000);
+};
+
+sendButton.addEventListener("click", handleSend);
+userInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    handleSend();
+  }
+});
+
+resetChat.addEventListener("click", () => {
+  chatArea.innerHTML = "";
+  conversationHistory = [];
+  chatMemory = [];
+  lastUserMessage = "";
+  lastGaiResponse = "";
+  mathModeActive = false;
+  addMessage("Sohbet sıfırlandı. Merhaba demek ister misin?", "gai");
+});

--- a/style.css
+++ b/style.css
@@ -1,108 +1,356 @@
+:root {
+  --blue-50: #f2f7ff;
+  --blue-100: #e5efff;
+  --blue-200: #c3dbff;
+  --blue-300: #9fc3ff;
+  --blue-400: #6ca4ff;
+  --blue-500: #3c7bff;
+  --blue-600: #1b56e3;
+  --blue-700: #1642b5;
+  --blue-900: #0f1f4a;
+  --white: #ffffff;
+  --shadow: 0 20px 40px rgba(15, 31, 74, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
-  background-color: #0d0d0d;
-  color: white;
+  font-family: "Segoe UI", Tahoma, sans-serif;
+  background: linear-gradient(135deg, var(--blue-50), var(--white));
+  color: var(--blue-900);
+  min-height: 100vh;
+  overflow-x: hidden;
 }
 
-.gizli {
-  display: none;
-}
-
-#girisEkrani {
-  text-align: center;
-  padding: 40px;
-}
-
-#girisEkrani input, #girisEkrani button {
-  display: block;
-  margin: 10px auto;
-  padding: 10px;
-  width: 80%;
-}
-
-header {
-  background-color: #1a1a1a;
-  padding: 10px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-#arama {
-  padding: 8px;
-  border-radius: 5px;
-  border: none;
-}
-
-.video-galeri {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 15px;
-  justify-content: center;
-  padding: 20px;
-}
-
-.video {
-  background: #1a1a1a;
-  padding: 10px;
-  border-radius: 10px;
-  width: 200px;
-  text-align: center;
-  position: relative;
-}
-
-.video video {
-  width: 100%;
-  border-radius: 5px;
-}
-
-.video button {
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  background: red;
-  color: white;
-  border: none;
-  border-radius: 50%;
-  padding: 5px;
-  cursor: pointer;
-}
-
-#profil {
-  text-align: center;
-  margin-top: 20px;
-}
-
-#profil img {
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  object-fit: cover;
-  background-color: white;
-}
-
-#videoDosyasi, #videoBaslik {
-  display: block;
-  margin: 10px auto;
-  padding: 8px;
-  width: 80%;
-}
-
-nav#altMenu {
+body::before,
+body::after {
+  content: "";
   position: fixed;
-  bottom: 0;
-  width: 100%;
-  background: #111;
-  display: flex;
-  justify-content: space-around;
-  padding: 10px 0;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(60, 123, 255, 0.16), transparent 45%),
+    radial-gradient(circle at bottom right, rgba(108, 164, 255, 0.18), transparent 40%);
+  animation: floatBackground 12s ease-in-out infinite alternate;
+  pointer-events: none;
+  z-index: -1;
 }
 
-nav button {
-  background: none;
-  border: none;
-  color: white;
-  font-size: 24px;
+body::after {
+  animation-delay: 2s;
+  opacity: 0.7;
+}
+
+@keyframes floatBackground {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  100% {
+    transform: translate3d(-20px, 20px, 0);
+  }
+}
+
+.app {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 32px 24px 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px 24px;
+  background: var(--white);
+  border-radius: 24px;
+  box-shadow: var(--shadow);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.brand-logo {
+  width: 60px;
+  height: 60px;
+  border-radius: 20px;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  letter-spacing: 1px;
+  color: var(--white);
+  background: linear-gradient(135deg, var(--blue-500), var(--blue-700));
+  box-shadow: 0 0 20px rgba(60, 123, 255, 0.45);
+  animation: logoPulse 2.5s ease-in-out infinite;
+}
+
+.brand-logo.thinking {
+  animation: logoSpin 3s ease-in-out forwards;
+}
+
+@keyframes logoPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 20px rgba(60, 123, 255, 0.45);
+    transform: scale(1);
+  }
+  50% {
+    box-shadow: 0 0 30px rgba(60, 123, 255, 0.7);
+    transform: scale(1.04);
+  }
+}
+
+@keyframes logoSpin {
+  0% {
+    transform: rotate(0deg) scale(1);
+  }
+  70% {
+    transform: rotate(360deg) scale(1.1);
+  }
+  100% {
+    transform: rotate(360deg) scale(1);
+  }
+}
+
+.brand-text {
+  display: flex;
+  flex-direction: column;
+}
+
+.brand-name {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.brand-sub {
+  font-size: 0.9rem;
+  color: rgba(15, 31, 74, 0.7);
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.ghost-button {
+  border: 1px solid var(--blue-200);
+  background: var(--white);
+  color: var(--blue-700);
+  padding: 10px 16px;
+  border-radius: 999px;
+  font-weight: 600;
   cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.ghost-button:hover {
+  background: var(--blue-100);
+  border-color: var(--blue-300);
+}
+
+.profile-chip {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: var(--blue-100);
+  display: grid;
+  place-items: center;
+  font-size: 1.2rem;
+  box-shadow: 0 6px 16px rgba(60, 123, 255, 0.15);
+}
+
+.hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.hero-card {
+  flex: 1;
+  background: var(--white);
+  padding: 20px 24px;
+  border-radius: 24px;
+  box-shadow: var(--shadow);
+}
+
+.hero-card h1 {
+  margin: 0 0 8px;
+  font-size: 1.6rem;
+}
+
+.hero-card p {
+  margin: 0;
+  color: rgba(15, 31, 74, 0.65);
+}
+
+.plus-button {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  border: none;
+  background: linear-gradient(135deg, var(--blue-400), var(--blue-600));
+  color: var(--white);
+  font-size: 2rem;
+  cursor: pointer;
+  box-shadow: 0 0 24px rgba(60, 123, 255, 0.5);
+  animation: plusGlow 2s ease-in-out infinite;
+}
+
+@keyframes plusGlow {
+  0%,
+  100% {
+    box-shadow: 0 0 24px rgba(60, 123, 255, 0.5);
+  }
+  50% {
+    box-shadow: 0 0 40px rgba(60, 123, 255, 0.8);
+  }
+}
+
+.chat-area {
+  background: var(--white);
+  border-radius: 24px;
+  padding: 24px;
+  box-shadow: var(--shadow);
+  min-height: 360px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-height: 55vh;
+  overflow-y: auto;
+}
+
+.message {
+  display: flex;
+}
+
+.message.gai {
+  justify-content: flex-start;
+}
+
+.message.user {
+  justify-content: flex-end;
+}
+
+.bubble {
+  padding: 14px 18px;
+  border-radius: 18px;
+  max-width: 70%;
+  line-height: 1.5;
+  font-size: 0.98rem;
+  box-shadow: 0 8px 18px rgba(15, 31, 74, 0.08);
+}
+
+.message.gai .bubble {
+  background: var(--blue-100);
+  border: 1px solid var(--blue-200);
+}
+
+.message.user .bubble {
+  background: var(--blue-500);
+  color: var(--white);
+}
+
+.bubble.typing::after {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 16px;
+  margin-left: 6px;
+  border-radius: 4px;
+  background: var(--blue-600);
+  animation: caret 1s steps(1) infinite;
+}
+
+@keyframes caret {
+  0%,
+  50% {
+    opacity: 1;
+  }
+  51%,
+  100% {
+    opacity: 0;
+  }
+}
+
+.composer {
+  background: var(--white);
+  border-radius: 24px;
+  padding: 20px 24px;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.input-wrapper {
+  display: flex;
+  gap: 12px;
+}
+
+#userInput {
+  flex: 1;
+  padding: 12px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--blue-200);
+  font-size: 1rem;
+  outline: none;
+}
+
+#userInput:focus {
+  border-color: var(--blue-400);
+  box-shadow: 0 0 0 3px rgba(60, 123, 255, 0.15);
+}
+
+#sendButton {
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: none;
+  background: var(--blue-600);
+  color: var(--white);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+#sendButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(27, 86, 227, 0.25);
+}
+
+.composer-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(15, 31, 74, 0.6);
+}
+
+@media (max-width: 860px) {
+  .hero {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .plus-button {
+    align-self: flex-end;
+  }
+
+  .bubble {
+    max-width: 85%;
+  }
+
+  .input-wrapper {
+    flex-direction: column;
+  }
+
+  #sendButton {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
### Motivation
- Replace the previous video app layout with a compact, sketch-driven chat experience named GAI-1.0 that acts as a small Turkish-only rule-based assistant. 
- Provide a clear visual identity (blue/white theme, logo/plus animations and typing effect) to match the requested UI and perceived “thinking” behavior. 
- Implement a deterministic, local rule engine using `if/else`, string matching and a small memory to keep the assistant self-contained without external LLM dependencies.

### Description
- Replaced `index.html` with a new chat layout (`.app`, header, hero, `#chatArea`, composer) and added `id` hooks like `gaiLogo`, `resetChat`, `plusButton`, `userInput`, and `sendButton` for UI interactions. 
- Rewrote `style.css` to implement the blue/white theme, background float animation, logo pulse/`thinking` spin, plus-button glow, message bubble styles and responsive layout. 
- Replaced the old script with `script.js` that implements rule-based behavior: a large Turkish keyword pool, `includesAny` string matching, `conversationHistory`, `lastUserMessage`, `lastGaiResponse`, `chatMemory`, math detection/evaluation (`detectMathExpression`, `evaluateMath`), varied response pools, delayed typing animation and a 3s “thinking” state that triggers logo animation. 
- Added chat controls including `resetChat` to clear memory and preserved UI behaviors like typewriter-style response display via `typeResponse` and `handleSend` event wiring.

### Testing
- Hosted the site with `python -m http.server 8000` and captured a visual verification screenshot using a Playwright script, which completed successfully and produced `artifacts/gai-1-0.png`. 
- No unit tests were added; the change was validated via the manual/automated visual check above and a local commit was created.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967bbe32f8c832c98401427f120d5a8)