### PR TITLE
Add LinguaGo Duolingo-style English learning UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,49 +2,122 @@
 <html lang="tr">
 <head>
   <meta charset="UTF-8">
-  <title>MemTube</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>LinguaGo - İngilizce Öğren</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
-  <!-- Kayıt Ekranı -->
-  <div id="girisEkrani">
-    <h2>MemTube'e Giriş</h2>
-    <input type="text" id="kullaniciAdi" placeholder="Takma Ad (zorunlu)">
-    <input type="file" id="profilResmi" accept="image/*">
-    <button onclick="girisYap()">Giriş Yap</button>
-  </div>
-
-  <!-- Ana Ekran -->
-  <div id="anaEkran" class="gizli">
-    <header>
-      <h1>📺 MemTube</h1>
-      <input type="text" id="arama" placeholder="Ara...">
+  <div class="app">
+    <header class="app-header">
+      <div class="brand">
+        <span class="brand-icon">🦉</span>
+        <div>
+          <p class="brand-name">LinguaGo</p>
+          <p class="brand-tagline">İngilizceyi günlük 5 dakikada öğren</p>
+        </div>
+      </div>
+      <div class="stats">
+        <div class="stat">
+          <span class="stat-label">Seri</span>
+          <span id="streak" class="stat-value">3 gün</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">Can</span>
+          <span id="hearts" class="stat-value">5 ❤</span>
+        </div>
+        <div class="stat">
+          <span class="stat-label">XP</span>
+          <span id="xp" class="stat-value">120</span>
+        </div>
+      </div>
     </header>
 
-    <!-- Ana Sayfa -->
-    <main id="anaSayfa">
-      <div id="videoListe" class="video-galeri"></div>
+    <main>
+      <section class="hero">
+        <div>
+          <h1>Bugünkü hedefin: 10 dakika pratik</h1>
+          <p>Dinleme, kelime ve konuşma pratiklerini tamamlayarak rozet kazan.</p>
+          <button class="primary" id="startLesson">Derse Başla</button>
+        </div>
+        <div class="goal-card">
+          <h3>Günlük hedef</h3>
+          <div class="goal-progress">
+            <div id="goalFill" class="goal-fill" style="width: 30%"></div>
+          </div>
+          <p><span id="goalValue">3</span>/10 dakika tamamlandı</p>
+        </div>
+      </section>
+
+      <section class="path">
+        <h2>Öğrenme Yolu</h2>
+        <div class="path-grid">
+          <article class="lesson-card active">
+            <h3>Selamlaşma</h3>
+            <p>"Hi", "Good morning" ifadelerini öğren.</p>
+            <span class="pill">Başlangıç</span>
+          </article>
+          <article class="lesson-card">
+            <h3>Günlük rutin</h3>
+            <p>Sabah rutinini anlatan cümleler.</p>
+            <span class="pill">Kilitli</span>
+          </article>
+          <article class="lesson-card">
+            <h3>Yemek zamanı</h3>
+            <p>Menüden sipariş vermeyi öğren.</p>
+            <span class="pill">Kilitli</span>
+          </article>
+          <article class="lesson-card">
+            <h3>Gezinti</h3>
+            <p>Şehir içinde yön tarifi alın.</p>
+            <span class="pill">Kilitli</span>
+          </article>
+        </div>
+      </section>
+
+      <section class="practice">
+        <div class="practice-header">
+          <h2>Hızlı Pratik</h2>
+          <span class="badge">3 soru</span>
+        </div>
+
+        <div class="question-card">
+          <div class="question-meta">
+            <span class="chip">Dinleme</span>
+            <span class="chip">Seviye A1</span>
+          </div>
+          <h3 id="questionText">"Hello" kelimesinin Türkçe karşılığı nedir?</h3>
+          <div id="options" class="options">
+            <button class="option" data-correct="true">Merhaba</button>
+            <button class="option">Lütfen</button>
+            <button class="option">Hoşça kal</button>
+            <button class="option">Teşekkürler</button>
+          </div>
+          <div class="feedback" id="feedback">Doğru seçeneği seçip kontrol et.</div>
+          <div class="actions">
+            <button class="ghost" id="skipQuestion">Atla</button>
+            <button class="primary" id="checkAnswer" disabled>Kontrol Et</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="tips">
+        <h2>Bugünün İpuçları</h2>
+        <div class="tips-grid">
+          <div class="tip-card">
+            <h4>Hızlı tekrar</h4>
+            <p>5 dakikalık sesli tekrarlarla kelimeleri kalıcılaştır.</p>
+          </div>
+          <div class="tip-card">
+            <h4>Konuşma koçu</h4>
+            <p>Sesini kaydedip telaffuz puanı al.</p>
+          </div>
+          <div class="tip-card">
+            <h4>Mini hikayeler</h4>
+            <p>Kısa hikayelerle okuma pratiği yap.</p>
+          </div>
+        </div>
+      </section>
     </main>
-
-    <!-- Hesabım Sayfası -->
-    <section id="hesabim" class="gizli">
-      <div id="profil">
-        <img id="profilGorsel" alt="Profil Resmi">
-        <h3 id="kAdi"></h3>
-      </div>
-      <h4>Videolarım</h4>
-      <input type="file" id="videoDosyasi" accept="video/*">
-      <input type="text" id="videoBaslik" placeholder="Video Başlığı">
-      <button onclick="videoYukle()">+ Yükle</button>
-      <div id="videolar" class="video-galeri"></div>
-    </section>
-
-    <!-- Alt Menü -->
-    <nav id="altMenu">
-      <button onclick="goAnaSayfa()">🏠</button>
-      <button onclick="goHesabim()">👤</button>
-    </nav>
   </div>
 
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,97 +1,124 @@
-window.onload = () => {
-  const k = localStorage.getItem("kullaniciAdi");
-  const p = localStorage.getItem("profilResmi");
+const questions = [
+  {
+    text: "\"Hello\" kelimesinin Türkçe karşılığı nedir?",
+    options: ["Merhaba", "Lütfen", "Hoşça kal", "Teşekkürler"],
+    correctIndex: 0,
+    skill: "Dinleme",
+  },
+  {
+    text: "\"I am a student\" cümlesinin anlamı hangisidir?",
+    options: [
+      "Ben bir öğrenciyim",
+      "Ben bir öğretmenim",
+      "Öğrenciler burada",
+      "Benim öğrencim var",
+    ],
+    correctIndex: 0,
+    skill: "Okuma",
+  },
+  {
+    text: "\"Good night\" için doğru Türkçe ifade hangisi?",
+    options: ["Günaydın", "İyi geceler", "Hoş geldin", "İyi öğlen"],
+    correctIndex: 1,
+    skill: "Konuşma",
+  },
+];
 
-  if (k && p) {
-    document.getElementById("girisEkrani").style.display = "none";
-    document.getElementById("anaEkran").classList.remove("gizli");
-    document.getElementById("kAdi").innerText = k;
-    document.getElementById("profilGorsel").src = p;
-    videolariYukle();
-  }
+const streakEl = document.getElementById("streak");
+const heartsEl = document.getElementById("hearts");
+const xpEl = document.getElementById("xp");
+const goalFill = document.getElementById("goalFill");
+const goalValue = document.getElementById("goalValue");
+const questionText = document.getElementById("questionText");
+const optionsEl = document.getElementById("options");
+const feedbackEl = document.getElementById("feedback");
+const checkAnswerBtn = document.getElementById("checkAnswer");
+const skipQuestionBtn = document.getElementById("skipQuestion");
+
+let currentIndex = 0;
+let selectedIndex = null;
+let xp = 120;
+let streak = 3;
+let hearts = 5;
+let minutes = 3;
+let isAnswered = false;
+
+const updateStats = () => {
+  streakEl.textContent = `${streak} gün`;
+  heartsEl.textContent = `${hearts} ❤`;
+  xpEl.textContent = xp;
+  goalValue.textContent = minutes;
+  goalFill.style.width = `${Math.min((minutes / 10) * 100, 100)}%`;
 };
 
-function girisYap() {
-  const k = document.getElementById("kullaniciAdi").value.trim();
-  const p = document.getElementById("profilResmi").files[0];
+const renderQuestion = () => {
+  const question = questions[currentIndex];
+  questionText.textContent = question.text;
+  feedbackEl.textContent = "Doğru seçeneği seçip kontrol et.";
+  optionsEl.innerHTML = "";
+  selectedIndex = null;
+  checkAnswerBtn.disabled = true;
+  checkAnswerBtn.textContent = "Kontrol Et";
+  isAnswered = false;
 
-  if (!k || !p) {
-    alert("Ad ve profil resmi gerekli kaptan!");
-    return;
-  }
+  question.options.forEach((option, index) => {
+    const button = document.createElement("button");
+    button.className = "option";
+    button.textContent = option;
+    button.addEventListener("click", () => {
+      optionsEl.querySelectorAll(".option").forEach((item) => {
+        item.classList.remove("selected");
+      });
+      button.classList.add("selected");
+      selectedIndex = index;
+      checkAnswerBtn.disabled = false;
+    });
+    optionsEl.appendChild(button);
+  });
+};
 
-  const reader = new FileReader();
-  reader.onload = () => {
-    localStorage.setItem("kullaniciAdi", k);
-    localStorage.setItem("profilResmi", reader.result);
-    location.reload();
-  };
-  reader.readAsDataURL(p);
-}
-
-function goAnaSayfa() {
-  document.getElementById("hesabim").classList.add("gizli");
-  document.getElementById("anaSayfa").style.display = "block";
-}
-
-function goHesabim() {
-  document.getElementById("anaSayfa").style.display = "none";
-  document.getElementById("hesabim").classList.remove("gizli");
-}
-
-function videoYukle() {
-  const dosya = document.getElementById("videoDosyasi").files[0];
-  const baslik = document.getElementById("videoBaslik").value;
-  const kullanici = localStorage.getItem("kullaniciAdi");
-
-  if (!dosya || !baslik) {
-    alert("Video ve başlık eksik!");
-    return;
-  }
-
-  const videoURL = URL.createObjectURL(dosya);
-  const video = { baslik: baslik, url: videoURL, sahip: kullanici };
-
-  const mevcut = JSON.parse(localStorage.getItem("videolar") || "[]");
-  mevcut.push(video);
-  localStorage.setItem("videolar", JSON.stringify(mevcut));
-  videolariYukle();
-
-  document.getElementById("videoDosyasi").value = "";
-  document.getElementById("videoBaslik").value = "";
-}
-
-function videolariYukle() {
-  const videolar = JSON.parse(localStorage.getItem("videolar") || "[]");
-  const liste = document.getElementById("videoListe");
-  const hesap = document.getElementById("videolar");
-  const kullanici = localStorage.getItem("kullaniciAdi");
-
-  liste.innerHTML = "";
-  hesap.innerHTML = "";
-
-  videolar.forEach((v, i) => {
-    const div = document.createElement("div");
-    div.className = "video";
-    div.innerHTML = `
-      <video src="${v.url}" controls></video>
-      <p>${v.baslik}</p>
-    `;
-    // Ana sayfaya herkesin videoları
-    liste.appendChild(div.cloneNode(true));
-
-    // Sadece kendi videolarına silme butonu
-    if (v.sahip === kullanici) {
-      const divHesap = div.cloneNode(true);
-      const silBtn = document.createElement("button");
-      silBtn.innerText = "❌";
-      silBtn.onclick = () => {
-        videolar.splice(i, 1);
-        localStorage.setItem("videolar", JSON.stringify(videolar));
-        videolariYukle();
-      };
-      divHesap.appendChild(silBtn);
-      hesap.appendChild(divHesap);
+const revealAnswer = () => {
+  const question = questions[currentIndex];
+  optionsEl.querySelectorAll(".option").forEach((item, index) => {
+    if (index === question.correctIndex) {
+      item.classList.add("correct");
+    }
+    if (index === selectedIndex && selectedIndex !== question.correctIndex) {
+      item.classList.add("wrong");
     }
   });
-}
+};
+
+checkAnswerBtn.addEventListener("click", () => {
+  if (isAnswered) {
+    currentIndex = (currentIndex + 1) % questions.length;
+    renderQuestion();
+    return;
+  }
+
+  const question = questions[currentIndex];
+  revealAnswer();
+  isAnswered = true;
+
+  if (selectedIndex === question.correctIndex) {
+    feedbackEl.textContent = "Harika! 10 XP kazandın.";
+    xp += 10;
+    minutes += 2;
+  } else {
+    feedbackEl.textContent = "Tekrar dene! Bir can kaybettin.";
+    hearts = Math.max(0, hearts - 1);
+  }
+
+  checkAnswerBtn.textContent = currentIndex === questions.length - 1 ? "Tamamla" : "Devam";
+  checkAnswerBtn.disabled = false;
+  updateStats();
+});
+
+skipQuestionBtn.addEventListener("click", () => {
+  feedbackEl.textContent = "Soru atlandı. Hızlıca diğerine geç.";
+  currentIndex = (currentIndex + 1) % questions.length;
+  renderQuestion();
+});
+
+updateStats();
+renderQuestion();

--- a/style.css
+++ b/style.css
@@ -1,108 +1,309 @@
+:root {
+  --green: #58cc02;
+  --green-dark: #42a301;
+  --blue: #2c7ef8;
+  --text: #202124;
+  --muted: #5f6368;
+  --bg: #f7f9fb;
+  --card: #ffffff;
+  --border: #e3e7ed;
+  --warning: #ffb020;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
-  background-color: #0d0d0d;
-  color: white;
+  font-family: "Segoe UI", system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--text);
 }
 
-.gizli {
-  display: none;
+.app {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px;
 }
 
-#girisEkrani {
-  text-align: center;
-  padding: 40px;
-}
-
-#girisEkrani input, #girisEkrani button {
-  display: block;
-  margin: 10px auto;
-  padding: 10px;
-  width: 80%;
-}
-
-header {
-  background-color: #1a1a1a;
-  padding: 10px;
+.app-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
+  background: var(--card);
+  border-radius: 18px;
+  padding: 18px 24px;
+  box-shadow: 0 10px 30px rgba(35, 50, 80, 0.08);
+  position: sticky;
+  top: 16px;
+  z-index: 10;
 }
 
-#arama {
-  padding: 8px;
-  border-radius: 5px;
-  border: none;
-}
-
-.video-galeri {
+.brand {
   display: flex;
-  flex-wrap: wrap;
-  gap: 15px;
-  justify-content: center;
-  padding: 20px;
+  align-items: center;
+  gap: 14px;
 }
 
-.video {
-  background: #1a1a1a;
-  padding: 10px;
-  border-radius: 10px;
-  width: 200px;
-  text-align: center;
+.brand-icon {
+  font-size: 36px;
+}
+
+.brand-name {
+  font-weight: 700;
+  margin: 0;
+  font-size: 20px;
+}
+
+.brand-tagline {
+  margin: 2px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.stats {
+  display: flex;
+  gap: 18px;
+}
+
+.stat {
+  text-align: right;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.stat-value {
+  display: block;
+  font-weight: 700;
+  color: var(--text);
+  font-size: 15px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.3fr 0.7fr;
+  gap: 24px;
+  margin-top: 28px;
+}
+
+.hero h1 {
+  font-size: 28px;
+  margin-bottom: 8px;
+}
+
+.hero p {
+  color: var(--muted);
+  margin-bottom: 18px;
+}
+
+.primary {
+  background: var(--green);
+  color: white;
+  border: none;
+  padding: 12px 24px;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 8px 20px rgba(88, 204, 2, 0.25);
+  transition: transform 0.2s ease;
+}
+
+.primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.primary:hover:not(:disabled) {
+  transform: translateY(-2px);
+}
+
+.ghost {
+  background: transparent;
+  border: 1px solid var(--border);
+  padding: 12px 20px;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.goal-card {
+  background: var(--card);
+  padding: 20px;
+  border-radius: 18px;
+  border: 1px solid var(--border);
+}
+
+.goal-progress {
+  width: 100%;
+  height: 10px;
+  background: #edf1f6;
+  border-radius: 999px;
+  margin: 12px 0;
+  overflow: hidden;
+}
+
+.goal-fill {
+  height: 100%;
+  background: var(--green);
+  border-radius: 999px;
+}
+
+.path {
+  margin-top: 36px;
+}
+
+.path-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+  margin-top: 16px;
+}
+
+.lesson-card {
+  background: var(--card);
+  border-radius: 16px;
+  padding: 18px;
+  border: 1px solid var(--border);
   position: relative;
 }
 
-.video video {
-  width: 100%;
-  border-radius: 5px;
+.lesson-card.active {
+  border: 2px solid var(--green);
+  box-shadow: 0 12px 24px rgba(88, 204, 2, 0.18);
 }
 
-.video button {
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  background: red;
-  color: white;
-  border: none;
-  border-radius: 50%;
-  padding: 5px;
-  cursor: pointer;
+.pill {
+  display: inline-block;
+  margin-top: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #eef7e3;
+  color: var(--green-dark);
+  font-size: 12px;
+  font-weight: 700;
 }
 
-#profil {
-  text-align: center;
-  margin-top: 20px;
+.practice {
+  margin-top: 36px;
 }
 
-#profil img {
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  object-fit: cover;
-  background-color: white;
-}
-
-#videoDosyasi, #videoBaslik {
-  display: block;
-  margin: 10px auto;
-  padding: 8px;
-  width: 80%;
-}
-
-nav#altMenu {
-  position: fixed;
-  bottom: 0;
-  width: 100%;
-  background: #111;
+.practice-header {
   display: flex;
-  justify-content: space-around;
-  padding: 10px 0;
+  align-items: center;
+  justify-content: space-between;
 }
 
-nav button {
-  background: none;
-  border: none;
+.badge {
+  background: var(--blue);
   color: white;
-  font-size: 24px;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.question-card {
+  background: var(--card);
+  border-radius: 20px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  margin-top: 16px;
+}
+
+.question-meta {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.chip {
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #f1f4ff;
+  color: #4263eb;
+  font-weight: 600;
+}
+
+.options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+  margin: 18px 0;
+}
+
+.option {
+  border: 2px solid transparent;
+  padding: 12px 14px;
+  border-radius: 14px;
+  background: #f5f7fa;
   cursor: pointer;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.option.selected {
+  border-color: var(--blue);
+  background: #e9f0ff;
+}
+
+.option.correct {
+  border-color: var(--green);
+  background: #eaf7db;
+}
+
+.option.wrong {
+  border-color: #ff6b6b;
+  background: #ffe3e3;
+}
+
+.feedback {
+  background: #f6f9ff;
+  border-radius: 12px;
+  padding: 10px 14px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.actions {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 16px;
+}
+
+.tips {
+  margin: 36px 0 60px;
+}
+
+.tips-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.tip-card {
+  background: var(--card);
+  border-radius: 16px;
+  padding: 18px;
+  border: 1px solid var(--border);
+}
+
+@media (max-width: 860px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .stats {
+    width: 100%;
+    justify-content: space-between;
+  }
 }


### PR DESCRIPTION
### Motivation
- Replace the previous MemTube video/profile UI with a lightweight, Duolingo-inspired English learning landing page to provide a simple practice flow and visual lesson path.
- Provide a self-contained static frontend that demonstrates lesson cards, a quick practice quiz, and simple progression stats (XP, streak, hearts).

### Description
- Replace `index.html` with a new layout for "LinguaGo" that includes header stats, hero/goal card, lesson path, practice question card and tips section.
- Rewrite `style.css` with a new design system (colors, cards, responsive layout) and styles for lesson/path/practice components and option states.
- Replace the previous video/profile JavaScript with `script.js` implementing a questions array, `updateStats`, `renderQuestion`, `revealAnswer`, and handlers for `checkAnswer` and `skipQuestion`, plus an `isAnswered` state to control next-question behavior.
- Remove the previous localStorage video upload/listing logic and instead update XP, hearts, and minutes progress when answering questions.

### Testing
- Started a local static server via `python -m http.server 8000` and ran a Playwright script that loaded `http://127.0.0.1:8000/index.html` and captured a screenshot `artifacts/linguago-home.png`, which completed successfully.
- No unit tests or automated CI were run against the frontend logic beyond the screenshot smoke test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696aa8817244832c86eac95ec0a35d25)