### PR TITLE
Add 3D phone showcase with three-finger rotation and power toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,8 +33,8 @@
               <div class="kamera"></div>
               <div class="ekran">
                 <div class="ekran-icerik">
-                  <span>MemTube</span>
-                  <span>3D Görünüm</span>
+                  <span>Yeni Nesil</span>
+                  <span>Akıllı Telefon</span>
                 </div>
               </div>
             </div>
@@ -44,7 +44,7 @@
                 <div class="lens"></div>
                 <div class="flash"></div>
               </div>
-              <div class="logo">MT</div>
+              <div class="logo">NX</div>
             </div>
             <div class="telefon-yuz telefon-sol"></div>
             <div class="telefon-yuz telefon-sag"></div>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,38 @@
 
     <!-- Ana Sayfa -->
     <main id="anaSayfa">
+      <section id="telefonVitrini" class="telefon-vitrini">
+        <h2>3D Telefon Deneyimi</h2>
+        <p class="telefon-ipucu">Üç parmakla kaydırarak telefonu çevir, yanındaki güç butonuna tıklayarak ekranı aç/kapat.</p>
+        <div class="telefon-sahne" id="telefonSahne">
+          <div class="telefon" id="telefonModel" aria-live="polite">
+            <div class="telefon-yuz telefon-on">
+              <div class="kamera"></div>
+              <div class="ekran">
+                <div class="ekran-icerik">
+                  <span>MemTube</span>
+                  <span>3D Görünüm</span>
+                </div>
+              </div>
+            </div>
+            <div class="telefon-yuz telefon-arka">
+              <div class="kamera-modul">
+                <div class="lens"></div>
+                <div class="lens"></div>
+                <div class="flash"></div>
+              </div>
+              <div class="logo">MT</div>
+            </div>
+            <div class="telefon-yuz telefon-sol"></div>
+            <div class="telefon-yuz telefon-sag"></div>
+            <div class="telefon-yuz telefon-ust"></div>
+            <div class="telefon-yuz telefon-alt"></div>
+            <button class="acma-kapama" id="gucButonu" type="button" aria-pressed="false">
+              ⏻
+            </button>
+          </div>
+        </div>
+      </section>
       <div id="videoListe" class="video-galeri"></div>
     </main>
 

--- a/script.js
+++ b/script.js
@@ -9,7 +9,103 @@ window.onload = () => {
     document.getElementById("profilGorsel").src = p;
     videolariYukle();
   }
+
+  telefonModeliniBaslat();
 };
+
+function telefonModeliniBaslat() {
+  const telefon = document.getElementById("telefonModel");
+  const sahne = document.getElementById("telefonSahne");
+  const gucButonu = document.getElementById("gucButonu");
+
+  if (!telefon || !sahne || !gucButonu) {
+    return;
+  }
+
+  let rotX = -12;
+  let rotY = 20;
+  let surukleniyor = false;
+  let baslangic = { x: 0, y: 0 };
+
+  const uygulaTransform = () => {
+    telefon.style.transform = `rotateX(${rotX}deg) rotateY(${rotY}deg)`;
+  };
+
+  const koordinatOrtalama = (dokunuslar) => {
+    const kullanilan = Math.min(dokunuslar.length, 3);
+    let toplamX = 0;
+    let toplamY = 0;
+    for (let i = 0; i < kullanilan; i += 1) {
+      toplamX += dokunuslar[i].clientX;
+      toplamY += dokunuslar[i].clientY;
+    }
+    return {
+      x: toplamX / kullanilan,
+      y: toplamY / kullanilan,
+    };
+  };
+
+  sahne.addEventListener("mousedown", (event) => {
+    surukleniyor = true;
+    baslangic = { x: event.clientX, y: event.clientY };
+  });
+
+  window.addEventListener("mousemove", (event) => {
+    if (!surukleniyor) {
+      return;
+    }
+    const deltaX = event.clientX - baslangic.x;
+    const deltaY = event.clientY - baslangic.y;
+    baslangic = { x: event.clientX, y: event.clientY };
+    rotY += deltaX * 0.4;
+    rotX -= deltaY * 0.4;
+    uygulaTransform();
+  });
+
+  window.addEventListener("mouseup", () => {
+    surukleniyor = false;
+  });
+
+  sahne.addEventListener(
+    "touchstart",
+    (event) => {
+      if (event.touches.length < 3) {
+        surukleniyor = false;
+        return;
+      }
+      surukleniyor = true;
+      baslangic = koordinatOrtalama(event.touches);
+    },
+    { passive: true }
+  );
+
+  sahne.addEventListener(
+    "touchmove",
+    (event) => {
+      if (!surukleniyor || event.touches.length < 3) {
+        return;
+      }
+      event.preventDefault();
+      const merkez = koordinatOrtalama(event.touches);
+      const deltaX = merkez.x - baslangic.x;
+      const deltaY = merkez.y - baslangic.y;
+      baslangic = merkez;
+      rotY += deltaX * 0.4;
+      rotX -= deltaY * 0.4;
+      uygulaTransform();
+    },
+    { passive: false }
+  );
+
+  sahne.addEventListener("touchend", () => {
+    surukleniyor = false;
+  });
+
+  gucButonu.addEventListener("click", () => {
+    const kapali = telefon.classList.toggle("is-off");
+    gucButonu.setAttribute("aria-pressed", String(kapali));
+  });
+}
 
 function girisYap() {
   const k = document.getElementById("kullaniciAdi").value.trim();

--- a/style.css
+++ b/style.css
@@ -132,8 +132,8 @@ nav button {
 }
 
 .telefon {
-  width: 220px;
-  height: 440px;
+  width: 240px;
+  height: 480px;
   position: relative;
   transform-style: preserve-3d;
   transform: rotateX(-12deg) rotateY(20deg);
@@ -142,138 +142,141 @@ nav button {
 
 .telefon-yuz {
   position: absolute;
-  background: linear-gradient(160deg, #151515, #252525);
-  border-radius: 28px;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6);
+  background: linear-gradient(160deg, #141b2d, #0b0f1a);
+  border-radius: 34px;
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.7);
 }
 
 .telefon-on,
 .telefon-arka {
-  width: 220px;
-  height: 440px;
+  width: 240px;
+  height: 480px;
 }
 
 .telefon-on {
-  transform: translateZ(15px);
-  background: #111;
-  border: 2px solid #2a2a2a;
+  transform: translateZ(16px);
+  background: #0a0f1a;
+  border: 2px solid #1f2a3f;
 }
 
 .telefon-arka {
-  transform: rotateY(180deg) translateZ(15px);
-  background: linear-gradient(145deg, #1f1f1f, #2f2f2f);
-  border: 2px solid #141414;
+  transform: rotateY(180deg) translateZ(16px);
+  background: linear-gradient(145deg, #0f1526, #1b2440);
+  border: 2px solid #0b1120;
 }
 
 .telefon-sol,
 .telefon-sag {
-  width: 30px;
-  height: 440px;
+  width: 32px;
+  height: 480px;
   top: 0;
-  border-radius: 22px;
-  background: #1a1a1a;
+  border-radius: 28px;
+  background: #111827;
 }
 
 .telefon-sol {
-  transform: rotateY(-90deg) translateZ(15px);
+  transform: rotateY(-90deg) translateZ(16px);
   transform-origin: left;
-  left: -15px;
+  left: -16px;
 }
 
 .telefon-sag {
-  transform: rotateY(90deg) translateZ(205px);
+  transform: rotateY(90deg) translateZ(224px);
   transform-origin: right;
-  right: -15px;
+  right: -16px;
 }
 
 .telefon-ust,
 .telefon-alt {
-  width: 220px;
-  height: 30px;
+  width: 240px;
+  height: 32px;
   left: 0;
-  background: #1a1a1a;
-  border-radius: 22px;
+  background: #111827;
+  border-radius: 28px;
 }
 
 .telefon-ust {
-  transform: rotateX(90deg) translateZ(15px);
+  transform: rotateX(90deg) translateZ(16px);
   transform-origin: top;
-  top: -15px;
+  top: -16px;
 }
 
 .telefon-alt {
-  transform: rotateX(-90deg) translateZ(425px);
+  transform: rotateX(-90deg) translateZ(464px);
   transform-origin: bottom;
-  bottom: -15px;
+  bottom: -16px;
 }
 
 .ekran {
   position: absolute;
-  inset: 20px;
-  border-radius: 22px;
-  background: radial-gradient(circle at top, #1c1c1c 20%, #050505 80%);
+  inset: 14px;
+  border-radius: 28px;
+  background: radial-gradient(circle at top, #1d2a48 10%, #05070c 75%);
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 2px solid #2c2c2c;
-  transition: background 0.3s ease, box-shadow 0.3s ease;
-  box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  transition: background 0.3s ease, box-shadow 0.3s ease, opacity 0.3s ease;
+  box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.7);
+  overflow: hidden;
 }
 
 .ekran-icerik {
   display: flex;
   flex-direction: column;
   gap: 6px;
-  font-weight: bold;
+  font-weight: 600;
   letter-spacing: 1px;
-  color: #e4e4e4;
+  color: #e6f0ff;
   opacity: 1;
   transition: opacity 0.3s ease;
 }
 
 .kamera {
   position: absolute;
-  top: 14px;
+  top: 10px;
   left: 50%;
-  width: 60px;
-  height: 12px;
-  background: #090909;
-  border-radius: 10px;
+  width: 90px;
+  height: 18px;
+  background: linear-gradient(90deg, #0b0f1a, #1b2334);
+  border-radius: 14px;
   transform: translateX(-50%);
+  box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.8);
 }
 
 .kamera::before {
   content: "";
   position: absolute;
-  right: 8px;
-  top: 2px;
-  width: 8px;
-  height: 8px;
-  background: #2f2f2f;
+  right: 10px;
+  top: 4px;
+  width: 10px;
+  height: 10px;
+  background: #2c364f;
   border-radius: 50%;
 }
 
 .kamera-modul {
   position: absolute;
-  top: 24px;
-  left: 24px;
-  width: 80px;
-  height: 110px;
-  background: #0f0f0f;
-  border-radius: 18px;
+  top: 28px;
+  left: 28px;
+  width: 92px;
+  height: 130px;
+  background: rgba(10, 15, 30, 0.9);
+  border-radius: 22px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 12px;
-  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.6);
+  gap: 10px;
+  padding: 14px;
+  box-shadow: inset 0 0 24px rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .kamera-modul .lens {
-  width: 46px;
-  height: 46px;
+  width: 52px;
+  height: 52px;
   border-radius: 50%;
-  background: radial-gradient(circle, #3a3a3a, #0b0b0b);
-  border: 2px solid #1a1a1a;
+  background: radial-gradient(circle, #4f5d82, #0b0f1a);
+  border: 2px solid #1b2438;
 }
 
 .kamera-modul .flash {
@@ -286,38 +289,38 @@ nav button {
 
 .telefon-arka .logo {
   position: absolute;
-  bottom: 40px;
+  bottom: 46px;
   left: 50%;
   transform: translateX(-50%);
-  font-size: 28px;
-  letter-spacing: 2px;
-  color: rgba(255, 255, 255, 0.4);
+  font-size: 24px;
+  letter-spacing: 4px;
+  color: rgba(255, 255, 255, 0.5);
 }
 
 .acma-kapama {
   position: absolute;
-  right: -18px;
-  top: 120px;
-  width: 38px;
-  height: 60px;
-  border-radius: 18px;
-  border: 2px solid #2a2a2a;
-  background: #2d2d2d;
-  color: #f5f5f5;
+  right: -20px;
+  top: 140px;
+  width: 40px;
+  height: 68px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: linear-gradient(180deg, #2a3550, #101626);
+  color: #f1f5ff;
   cursor: pointer;
-  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.4);
-  transform: translateZ(20px);
+  box-shadow: 0 10px 16px rgba(0, 0, 0, 0.45);
+  transform: translateZ(22px);
 }
 
 .acma-kapama:active {
-  transform: translateZ(14px);
+  transform: translateZ(16px);
 }
 
 .telefon.is-off .ekran {
-  background: #050505;
+  background: #04060b;
   box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.9);
 }
 
 .telefon.is-off .ekran-icerik {
-  opacity: 0.1;
+  opacity: 0.08;
 }

--- a/style.css
+++ b/style.css
@@ -106,3 +106,218 @@ nav button {
   font-size: 24px;
   cursor: pointer;
 }
+
+.telefon-vitrini {
+  text-align: center;
+  padding: 30px 20px 10px;
+}
+
+.telefon-vitrini h2 {
+  margin-bottom: 10px;
+}
+
+.telefon-ipucu {
+  color: #b8b8b8;
+  margin-bottom: 20px;
+  font-size: 14px;
+}
+
+.telefon-sahne {
+  perspective: 1200px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 520px;
+}
+
+.telefon {
+  width: 220px;
+  height: 440px;
+  position: relative;
+  transform-style: preserve-3d;
+  transform: rotateX(-12deg) rotateY(20deg);
+  transition: transform 0.2s ease-out;
+}
+
+.telefon-yuz {
+  position: absolute;
+  background: linear-gradient(160deg, #151515, #252525);
+  border-radius: 28px;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.6);
+}
+
+.telefon-on,
+.telefon-arka {
+  width: 220px;
+  height: 440px;
+}
+
+.telefon-on {
+  transform: translateZ(15px);
+  background: #111;
+  border: 2px solid #2a2a2a;
+}
+
+.telefon-arka {
+  transform: rotateY(180deg) translateZ(15px);
+  background: linear-gradient(145deg, #1f1f1f, #2f2f2f);
+  border: 2px solid #141414;
+}
+
+.telefon-sol,
+.telefon-sag {
+  width: 30px;
+  height: 440px;
+  top: 0;
+  border-radius: 22px;
+  background: #1a1a1a;
+}
+
+.telefon-sol {
+  transform: rotateY(-90deg) translateZ(15px);
+  transform-origin: left;
+  left: -15px;
+}
+
+.telefon-sag {
+  transform: rotateY(90deg) translateZ(205px);
+  transform-origin: right;
+  right: -15px;
+}
+
+.telefon-ust,
+.telefon-alt {
+  width: 220px;
+  height: 30px;
+  left: 0;
+  background: #1a1a1a;
+  border-radius: 22px;
+}
+
+.telefon-ust {
+  transform: rotateX(90deg) translateZ(15px);
+  transform-origin: top;
+  top: -15px;
+}
+
+.telefon-alt {
+  transform: rotateX(-90deg) translateZ(425px);
+  transform-origin: bottom;
+  bottom: -15px;
+}
+
+.ekran {
+  position: absolute;
+  inset: 20px;
+  border-radius: 22px;
+  background: radial-gradient(circle at top, #1c1c1c 20%, #050505 80%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #2c2c2c;
+  transition: background 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.8);
+}
+
+.ekran-icerik {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: bold;
+  letter-spacing: 1px;
+  color: #e4e4e4;
+  opacity: 1;
+  transition: opacity 0.3s ease;
+}
+
+.kamera {
+  position: absolute;
+  top: 14px;
+  left: 50%;
+  width: 60px;
+  height: 12px;
+  background: #090909;
+  border-radius: 10px;
+  transform: translateX(-50%);
+}
+
+.kamera::before {
+  content: "";
+  position: absolute;
+  right: 8px;
+  top: 2px;
+  width: 8px;
+  height: 8px;
+  background: #2f2f2f;
+  border-radius: 50%;
+}
+
+.kamera-modul {
+  position: absolute;
+  top: 24px;
+  left: 24px;
+  width: 80px;
+  height: 110px;
+  background: #0f0f0f;
+  border-radius: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.6);
+}
+
+.kamera-modul .lens {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #3a3a3a, #0b0b0b);
+  border: 2px solid #1a1a1a;
+}
+
+.kamera-modul .flash {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #f5e7b2;
+  box-shadow: 0 0 12px rgba(255, 255, 200, 0.8);
+}
+
+.telefon-arka .logo {
+  position: absolute;
+  bottom: 40px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 28px;
+  letter-spacing: 2px;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.acma-kapama {
+  position: absolute;
+  right: -18px;
+  top: 120px;
+  width: 38px;
+  height: 60px;
+  border-radius: 18px;
+  border: 2px solid #2a2a2a;
+  background: #2d2d2d;
+  color: #f5f5f5;
+  cursor: pointer;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.4);
+  transform: translateZ(20px);
+}
+
+.acma-kapama:active {
+  transform: translateZ(14px);
+}
+
+.telefon.is-off .ekran {
+  background: #050505;
+  box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.9);
+}
+
+.telefon.is-off .ekran-icerik {
+  opacity: 0.1;
+}


### PR DESCRIPTION
### Motivation
- Provide an interactive 3D phone demo on the main page so users can rotate the device with touch or mouse and toggle the screen with a power button.
- Improve visual engagement by adding a stylized phone model (front/back/sides, camera, screen content) that fits the app theme.

### Description
- Added a new `section` (#telefonVitrini) with the 3D phone markup and an accessible power button in `index.html`.
- Implemented detailed 3D styling for the phone, faces, camera module, screen and power button in `style.css` using CSS 3D transforms and transitions.
- Implemented `telefonModeliniBaslat()` in `script.js` to initialize mouse drag rotation, three-finger touch rotation (averaging up to 3 touch points), and a power toggle that adds/removes the `is-off` class and updates `aria-pressed`.
- Hooked the phone initialization into `window.onload` so the demo is active when the main UI is shown.

### Testing
- Served the site with `python -m http.server 4173` and ran a headless Playwright script to open `http://127.0.0.1:4173/`, reveal the main UI, scroll to the phone showcase and capture a screenshot `artifacts/telefon-vitrini.png`, which completed successfully.
- Verified static checks by loading the modified `index.html`, `style.css`, and `script.js` in the browser during the screenshot test (served responses returned `200`).
- No automated unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69711658f1fc832c83547bcb32fcce6f)