### PR TITLE
Focus homepage on full-screen 3D phone showcase

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,45 +7,38 @@
 </head>
 <body>
 
-  <!-- Kayıt Ekranı -->
-  <div id="girisEkrani">
-    <h2>MemTube'e Giriş</h2>
-    <input type="text" id="kullaniciAdi" placeholder="Takma Ad (zorunlu)">
-    <input type="file" id="profilResmi" accept="image/*">
-    <button onclick="girisYap()">Giriş Yap</button>
-  </div>
-
-  <!-- Ana Ekran -->
-  <div id="anaEkran" class="gizli">
-    <header>
-      <h1>📺 MemTube</h1>
-      <input type="text" id="arama" placeholder="Ara...">
-    </header>
-
-    <!-- Ana Sayfa -->
-    <main id="anaSayfa">
-      <div id="videoListe" class="video-galeri"></div>
-    </main>
-
-    <!-- Hesabım Sayfası -->
-    <section id="hesabim" class="gizli">
-      <div id="profil">
-        <img id="profilGorsel" alt="Profil Resmi">
-        <h3 id="kAdi"></h3>
+  <main class="telefon-vitrini tam-ekran">
+    <h1>Yeni Nesil Telefon</h1>
+    <p class="telefon-ipucu">Üç parmakla kaydırarak telefonu çevir, yanındaki güç butonuna tıklayarak ekranı aç/kapat.</p>
+    <div class="telefon-sahne" id="telefonSahne">
+      <div class="telefon" id="telefonModel" aria-live="polite">
+        <div class="telefon-yuz telefon-on">
+          <div class="kamera"></div>
+          <div class="ekran">
+            <div class="ekran-icerik">
+              <span>Yeni Nesil</span>
+              <span>Akıllı Telefon</span>
+            </div>
+          </div>
+        </div>
+        <div class="telefon-yuz telefon-arka">
+          <div class="kamera-modul">
+            <div class="lens"></div>
+            <div class="lens"></div>
+            <div class="flash"></div>
+          </div>
+          <div class="logo">NX</div>
+        </div>
+        <div class="telefon-yuz telefon-sol"></div>
+        <div class="telefon-yuz telefon-sag"></div>
+        <div class="telefon-yuz telefon-ust"></div>
+        <div class="telefon-yuz telefon-alt"></div>
+        <button class="acma-kapama" id="gucButonu" type="button" aria-pressed="false">
+          ⏻
+        </button>
       </div>
-      <h4>Videolarım</h4>
-      <input type="file" id="videoDosyasi" accept="video/*">
-      <input type="text" id="videoBaslik" placeholder="Video Başlığı">
-      <button onclick="videoYukle()">+ Yükle</button>
-      <div id="videolar" class="video-galeri"></div>
-    </section>
-
-    <!-- Alt Menü -->
-    <nav id="altMenu">
-      <button onclick="goAnaSayfa()">🏠</button>
-      <button onclick="goHesabim()">👤</button>
-    </nav>
-  </div>
+    </div>
+  </main>
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -1,15 +1,118 @@
 window.onload = () => {
-  const k = localStorage.getItem("kullaniciAdi");
-  const p = localStorage.getItem("profilResmi");
+  const girisEkrani = document.getElementById("girisEkrani");
+  const anaEkran = document.getElementById("anaEkran");
+  const kullaniciAdi = document.getElementById("kAdi");
+  const profilGorsel = document.getElementById("profilGorsel");
 
-  if (k && p) {
-    document.getElementById("girisEkrani").style.display = "none";
-    document.getElementById("anaEkran").classList.remove("gizli");
-    document.getElementById("kAdi").innerText = k;
-    document.getElementById("profilGorsel").src = p;
-    videolariYukle();
+  if (girisEkrani && anaEkran && kullaniciAdi && profilGorsel) {
+    const k = localStorage.getItem("kullaniciAdi");
+    const p = localStorage.getItem("profilResmi");
+
+    if (k && p) {
+      girisEkrani.style.display = "none";
+      anaEkran.classList.remove("gizli");
+      kullaniciAdi.innerText = k;
+      profilGorsel.src = p;
+      videolariYukle();
+    }
   }
+
+  telefonModeliniBaslat();
 };
+
+function telefonModeliniBaslat() {
+  const telefon = document.getElementById("telefonModel");
+  const sahne = document.getElementById("telefonSahne");
+  const gucButonu = document.getElementById("gucButonu");
+
+  if (!telefon || !sahne || !gucButonu) {
+    return;
+  }
+
+  let rotX = -12;
+  let rotY = 20;
+  let surukleniyor = false;
+  let baslangic = { x: 0, y: 0 };
+
+  const uygulaTransform = () => {
+    telefon.style.transform = `rotateX(${rotX}deg) rotateY(${rotY}deg)`;
+  };
+
+  const koordinatOrtalama = (dokunuslar) => {
+    const kullanilan = Math.min(dokunuslar.length, 3);
+    let toplamX = 0;
+    let toplamY = 0;
+    for (let i = 0; i < kullanilan; i += 1) {
+      toplamX += dokunuslar[i].clientX;
+      toplamY += dokunuslar[i].clientY;
+    }
+    return {
+      x: toplamX / kullanilan,
+      y: toplamY / kullanilan,
+    };
+  };
+
+  sahne.addEventListener("mousedown", (event) => {
+    surukleniyor = true;
+    baslangic = { x: event.clientX, y: event.clientY };
+  });
+
+  window.addEventListener("mousemove", (event) => {
+    if (!surukleniyor) {
+      return;
+    }
+    const deltaX = event.clientX - baslangic.x;
+    const deltaY = event.clientY - baslangic.y;
+    baslangic = { x: event.clientX, y: event.clientY };
+    rotY += deltaX * 0.4;
+    rotX -= deltaY * 0.4;
+    uygulaTransform();
+  });
+
+  window.addEventListener("mouseup", () => {
+    surukleniyor = false;
+  });
+
+  sahne.addEventListener(
+    "touchstart",
+    (event) => {
+      if (event.touches.length < 3) {
+        surukleniyor = false;
+        return;
+      }
+      surukleniyor = true;
+      baslangic = koordinatOrtalama(event.touches);
+    },
+    { passive: true }
+  );
+
+  sahne.addEventListener(
+    "touchmove",
+    (event) => {
+      if (!surukleniyor || event.touches.length < 3) {
+        return;
+      }
+      event.preventDefault();
+      const merkez = koordinatOrtalama(event.touches);
+      const deltaX = merkez.x - baslangic.x;
+      const deltaY = merkez.y - baslangic.y;
+      baslangic = merkez;
+      rotY += deltaX * 0.4;
+      rotX -= deltaY * 0.4;
+      uygulaTransform();
+    },
+    { passive: false }
+  );
+
+  sahne.addEventListener("touchend", () => {
+    surukleniyor = false;
+  });
+
+  gucButonu.addEventListener("click", () => {
+    const kapali = telefon.classList.toggle("is-off");
+    gucButonu.setAttribute("aria-pressed", String(kapali));
+  });
+}
 
 function girisYap() {
   const k = document.getElementById("kullaniciAdi").value.trim();

--- a/style.css
+++ b/style.css
@@ -156,6 +156,7 @@ nav button {
   background: linear-gradient(160deg, #141b2d, #0b0f1a);
   border-radius: 34px;
   box-shadow: 0 30px 60px rgba(0, 0, 0, 0.7);
+  pointer-events: none;
 }
 
 .telefon-on,
@@ -321,6 +322,7 @@ nav button {
   cursor: pointer;
   box-shadow: 0 10px 16px rgba(0, 0, 0, 0.45);
   transform: translateZ(22px);
+  z-index: 3;
 }
 
 .acma-kapama:active {

--- a/style.css
+++ b/style.css
@@ -106,3 +106,232 @@ nav button {
   font-size: 24px;
   cursor: pointer;
 }
+
+.telefon-vitrini {
+  text-align: center;
+  padding: 30px 20px 10px;
+}
+
+.telefon-vitrini.tam-ekran {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.telefon-vitrini h1 {
+  margin-bottom: 12px;
+}
+
+.telefon-vitrini h2 {
+  margin-bottom: 10px;
+}
+
+.telefon-ipucu {
+  color: #b8b8b8;
+  margin-bottom: 20px;
+  font-size: 14px;
+}
+
+.telefon-sahne {
+  perspective: 1200px;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 520px;
+}
+
+.telefon {
+  width: 240px;
+  height: 480px;
+  position: relative;
+  transform-style: preserve-3d;
+  transform: rotateX(-12deg) rotateY(20deg);
+  transition: transform 0.2s ease-out;
+}
+
+.telefon-yuz {
+  position: absolute;
+  background: linear-gradient(160deg, #141b2d, #0b0f1a);
+  border-radius: 34px;
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.7);
+}
+
+.telefon-on,
+.telefon-arka {
+  width: 240px;
+  height: 480px;
+}
+
+.telefon-on {
+  transform: translateZ(16px);
+  background: #0a0f1a;
+  border: 2px solid #1f2a3f;
+}
+
+.telefon-arka {
+  transform: rotateY(180deg) translateZ(16px);
+  background: linear-gradient(145deg, #0f1526, #1b2440);
+  border: 2px solid #0b1120;
+}
+
+.telefon-sol,
+.telefon-sag {
+  width: 32px;
+  height: 480px;
+  top: 0;
+  border-radius: 28px;
+  background: #111827;
+}
+
+.telefon-sol {
+  transform: rotateY(-90deg) translateZ(16px);
+  transform-origin: left;
+  left: -16px;
+}
+
+.telefon-sag {
+  transform: rotateY(90deg) translateZ(224px);
+  transform-origin: right;
+  right: -16px;
+}
+
+.telefon-ust,
+.telefon-alt {
+  width: 240px;
+  height: 32px;
+  left: 0;
+  background: #111827;
+  border-radius: 28px;
+}
+
+.telefon-ust {
+  transform: rotateX(90deg) translateZ(16px);
+  transform-origin: top;
+  top: -16px;
+}
+
+.telefon-alt {
+  transform: rotateX(-90deg) translateZ(464px);
+  transform-origin: bottom;
+  bottom: -16px;
+}
+
+.ekran {
+  position: absolute;
+  inset: 14px;
+  border-radius: 28px;
+  background: radial-gradient(circle at top, #1d2a48 10%, #05070c 75%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  transition: background 0.3s ease, box-shadow 0.3s ease, opacity 0.3s ease;
+  box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.7);
+  overflow: hidden;
+}
+
+.ekran-icerik {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-weight: 600;
+  letter-spacing: 1px;
+  color: #e6f0ff;
+  opacity: 1;
+  transition: opacity 0.3s ease;
+}
+
+.kamera {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  width: 90px;
+  height: 18px;
+  background: linear-gradient(90deg, #0b0f1a, #1b2334);
+  border-radius: 14px;
+  transform: translateX(-50%);
+  box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.8);
+}
+
+.kamera::before {
+  content: "";
+  position: absolute;
+  right: 10px;
+  top: 4px;
+  width: 10px;
+  height: 10px;
+  background: #2c364f;
+  border-radius: 50%;
+}
+
+.kamera-modul {
+  position: absolute;
+  top: 28px;
+  left: 28px;
+  width: 92px;
+  height: 130px;
+  background: rgba(10, 15, 30, 0.9);
+  border-radius: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  box-shadow: inset 0 0 24px rgba(0, 0, 0, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.kamera-modul .lens {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  background: radial-gradient(circle, #4f5d82, #0b0f1a);
+  border: 2px solid #1b2438;
+}
+
+.kamera-modul .flash {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #f5e7b2;
+  box-shadow: 0 0 12px rgba(255, 255, 200, 0.8);
+}
+
+.telefon-arka .logo {
+  position: absolute;
+  bottom: 46px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 24px;
+  letter-spacing: 4px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.acma-kapama {
+  position: absolute;
+  right: -20px;
+  top: 140px;
+  width: 40px;
+  height: 68px;
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: linear-gradient(180deg, #2a3550, #101626);
+  color: #f1f5ff;
+  cursor: pointer;
+  box-shadow: 0 10px 16px rgba(0, 0, 0, 0.45);
+  transform: translateZ(22px);
+}
+
+.acma-kapama:active {
+  transform: translateZ(16px);
+}
+
+.telefon.is-off .ekran {
+  background: #04060b;
+  box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.9);
+}
+
+.telefon.is-off .ekran-icerik {
+  opacity: 0.08;
+}


### PR DESCRIPTION
### Motivation
- The homepage previously included the MemTube login/feeds UI but the goal is a dedicated 3D phone showcase, so the page was simplified to surface the phone demo directly. 
- Initialization now needs to be defensive because app-specific elements may be absent after removing the app layout.

### Description
- Replaced the previous MemTube layout (login, main feed, account sections, bottom nav) in `index.html` with a focused full-screen phone showcase (`<main class="telefon-vitrini tam-ekran">`).
- Added/adjusted layout and visual rules in `style.css`, including `.telefon-vitrini.tam-ekran` centering and the existing phone/scene styles to support the full-screen presentation.
- Implemented `telefonModeliniBaslat()` in `script.js` and moved phone interaction logic into it, adding guards that bail out when the phone scene elements are not present.
- Kept interactive controls: mouse drag rotation, three-finger touch rotation (averaging up to 3 touches), and a power toggle that toggles the `is-off` class and updates `aria-pressed` on `#gucButonu`.

### Testing
- Served the site with `python -m http.server 4173` and confirmed the server responded to asset requests (`/`, `/style.css`, `/script.js`) with `200` responses during the run; this completed successfully.
- Ran a headless Playwright script that opened `http://127.0.0.1:4173/` and captured a screenshot at `artifacts/telefon-vitrini-tam-ekran.png`, which succeeded.
- No automated unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69711658f1fc832c83547bcb32fcce6f)