### PR TITLE
Redesign app into WhatsApp-style NPC chat with knowledge-base responses

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,49 +2,52 @@
 <html lang="tr">
 <head>
   <meta charset="UTF-8">
-  <title>MemTube</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WhatsApp Nova</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
-  <!-- Kayıt Ekranı -->
-  <div id="girisEkrani">
-    <h2>MemTube'e Giriş</h2>
-    <input type="text" id="kullaniciAdi" placeholder="Takma Ad (zorunlu)">
-    <input type="file" id="profilResmi" accept="image/*">
-    <button onclick="girisYap()">Giriş Yap</button>
-  </div>
-
-  <!-- Ana Ekran -->
-  <div id="anaEkran" class="gizli">
-    <header>
-      <h1>📺 MemTube</h1>
-      <input type="text" id="arama" placeholder="Ara...">
-    </header>
-
-    <!-- Ana Sayfa -->
-    <main id="anaSayfa">
-      <div id="videoListe" class="video-galeri"></div>
-    </main>
-
-    <!-- Hesabım Sayfası -->
-    <section id="hesabim" class="gizli">
-      <div id="profil">
-        <img id="profilGorsel" alt="Profil Resmi">
-        <h3 id="kAdi"></h3>
+  <div class="app">
+    <aside class="sidebar">
+      <div class="sidebar-header">
+        <div class="profile">
+          <div class="avatar">🟢</div>
+          <div>
+            <p class="title">WhatsApp Nova</p>
+            <p class="subtitle">Sonsuz bilgi hattı</p>
+          </div>
+        </div>
+        <button class="new-chat" id="yeniSohbet">+ Yeni Sohbet</button>
       </div>
-      <h4>Videolarım</h4>
-      <input type="file" id="videoDosyasi" accept="video/*">
-      <input type="text" id="videoBaslik" placeholder="Video Başlığı">
-      <button onclick="videoYukle()">+ Yükle</button>
-      <div id="videolar" class="video-galeri"></div>
-    </section>
 
-    <!-- Alt Menü -->
-    <nav id="altMenu">
-      <button onclick="goAnaSayfa()">🏠</button>
-      <button onclick="goHesabim()">👤</button>
-    </nav>
+      <div class="search">
+        <input type="text" id="sohbetAra" placeholder="Sohbet ara">
+      </div>
+
+      <div class="chat-list" id="sohbetListesi"></div>
+    </aside>
+
+    <main class="chat">
+      <header class="chat-header">
+        <div>
+          <h1>Evrensel Bilge NPC</h1>
+          <p>Her şeyi bilen rehber</p>
+        </div>
+        <div class="status">
+          <span class="dot"></span>
+          Çevrimiçi
+        </div>
+      </header>
+
+      <section class="chat-body" id="mesajAlani"></section>
+
+      <section class="suggestions" id="oneriler"></section>
+
+      <footer class="chat-input">
+        <input type="text" id="mesajInput" placeholder="Bir şey sor, evrenin cevabı burada...">
+        <button id="gonderBtn">Gönder</button>
+      </footer>
+    </main>
   </div>
 
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,97 +1,221 @@
-window.onload = () => {
-  const k = localStorage.getItem("kullaniciAdi");
-  const p = localStorage.getItem("profilResmi");
+const sohbetListesi = document.getElementById("sohbetListesi");
+const mesajAlani = document.getElementById("mesajAlani");
+const mesajInput = document.getElementById("mesajInput");
+const gonderBtn = document.getElementById("gonderBtn");
+const oneriler = document.getElementById("oneriler");
+const sohbetAra = document.getElementById("sohbetAra");
+const yeniSohbet = document.getElementById("yeniSohbet");
 
-  if (k && p) {
-    document.getElementById("girisEkrani").style.display = "none";
-    document.getElementById("anaEkran").classList.remove("gizli");
-    document.getElementById("kAdi").innerText = k;
-    document.getElementById("profilGorsel").src = p;
-    videolariYukle();
+const quickPrompts = [
+  "Mars'a taşınmak mümkün mü?",
+  "Türk kahvesi nasıl yapılır?",
+  "Bugün motivasyon ver.",
+  "Bir iş fikri öner.",
+  "Rüyalar neden görülür?",
+  "Yapay zeka geleceği nasıl etkileyecek?"
+];
+
+const knowledgeBase = [
+  {
+    keywords: ["evren", "galaksi", "yıldız", "uzay", "mars"],
+    answer: "Evren 13,8 milyar yıllık bir hikâye. Mars, ince atmosferi ve su izi sayesinde araştırma üssü için ideal aday. Enerji, yaşam destek sistemleri ve radyasyon kalkanı ana ihtiyaçlar."
+  },
+  {
+    keywords: ["tarih", "osmanlı", "roma", "antik"],
+    answer: "Tarih döngüler ve dönüşümlerle ilerler. Osmanlı 600 yıl boyunca çok kültürlü bir imparatorluktu; Roma ise hukuk ve şehircilik temeli attı."
+  },
+  {
+    keywords: ["kahve", "demleme", "türk", "espresso"],
+    answer: "Türk kahvesi için ince öğütülmüş kahve, soğuk su ve isteğe bağlı şekerle kısık ateşte köpük alın. İlk köpüğü fincana, kalanını taşırmadan pişir."
+  },
+  {
+    keywords: ["motivasyon", "ilham", "enerji"],
+    answer: "Motivasyon, küçük kazanımların bileşik etkisidir. Bugün tek bir küçük adım at ve onu tamamlamak için kendine 20 dakika ver."
+  },
+  {
+    keywords: ["iş", "girişim", "fikir", "start"],
+    answer: "Yerel hizmetleri dijitalleştiren mikro-platformlar yükselişte. Mahallende tek bir ihtiyacı seç, hızlı hizmet + şeffaf fiyatla prototip çıkar."
+  },
+  {
+    keywords: ["yapay", "zeka", "ai", "otomasyon"],
+    answer: "Yapay zeka tekrarlı işleri devralırken, insan odağı tasarım, strateji ve etik yönetişim daha değerli olacak. Öğrenme hızın en büyük avantajın."
+  },
+  {
+    keywords: ["rüya", "uyku", "bilinç"],
+    answer: "Rüyalar, beynin duyguları işlemesi ve hafızayı düzenlemesiyle ilişkilidir. REM uykusu sırasında öğrenilen bilgiler pekişir."
+  },
+  {
+    keywords: ["sağlık", "beslenme", "spor", "fitness"],
+    answer: "Dengeli beslenme için tabakta protein, lif ve sağlıklı yağ dengesini hedefle. Haftada 150 dakika orta tempolu hareket önerilir."
+  },
+  {
+    keywords: ["müzik", "sanat", "yaratıcılık"],
+    answer: "Yaratıcılık, farklı alanlardan bilgi harmanlamaktır. Yeni bir tür denemek, beynin yeni bağlantılar kurmasına yardımcı olur."
+  },
+  {
+    keywords: ["hava", "iklim", "çevre"],
+    answer: "İklim krizinin ana tetikleyicisi sera gazlarıdır. Enerji verimliliği, yenilenebilir kaynaklar ve bireysel tüketim değişimi kritik rol oynar."
   }
-};
+];
 
-function girisYap() {
-  const k = document.getElementById("kullaniciAdi").value.trim();
-  const p = document.getElementById("profilResmi").files[0];
+const sohbetler = [
+  { isim: "Evrensel Bilge", sonMesaj: "Her şeyi sorabilirsin.", saat: "Şimdi" },
+  { isim: "Astro Arşiv", sonMesaj: "Mars kolonisi planı hazır.", saat: "09:24" },
+  { isim: "İdeaLab", sonMesaj: "3 yeni iş fikri var.", saat: "Dün" }
+];
 
-  if (!k || !p) {
-    alert("Ad ve profil resmi gerekli kaptan!");
-    return;
-  }
+const hafiza = JSON.parse(localStorage.getItem("novaMesajlar")) || [
+  { role: "npc", text: "Merhaba! Ben Evrensel Bilge. Bana her şeyi sorabilirsin.", time: new Date().toLocaleTimeString("tr-TR", { hour: "2-digit", minute: "2-digit" }) }
+];
 
-  const reader = new FileReader();
-  reader.onload = () => {
-    localStorage.setItem("kullaniciAdi", k);
-    localStorage.setItem("profilResmi", reader.result);
-    location.reload();
-  };
-  reader.readAsDataURL(p);
-}
-
-function goAnaSayfa() {
-  document.getElementById("hesabim").classList.add("gizli");
-  document.getElementById("anaSayfa").style.display = "block";
-}
-
-function goHesabim() {
-  document.getElementById("anaSayfa").style.display = "none";
-  document.getElementById("hesabim").classList.remove("gizli");
-}
-
-function videoYukle() {
-  const dosya = document.getElementById("videoDosyasi").files[0];
-  const baslik = document.getElementById("videoBaslik").value;
-  const kullanici = localStorage.getItem("kullaniciAdi");
-
-  if (!dosya || !baslik) {
-    alert("Video ve başlık eksik!");
-    return;
-  }
-
-  const videoURL = URL.createObjectURL(dosya);
-  const video = { baslik: baslik, url: videoURL, sahip: kullanici };
-
-  const mevcut = JSON.parse(localStorage.getItem("videolar") || "[]");
-  mevcut.push(video);
-  localStorage.setItem("videolar", JSON.stringify(mevcut));
-  videolariYukle();
-
-  document.getElementById("videoDosyasi").value = "";
-  document.getElementById("videoBaslik").value = "";
-}
-
-function videolariYukle() {
-  const videolar = JSON.parse(localStorage.getItem("videolar") || "[]");
-  const liste = document.getElementById("videoListe");
-  const hesap = document.getElementById("videolar");
-  const kullanici = localStorage.getItem("kullaniciAdi");
-
-  liste.innerHTML = "";
-  hesap.innerHTML = "";
-
-  videolar.forEach((v, i) => {
-    const div = document.createElement("div");
-    div.className = "video";
-    div.innerHTML = `
-      <video src="${v.url}" controls></video>
-      <p>${v.baslik}</p>
+function sohbetleriCiz() {
+  sohbetListesi.innerHTML = "";
+  sohbetler.forEach((sohbet) => {
+    const card = document.createElement("div");
+    card.className = "chat-card";
+    card.innerHTML = `
+      <div>
+        <strong>${sohbet.isim}</strong>
+        <span>${sohbet.sonMesaj}</span>
+      </div>
+      <span>${sohbet.saat}</span>
     `;
-    // Ana sayfaya herkesin videoları
-    liste.appendChild(div.cloneNode(true));
-
-    // Sadece kendi videolarına silme butonu
-    if (v.sahip === kullanici) {
-      const divHesap = div.cloneNode(true);
-      const silBtn = document.createElement("button");
-      silBtn.innerText = "❌";
-      silBtn.onclick = () => {
-        videolar.splice(i, 1);
-        localStorage.setItem("videolar", JSON.stringify(videolar));
-        videolariYukle();
-      };
-      divHesap.appendChild(silBtn);
-      hesap.appendChild(divHesap);
-    }
+    sohbetListesi.appendChild(card);
   });
 }
+
+function mesajEkle(role, text) {
+  const time = new Date().toLocaleTimeString("tr-TR", { hour: "2-digit", minute: "2-digit" });
+  const mesaj = { role, text, time };
+  hafiza.push(mesaj);
+  localStorage.setItem("novaMesajlar", JSON.stringify(hafiza));
+
+  const bubble = document.createElement("div");
+  bubble.className = `message ${role}`;
+  bubble.innerHTML = `${text}<small>${time}</small>`;
+  mesajAlani.appendChild(bubble);
+  mesajAlani.scrollTop = mesajAlani.scrollHeight;
+}
+
+function renderMesajlar() {
+  mesajAlani.innerHTML = "";
+  hafiza.forEach((mesaj) => {
+    const bubble = document.createElement("div");
+    bubble.className = `message ${mesaj.role}`;
+    bubble.innerHTML = `${mesaj.text}<small>${mesaj.time}</small>`;
+    mesajAlani.appendChild(bubble);
+  });
+  mesajAlani.scrollTop = mesajAlani.scrollHeight;
+}
+
+function onerileriCiz() {
+  oneriler.innerHTML = "";
+  quickPrompts.forEach((prompt) => {
+    const button = document.createElement("button");
+    button.className = "suggestion-btn";
+    button.textContent = prompt;
+    button.addEventListener("click", () => {
+      mesajInput.value = prompt;
+      mesajGonder();
+    });
+    oneriler.appendChild(button);
+  });
+}
+
+function analizEt(metin) {
+  const temiz = metin.toLowerCase().replace(/[.,!?]/g, "");
+  const kelimeler = temiz.split(/\s+/).filter(Boolean);
+  return { temiz, kelimeler };
+}
+
+function bilgiBul(metin) {
+  const { kelimeler } = analizEt(metin);
+  let enYuksek = { skor: 0, cevap: null };
+
+  knowledgeBase.forEach((kayit) => {
+    const skor = kayit.keywords.reduce((acc, anahtar) => acc + (kelimeler.includes(anahtar) ? 1 : 0), 0);
+    if (skor > enYuksek.skor) {
+      enYuksek = { skor, cevap: kayit.answer };
+    }
+  });
+
+  return enYuksek.skor > 0 ? enYuksek.cevap : null;
+}
+
+function evrenselCevap(metin) {
+  const { temiz } = analizEt(metin);
+  const genel = [
+    "Konuya sistematik bakalım:",
+    "Bu başlık için üç katmanlı bir cevap vereyim:",
+    "Bunu en net şekilde özetleyeyim:"
+  ];
+
+  const derinlik = [
+    "1) Temel gerçek: Konunun çekirdeğini sadeleştir.",
+    "2) Bağlam: Etkileyen faktörleri ve bağlantıları düşün.",
+    "3) Eylem: Bugün uygulayabileceğin küçük bir adım seç."
+  ];
+
+  const kapanis = [
+    "İstersen hedefini netleştirelim, sana özel bir yol haritası çıkarırım.",
+    "Daha spesifik bir detay verirsen cevabı mikro düzeye indiririm.",
+    "Hangi açıdan derine inmeyi istersin?"
+  ];
+
+  return `${genel[Math.floor(Math.random() * genel.length)]}<br>${derinlik.join("<br>")}<br><br>"${temiz}" için gerekli tüm bağlantıları kurabilirim. ${kapanis[Math.floor(Math.random() * kapanis.length)]}`;
+}
+
+function generateNpcResponse(metin) {
+  const selamlar = ["selam", "merhaba", "hi", "hey", "günaydın", "iyi akşamlar"];
+  if (selamlar.some((selam) => metin.toLowerCase().includes(selam))) {
+    return "Selam! Ben Evrensel Bilge. Dilediğin konuyu aç, tüm yanıtları birleştirip sana net bir yol çıkarayım.";
+  }
+
+  const bilgi = bilgiBul(metin);
+  if (bilgi) {
+    return `${bilgi}<br><br>İstersen bu konuyu örneklerle de derinleştirebilirim.`;
+  }
+
+  return evrenselCevap(metin);
+}
+
+function mesajGonder() {
+  const mesaj = mesajInput.value.trim();
+  if (!mesaj) return;
+
+  mesajEkle("user", mesaj);
+  mesajInput.value = "";
+
+  setTimeout(() => {
+    const cevap = generateNpcResponse(mesaj);
+    mesajEkle("npc", cevap);
+  }, 600);
+}
+
+function sohbetAraIslemi() {
+  const arama = sohbetAra.value.toLowerCase();
+  const kartlar = Array.from(sohbetListesi.children);
+  kartlar.forEach((kart) => {
+    const isim = kart.querySelector("strong").textContent.toLowerCase();
+    kart.style.display = isim.includes(arama) ? "flex" : "none";
+  });
+}
+
+function yeniSohbetAc() {
+  localStorage.removeItem("novaMesajlar");
+  location.reload();
+}
+
+sohbetleriCiz();
+renderMesajlar();
+onerileriCiz();
+
+mesajInput.addEventListener("keydown", (event) => {
+  if (event.key === "Enter") {
+    mesajGonder();
+  }
+});
+
+gonderBtn.addEventListener("click", mesajGonder);
+sohbetAra.addEventListener("input", sohbetAraIslemi);
+yeniSohbet.addEventListener("click", yeniSohbetAc);

--- a/style.css
+++ b/style.css
@@ -1,108 +1,253 @@
-body {
+:root {
+  font-family: "Segoe UI", sans-serif;
+  color: #102a2a;
+  background: #0b141a;
+}
+
+* {
+  box-sizing: border-box;
   margin: 0;
-  font-family: Arial, sans-serif;
-  background-color: #0d0d0d;
-  color: white;
+  padding: 0;
 }
 
-.gizli {
-  display: none;
-}
-
-#girisEkrani {
-  text-align: center;
-  padding: 40px;
-}
-
-#girisEkrani input, #girisEkrani button {
-  display: block;
-  margin: 10px auto;
-  padding: 10px;
-  width: 80%;
-}
-
-header {
-  background-color: #1a1a1a;
-  padding: 10px;
+body {
+  height: 100vh;
   display: flex;
-  justify-content: space-between;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #0b141a 0%, #0f2b30 100%);
+}
+
+.app {
+  width: min(1100px, 95vw);
+  height: min(760px, 95vh);
+  background: #0b141a;
+  border-radius: 24px;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: 320px 1fr;
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.sidebar {
+  background: #101b22;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.sidebar-header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.profile {
+  display: flex;
+  gap: 12px;
   align-items: center;
 }
 
-#arama {
-  padding: 8px;
-  border-radius: 5px;
-  border: none;
+.avatar {
+  width: 46px;
+  height: 46px;
+  border-radius: 50%;
+  background: #25d366;
+  display: grid;
+  place-items: center;
+  font-size: 22px;
 }
 
-.video-galeri {
+.title {
+  color: #d4f7e1;
+  font-weight: 600;
+  font-size: 18px;
+}
+
+.subtitle {
+  color: #7fa7a3;
+  font-size: 13px;
+}
+
+.new-chat {
+  background: #1f2c34;
+  color: #c9e7e5;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 10px;
+  cursor: pointer;
+}
+
+.search input {
+  width: 100%;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: none;
+  background: #1b2a31;
+  color: #c9e7e5;
+}
+
+.chat-list {
+  flex: 1;
+  display: grid;
+  gap: 12px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.chat-card {
+  background: #152026;
+  border-radius: 16px;
+  padding: 14px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.chat-card strong {
+  color: #e2f7f5;
+  font-size: 15px;
+}
+
+.chat-card span {
+  font-size: 12px;
+  color: #7fa7a3;
+}
+
+.chat {
+  display: flex;
+  flex-direction: column;
+  background: #0b141a;
+}
+
+.chat-header {
+  padding: 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(16, 27, 34, 0.9);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.chat-header h1 {
+  font-size: 20px;
+  color: #d4f7e1;
+}
+
+.chat-header p {
+  font-size: 13px;
+  color: #7fa7a3;
+}
+
+.status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #9fd6c1;
+  font-size: 13px;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #25d366;
+  box-shadow: 0 0 10px #25d366;
+}
+
+.chat-body {
+  flex: 1;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
+  background: url('https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1200&q=80') center/cover;
+}
+
+.message {
+  max-width: 70%;
+  padding: 14px 16px;
+  border-radius: 18px;
+  line-height: 1.5;
+  font-size: 14px;
+  backdrop-filter: blur(8px);
+}
+
+.message.user {
+  align-self: flex-end;
+  background: rgba(37, 211, 102, 0.2);
+  border: 1px solid rgba(37, 211, 102, 0.4);
+  color: #dfffee;
+}
+
+.message.npc {
+  align-self: flex-start;
+  background: rgba(15, 43, 48, 0.75);
+  border: 1px solid rgba(127, 167, 163, 0.35);
+  color: #e1f3f1;
+}
+
+.message small {
+  display: block;
+  margin-top: 8px;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 11px;
+}
+
+.suggestions {
   display: flex;
   flex-wrap: wrap;
-  gap: 15px;
-  justify-content: center;
-  padding: 20px;
+  gap: 10px;
+  padding: 12px 24px 0;
 }
 
-.video {
-  background: #1a1a1a;
-  padding: 10px;
-  border-radius: 10px;
-  width: 200px;
-  text-align: center;
-  position: relative;
-}
-
-.video video {
-  width: 100%;
-  border-radius: 5px;
-}
-
-.video button {
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  background: red;
-  color: white;
-  border: none;
-  border-radius: 50%;
-  padding: 5px;
+.suggestion-btn {
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(16, 27, 34, 0.9);
+  color: #c9e7e5;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 12px;
   cursor: pointer;
 }
 
-#profil {
-  text-align: center;
-  margin-top: 20px;
-}
-
-#profil img {
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  object-fit: cover;
-  background-color: white;
-}
-
-#videoDosyasi, #videoBaslik {
-  display: block;
-  margin: 10px auto;
-  padding: 8px;
-  width: 80%;
-}
-
-nav#altMenu {
-  position: fixed;
-  bottom: 0;
-  width: 100%;
-  background: #111;
+.chat-input {
   display: flex;
-  justify-content: space-around;
-  padding: 10px 0;
+  gap: 12px;
+  padding: 16px 24px 24px;
+  background: rgba(16, 27, 34, 0.9);
 }
 
-nav button {
-  background: none;
+.chat-input input {
+  flex: 1;
+  padding: 12px 16px;
+  border-radius: 16px;
   border: none;
-  color: white;
-  font-size: 24px;
+  background: #1b2a31;
+  color: #e1f3f1;
+}
+
+.chat-input button {
+  background: #25d366;
+  color: #0b141a;
+  border: none;
+  border-radius: 16px;
+  padding: 12px 20px;
+  font-weight: 600;
   cursor: pointer;
+}
+
+@media (max-width: 900px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    display: none;
+  }
 }


### PR DESCRIPTION
### Motivation
- Replace the previous MemTube/video-sharing UI with a messaging-focused interface so users can interact with an omniscient NPC instead of limited conditional replies.
- Provide an on-device response generator (knowledge base + analysis + fallback reasoning) and useful quick prompts to make NPC answers more informative and context-aware.

### Description
- Replace `index.html` with a WhatsApp-inspired layout featuring a sidebar chat list, chat header/status, chat body, suggestions area, and input/footer controls.
- Replace `script.js` with a client-side NPC engine that implements `quickPrompts`, a `knowledgeBase`, text analysis (`analizEt`), `bilgiBul` matching, fallback reasoning (`evrenselCevap`), `generateNpcResponse`, message rendering, and `localStorage`-backed conversation persistence (`novaMesajlar`).
- Overhaul `style.css` to a new dark chat theme with styled chat bubbles, sidebar, suggestion buttons, and responsive layout.
- Add UI features including search in the chat list, a "New Chat" action, and automatic scroll/rendering of stored messages.

### Testing
- Launched a static server with `python -m http.server 8000`, which started successfully and served the app.
- Attempted an automated Playwright screenshot run to validate the UI, but the Chromium process crashed with a SIGSEGV and the Playwright step failed.
- No unit tests were added; no further automated tests completed, so manual UI verification is recommended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978e6f2530c832ca0b394c55689acd1)