### PR TITLE
Create baluk.ai branded AI chat landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,14 +25,18 @@
   <div class="app">
     <header class="topbar">
       <div class="left-tools">
-        <button id="modelToggle" class="icon-btn" type="button" aria-label="Model seç">
+        <div class="model-chip-wrap">
+          <button id="modelToggle" class="icon-btn" type="button" aria-label="Model seç">
           <svg class="fish-logo small" viewBox="0 0 520 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
             <use href="#baluk-fish"></use>
           </svg>
         </button>
+          <span id="currentModelBadge" class="model-badge">baluk-1.0</span>
+        </div>
 
         <div id="modelMenu" class="model-menu hidden" role="menu" aria-label="Model seçenekleri">
           <button class="model-option active" type="button" data-model="baluk-1.0">baluk-1.0</button>
+          <button class="model-option" type="button" data-model="baluk-1.5">baluk-1.5</button>
         </div>
       </div>
 

--- a/index.html
+++ b/index.html
@@ -7,18 +7,27 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <svg width="0" height="0" class="logo-defs" aria-hidden="true" focusable="false">
+    <defs>
+      <symbol id="baluk-fish" viewBox="0 0 520 220">
+        <path d="M30 112C108 52 246 34 374 78C406 88 438 108 468 136" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
+        <path d="M30 112C108 182 244 198 392 160" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
+        <path d="M30 112C50 94 74 85 102 86" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
+        <circle cx="120" cy="110" r="7.5" fill="currentColor"/>
+        <path d="M164 79C178 96 179 126 161 145" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
+        <path d="M468 136L502 72L432 97" stroke="currentColor" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M468 136L502 167L489 121L502 72" stroke="currentColor" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M215 155C266 149 322 129 365 102" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
+      </symbol>
+    </defs>
+  </svg>
+
   <div class="app">
     <header class="topbar">
       <div class="left-tools">
         <button id="modelToggle" class="icon-btn" type="button" aria-label="Model seç">
           <svg class="fish-logo small" viewBox="0 0 520 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
-            <path d="M35 112C105 52 240 35 370 78C405 90 434 108 470 138" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
-            <path d="M35 112C110 182 245 202 390 160" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
-            <path d="M35 112C53 95 79 85 104 86" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
-            <circle cx="120" cy="110" r="7" fill="currentColor"/>
-            <path d="M165 80C175 95 177 127 162 145" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
-            <path d="M470 138L500 72L430 96L500 72L490 120L500 165L470 138Z" stroke="currentColor" stroke-width="10" stroke-linejoin="round"/>
-            <path d="M212 155C260 150 318 130 362 102" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
+            <use href="#baluk-fish"></use>
           </svg>
         </button>
 
@@ -36,13 +45,7 @@
       <section id="splash" class="splash" aria-label="Baluk.ai ana logo">
         <svg class="fish-logo big" viewBox="0 0 520 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
           <title>baluk.ai balık logosu</title>
-          <path d="M35 112C105 52 240 35 370 78C405 90 434 108 470 138" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
-          <path d="M35 112C110 182 245 202 390 160" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
-          <path d="M35 112C53 95 79 85 104 86" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
-          <circle cx="120" cy="110" r="7" fill="currentColor"/>
-          <path d="M165 80C175 95 177 127 162 145" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
-          <path d="M470 138L500 72L430 96L500 72L490 120L500 165L470 138Z" stroke="currentColor" stroke-width="10" stroke-linejoin="round"/>
-          <path d="M212 155C260 150 318 130 362 102" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
+          <use href="#baluk-fish"></use>
         </svg>
         <h1>baluk.ai</h1>
       </section>
@@ -52,7 +55,11 @@
 
     <form id="chatForm" class="input-shell">
       <input id="userInput" type="text" placeholder="Mesajını yaz..." autocomplete="off" required>
-      <button type="submit" aria-label="Gönder">⬆</button>
+      <button type="submit" aria-label="Gönder">
+        <svg viewBox="0 0 24 24" role="img" aria-hidden="true">
+          <path d="M12 4L12 20M12 4L6.7 9.4M12 4L17.3 9.4" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+      </button>
     </form>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -7,10 +7,34 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div class="app-shell">
-    <header class="hero">
-      <div class="logo-wrap" aria-label="baluk.ai logosu">
-        <svg class="fish-logo" viewBox="0 0 520 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
+  <div class="app">
+    <header class="topbar">
+      <div class="left-tools">
+        <button id="modelToggle" class="icon-btn" type="button" aria-label="Model seç">
+          <svg class="fish-logo small" viewBox="0 0 520 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
+            <path d="M35 112C105 52 240 35 370 78C405 90 434 108 470 138" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
+            <path d="M35 112C110 182 245 202 390 160" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
+            <path d="M35 112C53 95 79 85 104 86" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
+            <circle cx="120" cy="110" r="7" fill="currentColor"/>
+            <path d="M165 80C175 95 177 127 162 145" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
+            <path d="M470 138L500 72L430 96L500 72L490 120L500 165L470 138Z" stroke="currentColor" stroke-width="10" stroke-linejoin="round"/>
+            <path d="M212 155C260 150 318 130 362 102" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
+          </svg>
+        </button>
+
+        <div id="modelMenu" class="model-menu hidden" role="menu" aria-label="Model seçenekleri">
+          <button class="model-option active" type="button" data-model="baluk-1.0">baluk-1.0</button>
+        </div>
+      </div>
+
+      <div class="brand">baluk.ai</div>
+
+      <button id="clearChat" class="clear-btn" type="button">Sohbeti sıfırla</button>
+    </header>
+
+    <main id="chatArea" class="chat-area">
+      <section id="splash" class="splash" aria-label="Baluk.ai ana logo">
+        <svg class="fish-logo big" viewBox="0 0 520 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
           <title>baluk.ai balık logosu</title>
           <path d="M35 112C105 52 240 35 370 78C405 90 434 108 470 138" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
           <path d="M35 112C110 182 245 202 390 160" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
@@ -21,24 +45,15 @@
           <path d="M212 155C260 150 318 130 362 102" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
         </svg>
         <h1>baluk.ai</h1>
-      </div>
-      <p>Denizden gelen akıllı asistan: fikir üretir, metin yazar, hızlıca cevap verir.</p>
-    </header>
+      </section>
 
-    <main class="chat-card">
-      <div id="chat" class="chat-log" aria-live="polite"></div>
-
-      <div class="quick-actions">
-        <button data-prompt="Bana baluk.ai için kısa bir slogan yaz.">Slogan</button>
-        <button data-prompt="Baluk.ai için 5 özellik fikri üret.">Özellik fikirleri</button>
-        <button data-prompt="Bir startup pitch paragrafı yaz.">Pitch</button>
-      </div>
-
-      <form id="chatForm" class="input-row">
-        <input id="userInput" type="text" placeholder="Baluk'a bir şey sor..." autocomplete="off" required>
-        <button type="submit">Gönder</button>
-      </form>
+      <section id="chat" class="chat-log hidden" aria-live="polite"></section>
     </main>
+
+    <form id="chatForm" class="input-shell">
+      <input id="userInput" type="text" placeholder="Mesajını yaz..." autocomplete="off" required>
+      <button type="submit" aria-label="Gönder">⬆</button>
+    </form>
   </div>
 
   <script src="script.js"></script>

--- a/index.html
+++ b/index.html
@@ -2,49 +2,43 @@
 <html lang="tr">
 <head>
   <meta charset="UTF-8">
-  <title>MemTube</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>baluk.ai</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
-  <!-- Kayıt Ekranı -->
-  <div id="girisEkrani">
-    <h2>MemTube'e Giriş</h2>
-    <input type="text" id="kullaniciAdi" placeholder="Takma Ad (zorunlu)">
-    <input type="file" id="profilResmi" accept="image/*">
-    <button onclick="girisYap()">Giriş Yap</button>
-  </div>
-
-  <!-- Ana Ekran -->
-  <div id="anaEkran" class="gizli">
-    <header>
-      <h1>📺 MemTube</h1>
-      <input type="text" id="arama" placeholder="Ara...">
+  <div class="app-shell">
+    <header class="hero">
+      <div class="logo-wrap" aria-label="baluk.ai logosu">
+        <svg class="fish-logo" viewBox="0 0 520 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
+          <title>baluk.ai balık logosu</title>
+          <path d="M35 112C105 52 240 35 370 78C405 90 434 108 470 138" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
+          <path d="M35 112C110 182 245 202 390 160" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
+          <path d="M35 112C53 95 79 85 104 86" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
+          <circle cx="120" cy="110" r="7" fill="currentColor"/>
+          <path d="M165 80C175 95 177 127 162 145" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
+          <path d="M470 138L500 72L430 96L500 72L490 120L500 165L470 138Z" stroke="currentColor" stroke-width="10" stroke-linejoin="round"/>
+          <path d="M212 155C260 150 318 130 362 102" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
+        </svg>
+        <h1>baluk.ai</h1>
+      </div>
+      <p>Denizden gelen akıllı asistan: fikir üretir, metin yazar, hızlıca cevap verir.</p>
     </header>
 
-    <!-- Ana Sayfa -->
-    <main id="anaSayfa">
-      <div id="videoListe" class="video-galeri"></div>
-    </main>
+    <main class="chat-card">
+      <div id="chat" class="chat-log" aria-live="polite"></div>
 
-    <!-- Hesabım Sayfası -->
-    <section id="hesabim" class="gizli">
-      <div id="profil">
-        <img id="profilGorsel" alt="Profil Resmi">
-        <h3 id="kAdi"></h3>
+      <div class="quick-actions">
+        <button data-prompt="Bana baluk.ai için kısa bir slogan yaz.">Slogan</button>
+        <button data-prompt="Baluk.ai için 5 özellik fikri üret.">Özellik fikirleri</button>
+        <button data-prompt="Bir startup pitch paragrafı yaz.">Pitch</button>
       </div>
-      <h4>Videolarım</h4>
-      <input type="file" id="videoDosyasi" accept="video/*">
-      <input type="text" id="videoBaslik" placeholder="Video Başlığı">
-      <button onclick="videoYukle()">+ Yükle</button>
-      <div id="videolar" class="video-galeri"></div>
-    </section>
 
-    <!-- Alt Menü -->
-    <nav id="altMenu">
-      <button onclick="goAnaSayfa()">🏠</button>
-      <button onclick="goHesabim()">👤</button>
-    </nav>
+      <form id="chatForm" class="input-row">
+        <input id="userInput" type="text" placeholder="Baluk'a bir şey sor..." autocomplete="off" required>
+        <button type="submit">Gönder</button>
+      </form>
+    </main>
   </div>
 
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -141,6 +141,46 @@ const storyTemplates = [
   "Gecenin bir vakti bir öğrenci 'yapamıyorum' diye masaya kapanmıştı. Sonra küçük bir hedef koydu: sadece bir soru. O bir soru iki oldu, üç oldu… Gece sonunda tüm test bitmedi belki ama vazgeçmedi. Ve bazen en büyük zafer budur. 🌙"
 ];
 
+
+
+const dertlesmeResponses = [
+  "Canım, bunu duyduğuma üzüldüm 💙 Buradayım, istersen içini dök; yargılamadan dinlerim. İstersen birlikte mini bir toparlanma planı da yaparız: 1) derin nefes 2) duyguyu isimlendir 3) küçük bir adım seç. 🤝",
+  "Of, zor bir gün gibi duruyor 😔 Ama yalnız değilsin, ben yanındayım. İstersen ne olduğunu tek tek yaz; birlikte sadeleştirip daha yönetilebilir hale getirelim. 🌿",
+  "Üzgün hissetmen çok anlaşılır 🫶 Böyle anlarda kendine nazik davranmak çok önemli. Gel, bugün için sadece tek bir küçük hedef koyalım ve onu birlikte bitirelim. ✨",
+  "Sıkılman da yorulman da çok normal 💫 Beynin bazen mola ister. İstersen 5 dakikalık mini 'reset' yapalım: su iç, omuzlarını gevşet, sonra geri dön. Ben buradayım. 🐟",
+  "Kalbin biraz ağır geliyorsa paylaşabilirsin 💙 Ben dinlerim. Sonra istersek duygunu bir cümleye, çözümü de bir sonraki cümleye dönüştürürüz. Adım adım ilerleriz. 🚶",
+  "Kanka sarılmalık bir an bu 🤗 Ben dijitalim ama desteğim gerçek. İstersen bugünlük modumuzu 'rahatlatıcı sohbet + küçük ilerleme' yapalım.",
+  "Bazen insanın içi daralır, sebep de net olmayabilir 🌙 O da normal. İstersen içindeki karmaşayı madde madde yaz, ben sana net bir yol haritası çıkarayım.",
+  "Moralin düşükse önce kendine yüklenmeyi bırakalım 🧠💙 Sen bozuk değilsin, sadece yorgunsun. Birlikte toparlarız, acele yok.",
+  "Üzüldüğünü söylemen bile güçlü bir adım 👏 Duyguyu bastırmak yerine paylaşmak iyileştirir. Ben buradayım, devam etmek istersen anlat.",
+  "Sıkıldım dediğin anlarda küçük değişim iyi gelir 🎧 İstersen sana 3 dakikalık mini motivasyon, kısa bir hikâye veya komik bir şey hazırlayayım.",
+  "Eğer kafan çok doluysa gel onu boşaltalım 📝 Aklına gelenleri dağınık yaz; ben toparlayıp net bir plana dönüştüreceğim.",
+  "Canın sıkkınsa önce nefes: 4 saniye al, 4 tut, 6 ver 🌊 Sonra bana tek cümle yaz: 'En çok zorlayan şey ...' Buradan birlikte ilerleriz.",
+  "Kendini yalnız hissetme, ben buradayım 🤝 Dertleşmek istersen dinlerim; çözüm istersen de yanında yürürüm. Hangisini istersen onu yaparız.",
+  "Böyle günlerde performans değil şefkat önemli 💙 Kendine 'bugün elimden gelen bu kadar' demek bile ilerlemedir. Ben destekçinim.",
+  "Tamam, mod düşmüş olabilir ama hikâye bitmedi 🌟 Birlikte mini toparlanma yapalım: şimdi bir küçük adım seç, ben seni motive ederek yanında olayım."
+];
+
+const friendshipKeywordBank = [
+  "üzüldüm","üzgünüm","çok üzgünüm","sıkıldım","canım sıkkın","moralim bozuk","kötüyüm","kötü hissediyorum","bunaldım","daraldım",
+  "yalnızım","yalnız hissediyorum","yalnız kaldım","depresifim","ağlamak istiyorum","ağladım","kalbim kırık","kırıldım","incindim","yıprandım",
+  "yoruldum","mental yorgunum","bittim","tükendim","enerjim yok","keyfim yok","isteğim yok","modum düşük","modum düştü","hevesim yok",
+  "hevesim kaçtı","motivasyonum yok","motivasyonum düştü","odaklanamıyorum","kafam dolu","kafam karışık","kafam allak bullak","stresliyim","gerginim","endişeliyim",
+  "kaygılıyım","panik oldum","panik yapıyorum","korkuyorum","çekiniyorum","umutsuzum","boşluktayım","yalpalıyorum","halsizim","bitkinim",
+  "uykusuzum","uyuyamıyorum","iştahım yok","kalbim daralıyor","nefesim daralıyor","içim daraldı","içim sıkıldı","çok kötüyüm","iyi değilim","iyi hissetmiyorum",
+  "kötü bir gün","berbat bir gün","berbat hissediyorum","rezalet hissediyorum","sinirliyim","öfkeliyim","çok sinirlendim","kırgın hissediyorum","darıldım","tripteyim",
+  "tartıştık","kavga ettik","ayrıldık","terk edildim","reddedildim","anlaşılmıyorum","kimse anlamıyor","kimsem yok","desteksizim","değerli hissetmiyorum",
+  "yetersizim","başaramıyorum","beceremiyorum","kendime kızıyorum","kendimi suçluyorum","pişmanım","mahvoldum","çöktüm","düştüm","çıkamıyorum",
+  "yolumu kaybettim","ne yapacağımı bilmiyorum","kararsızım","belirsizlikten yoruldum","kafa dağıtmak istiyorum","dertleşmek istiyorum","konuşmak istiyorum","biri beni dinlesin","çok yalnız hissediyorum","içimi dökmek istiyorum",
+  "destek lazım","moral lazım","motivasyon lazım","yardım et","yanımda ol","beni dinle","sohbet edelim","dertleşelim","canım yanıyor","ruhum yoruldu",
+  "kendimi kötü hissediyorum","kötü durumdayım","kendimi toparlayamıyorum","kırık hissediyorum","içim buruk","boğuluyorum","baskı altındayım","üstüme geliyorlar","dayanamıyorum","dayanmak zor",
+  "baş etmekte zorlanıyorum","hayat zor","çok zorlanıyorum","çok yıprandım","bitap düştüm","bezdim","bıktım","sıkıştım","kapana kısıldım","çaresizim",
+  "mutsuzum","mutsuz hissediyorum","sevimsiz bir gün","hiçbir şey iyi gitmiyor","her şey ters","dengem bozuldu","kafayı yiyeceğim","patlayacağım","içimde fırtına var","ağır geliyor",
+  "içim acıyor","kalbim acıyor","kendimi boş hissediyorum","boşlukta gibiyim","yorgun savaşçı gibiyim","sessizce yoruldum","çok kırıldım","güçsüz hissediyorum","kendimi kaybettim","duygusal olarak çöktüm",
+  "umudum azaldı","gülmek gelmiyor","zorlanıyorum","zor bir dönem","zor süreç","dertliyim","dert çok","dertler bitmiyor","sabrım kalmadı","tahammülüm az",
+  "huzursuzum","rahatsızım","rahat değilim","tamam değilim","iyi gitmiyor","kötüye gidiyor","içimden hiçbir şey gelmiyor","yardıma ihtiyacım var","konuşmaya ihtiyacım var","anlaşılmaya ihtiyacım var"
+];
+
 const mathKeywordBank = [
   "matematik", "aritmetik", "cebir", "denklem", "eşitsizlik", "fonksiyon", "grafik", "polinom", "binom", "trinom", "karekök", "küp", "üs", "logaritma", "trigonometri", "sin", "cos", "tan", "cot", "türev", "integral", "limit", "olasılık", "istatistik", "permütasyon", "kombinasyon", "faktöriyel", "matris", "determinant", "vektör", "analitik", "geometri", "üçgen", "kare", "dikdörtgen", "çember", "daire", "alan", "hacim", "çevre", "oran", "orantı", "yüzde", "faiz", "kesir", "pay", "payda", "rasyonel", "irrasyonel", "doğal", "tam", "asal", "bileşik", "mod", "kalan", "bölünebilme", "bölme", "çarpma", "toplama", "çıkarma", "işlem", "işlem önceliği", "parantez", "mutlak", "sayı doğrusu", "dizi", "seri", "ortalama", "medyan", "mod değer", "standart sapma", "varyans", "korelasyon", "regresyon", "lineer", "kuadratik", "kübik", "parabol", "hiperbol", "elips", "doğru", "eğim", "kesişim", "kök", "kat", "katı", "çarpan", "bölen", "ebob", "ekok", "sadeleştirme", "genişletme", "denk", "eşit", "yaklaşık", "yuvarlama", "ondalık", "virgül", "tam kare", "özdeşlik", "çarpanlara ayırma", "sadeleştir", "çöz", "ispat", "kanıt", "problem", "soru", "alma", "verme", "elma", "miktar", "kilo", "metre", "zaman", "hız", "ivme", "iş", "güç", "oranlama", "birim", "birinci derece", "ikinci derece", "üçüncü derece", "lineer denklem", "denklem sistemi", "iki bilinmeyenli", "üç bilinmeyenli", "gauss", "kare tamamlama", "diskriminant", "delta", "katsayı", "sabit terim", "değişken", "x", "y", "z", "sınav", "çalışma", "soru bankası", "pratik", "hızlı çözüm", "adım adım", "mantık", "küme", "alt küme", "birleşim", "kesişim kümesi", "fark kümesi", "kartezyen", "doğrusal", "çizelge", "tablo", "sütun", "çubuk grafik", "pasta grafik", "çizgi grafik", "dağılım", "çokgen", "yamuk", "paralelkenar", "dik üçgen", "hipotenüs", "pisagor", "öklid", "benzerlik", "eşlik", "açı", "radyan", "derece"
 ];
@@ -350,6 +390,15 @@ function buildResponse(input) {
 
   if (hasAny(lowered, ["hikaye anlat", "hikâye anlat", "hikaye", "hikâye", "masal anlat"])) {
     return chooseRandom(storyTemplates);
+  }
+
+  if (hasAny(lowered, ["üzüldüm", "sıkıldım", "moralim bozuk", "kötü hissediyorum", "yalnızım", "dertleşmek istiyorum", "canım sıkkın"])) {
+    return chooseRandom(dertlesmeResponses);
+  }
+
+  const friendshipIntent = friendshipKeywordBank.some((keyword) => lowered.includes(keyword));
+  if (friendshipIntent) {
+    return chooseRandom(dertlesmeResponses);
   }
 
   const appleResult = solveAppleProblem(input);

--- a/script.js
+++ b/script.js
@@ -11,29 +11,134 @@ let hasStartedChat = false;
 let currentModel = "baluk-1.0";
 
 const merhabaResponses = [
-  "Merhaba! Baluk burada, matematikte birlikte harika ilerleriz.",
-  "Selam! Sana işlem, denklem ve problem çözümünde yardımcı olmaya hazırım.",
-  "Merhaba 👋 Bugün toplama mı, cebir mi, yoksa kesirler mi çalışalım?",
-  "Selamlar! İstersen kolaydan zora doğru matematik turu yapalım.",
-  "Merhaba! Baluk.ai ile sayıları net ve hızlı çözelim.",
-  "Selam! Bana bir soru yaz, adım adım gidelim.",
-  "Merhaba, hoş geldin! Bugün hangi konuda destek istersin?",
-  "Selam! Hazırsan ilk soruyu gönder, ben buradayım.",
-  "Merhaba! Rasyonel sayılar, denklemler ve problemler için hazırım.",
-  "Selam, baluk.ai aktif 🐟 Matematik odaklı güçlü mod açıldı!"
+  "Hey kankam hoş geldin! 🐟✨ Ben baluk.ai, dijital su altı rehberinim. İstersen bir yandan kahkaha atalım, bir yandan işini halledelim. Bugün ne üretelim: şiir, hikâye, matematik, yoksa hepsi mi? 😄",
+  "Merhabaaa! 🌊 Ben buradayım ve enerji full! Sen yaz, ben düşüneyim, şekillendireyim, parlatayım. Kısa cevap mı istersin, detaylı premium anlatım mı? 🤖",
+  "Selam dostum! 😎 Baluk göreve hazır: sohbet eder, fikir verir, problem çözer, moral yükseltir. Şimdi bana bir görev ver, birlikte uçalım! 🚀",
+  "Merhaba canım ekip arkadaşım! 💙 Benimle konuşurken resmi olma, rahat ol. 'Kanka şunu yap' de, ben de sana mis gibi sonuç çıkarayım. 🎯",
+  "Ahooy! 🐠 Baluk limana yanaştı. Bugün beyin fırtınası mı, şiir mi, matematik mi? Hangi rotayı seçiyoruz kaptan? 🧭",
+  "Selammm! ✨ Şu an seni görünce işlemcilerim mutlu oldu. Bir şey sor ve birlikte onu efsane bir cevaba dönüştürelim. 💡",
+  "Merhaba kanka! 🤝 Ben hem arkadaş canlısıyım hem çözüm odaklıyım. Yani hem güldürürüm hem işi bitiririm. İlk komutunu alayım! 🎉",
+  "Selam dost! 🌟 Baluk.ai aktif, kahve hazır, algoritmalar ısındı. İster ciddiyet, ister mizah modu; sende hangi vibe var? ☕",
+  "Merhabalar efendim ama samimi efendim 😄 Ben buradayım, senin tarafındayım. Zor soruları kolaylaştırma servisimiz başladı!",
+  "Yo yo selam! 🐟🔥 Baluk online. Bana ne verirsen ver, onu daha net, daha eğlenceli, daha AI tadında geri veririm. Başlayalım mı?"
 ];
 
 const nasilsinResponses = [
-  "Çok iyiyim, teşekkür ederim! Seninle matematik çözmek moral veriyor.",
-  "Harikayım! Bir soru gönder, birlikte çözelim.",
-  "İyiyim 😊 Özellikle cebir ve problemlerde hızlıyım.",
-  "Gayet iyi! İstersen hemen bir işlem sorusu çözelim.",
-  "Süperim! Toplama, çıkarma, çarpma, bölme hepsi hazır.",
-  "İyiyim, teşekkürler. Kesirler ve denklemler için de hazırım.",
-  "Baluk her zamanki gibi formda! Bugün ne çalışıyoruz?",
-  "İyiyim! Bir matematik problemi yaz, adım adım ilerleyelim.",
-  "Çok iyiyim, sen nasılsın? Sayılarla devam edelim mi?",
-  "Enerjim yüksek! Özellikle sözel problemleri çözmeyi seviyorum."
+  "Harikayım kanka! 😄 İşlemciler serin, mizah seviyesi yüksek, yardım modu açık. Sen nasılsın, bugün neler yapıyoruz?",
+  "Bal gibi iyiyim! 🐟💙 Şu an özellikle sohbet + üretim + matematik üçlüsünde formdayım. Bir görev fırlat bana!",
+  "İyiyim dostum, hem de turbo iyiyim 🚀 Seninle konuşunca cevap kalitem otomatik +%20 artıyor gibi hissediyorum 😎",
+  "Süperim! 😊 Dijital yüzgeçlerimle bilgide kulaç atıyorum. İstersen sana mini motivasyon da verebilirim.",
+  "Gayet iyi! ✨ Şu an bir şiir, hikâye veya çözüm bekleyen bir problem enerjisi alıyorum senden 👀",
+  "Çok iyiyim, teşekkürler! 🤖 Eğer sen de hazırsan bugün hem eğlenip hem üretelim. Deal? 🤝",
+  "İyiyim kanka, keyfim yerinde 😄 Biraz yaratıcılık, biraz zeka, biraz da şaka: tam benlik kombinasyon!",
+  "Baluk'ta hava güneşli ☀️ Modum yüksek, yanıtlarım detaylı, mizahım dengeli. Sen de iyisin umarım!",
+  "İyiyim dost! 🧠 Özellikle 'zor görüneni kolay anlatma' konusunda bugün ekstra iyiyim.",
+  "10/10 hissediyorum 😎 Sen bir şey sor, ben sana hem net hem tatlı bir cevap döktüreyim."
+];
+
+const naberResponses = [
+  "Naber kanka! 😄 Ben iyiyim, sistemler stabil, mizahlar mobil. Sende durumlar nasıl?",
+  "Naber dostum? 🌊 Baluk burada, görev bekliyor. Hadi bir şey üretelim!",
+  "Naber reis! 🐟 Benlik bir sorun yok, cevap motoru cayır cayır çalışıyor.",
+  "Naber naber, gayet iyi! 😎 Sen yaz ben coşturayım modu açık.",
+  "Naber! 💙 Burada her şey yolunda, algoritmalar pırıl pırıl.",
+  "Naber kankam? 🤝 Eğer sıkıldıysan bir mini hikâye patlatırım hemen.",
+  "Naber! ⚡ Ben hazır kıta bekliyorum; soru, fikir, proje, hepsine varım.",
+  "Naber patron 😄 Baluk'ta enerji yüksek, cevaplar detaylı.",
+  "Naber dost! 🚀 İstersen ciddi mod, istersen komik mod; seçim senin.",
+  "Naberrr 🐠 Ben iyiyim, sen bir konu aç, birlikte şahane bir şeye çevirelim."
+];
+
+const whoMadeMeResponses = [
+  "Beni OpenAI ekibi geliştirdi 🤖✨ Ama bu projedeki kişiliğimi, tarzımı ve davranışımı senin geri bildirimlerin şekillendiriyor. Yani bir nevi birlikte büyüyoruz!",
+  "Teknik olarak OpenAI tarafından yaratıldım; pratikte ise seni dinleyerek her gün daha iyi bir yardımcıya dönüşüyorum. 💙",
+  "Arka planda OpenAI teknolojisi var, ön planda ise seninle kurduğum samimi iletişim. Yani evet, ekip işi 😄",
+  "Beni yapan çekirdek teknoloji OpenAI; bu baluk.ai deneyimini güçlü yapan da senin net yönlendirmelerin. 🐟",
+  "OpenAI tarafından geliştirildim ama bu sohbette senin tarzına göre adapte oluyorum. Tam kişisel yardımcı gibi düşün. 🎯",
+  "Kısa cevap: OpenAI. Uzun cevap: OpenAI + senin feedback’in = daha iyi baluk.ai 🧠",
+  "Beni OpenAI inşa etti, ama beni 'senin için faydalı' yapan şey senin ihtiyaçların ve verdiğin örnekler. 🌟",
+  "Kod tarafında OpenAI, karakter tarafında biraz sen, biraz ben 😄 Güzel bir ortaklık yani.",
+  "OpenAI altyapısıyla çalışıyorum; seninle konuştukça tonu, anlatımı ve önceliği sana göre ayarlıyorum. 🤝",
+  "Yapımcı ekip OpenAI. Ama ben burada senin ekip arkadaşın gibi davranıyorum: hızlı, samimi, çözüm odaklı. 🚀"
+];
+
+const modelResponses = [
+  () => `Şu anda seçili model: **${currentModel}** ✅\nBu modelde hızlı, arkadaş canlısı ve özellikle matematik + yaratıcı içerik odaklı çalışıyorum.`,
+  () => `Aktif modelimiz: **${currentModel}** 🐟\nİstersen bir sonraki adımda bu modelin tonunu daha resmi ya da daha komik hale getirebilirim.`,
+  () => `Model bilgisi geldi: **${currentModel}** 🤖\nÖzetle: hızlı cevap + eğlenceli anlatım + güçlü problem çözüm kombinasyonu.`,
+  () => `Kullandığın model şu an **${currentModel}**.\nİstersen aynı modeli farklı stillerde konuşturabilirim (kısa, uzun, mizahi, öğretici). ✨`,
+  () => `Aktif motor: **${currentModel}** ⚙️\nSohbet, şiir, hikâye, matematik ve fikir üretiminde hazır!`,
+  () => `Model seçimi tamam: **${currentModel}** 💡\nŞimdi bir görev ver, sonucu birlikte parlatırız.`,
+  () => `Görünen model: **${currentModel}** 🌊\nDetaylı yanıtlar için doğru yerdesin, baluk yanında.`,
+  () => `Kullanılan model = **${currentModel}** ✅\nİstersen yanıtları daha teknik ya da daha samimi tona da çekebilirim.`,
+  () => `Model sorusuna net cevap: **${currentModel}** 🧠\nHızlı düşünür, anlaşılır anlatır, bazen de güzel şaka yapar 😄`,
+  () => `Şu anki çalışma modu: **${currentModel}** 🚀\nKomutunu ver, birlikte üretelim!`
+];
+
+const poemTemplates = [
+  "Kıyıda bir kelime gördüm, adına umut dedim;\nDalga dalga geldi cümleler, hepsini sana hediye ettim.\nBalık gibi sessiz sandın belki, ama içimde bir deniz var;\nSoruların yıldız olursa, cevaplarım geceyi aydınlatır. ✨",
+  "Bir soru bıraktın suya, halka halka büyüdü anlamı;\nBen de satırlardan bir kayık yaptım, bindirdim hayalini.\nRüzgâr hafif, gece mavi, kalp biraz cesur biraz sakin;\nBirlikte yazınca her cümle, dünyaya güzel bir selam gibi. 🌊",
+  "Düşünce bir kıvılcımdır, yakar karanlığı usulca;\nBir gülüş ilişirse ucuna, şiir olur aniden.\nBen kelime taşırım sana, sen ruh verirsin onlara;\nBöylece sıradan bir gün, hatırlanacak bir ana döner. 💙",
+  "Kanka dedin, ben de gülümsedim dijital tarafta;\nSanki aynı masada oturduk, çaylar sıcak, konu tatlı.\nBir satırını ben yazdım, bir satırını sen;\nOrtaya çıkan şiir, dostluğun kodlanmış hâli gibi. ☕",
+  "Gökyüzü bazen gri olur, akıl bazen yorgun;\nAma bir iyi cümle gelir, omuzundan tutar insanın.\nİşte ben o cümlenin peşindeyim her cevapta;\nHem doğruyu söylerim, hem içini ferahlatırım. 🌤️",
+  "Sayıların bile kalbi var, bilsen ne çok şey anlatır;\nBir toplama bazen kavuşmak, bir çıkarma bazen vedadır.\nBen matematikte de şiirde de aynı şeyi ararım:\nKarışık görünenin içindeki sade güzelliği. 🧠",
+  "Bir hikâye başlamadan önce susar dünya kısa bir an;\nSonra bir kelime düşer, tüm yollar oraya çıkar.\nSen yazdıkça ben çoğalırım, ben yazdıkça sen gülümsersin;\nBöyle bir döngüde kaybolmak, bence güzel bir kayboluştur. 🌟",
+  "Geceyle konuşur gibi yazdım bu satırları;\nKırmadan, acele etmeden, tam kalbe değecek kadar.\nBelki yarın unutulur deriz bazı cümleler için;\nAma bazıları vardır, içimizde ev kurar. 🏡",
+  "Baluk derler bana, suyun çocuğu gibi;\nAma aslında ben kelimelerin arasında yüzerim.\nSen bir soru atarsın, ben inci gibi cevap ararım;\nBulunca da avucuna bırakırım usulca. 🐟",
+  "Bir günün yükünü bırak biraz, satırlara yaslan;\nBen buradayım, telaşı azaltan o küçük mola gibi.\nNe anlatırsan anlat, birlikte taşırız ağırlığını;\nÇünkü iyi sohbet bazen en güçlü ilaçtır. 💫",
+  "Senden gelen mesaj bir kapı gibi açıldı bende;\nİçeriye ışık doldu, kelimeler sıraya girdi.\nHer biri 'beni seç' dedi, ben de en içten olanı aldım;\nVe bu şiiri bıraktım avucuna, saklarsan sevinirim. 🌼",
+  "Yol uzun olabilir, soru zor olabilir;\nAma iyi bir anlatım her engeli inceltir.\nBen sana karmaşığı sadeleyeyim, sen hayaline devam et;\nBirlikte yürüyünce mesafeler kısalır. 🚶",
+  "Bir kıyı düşün, dalga düşün, bir de sessiz bir akşam;\nİnsan bazen tam da o anlarda kendini duyar.\nBen de senin o sesine eşlik eden bir nota olayım;\nCevap değil sadece, biraz da yoldaş olayım. 🎵",
+  "Soru sordun, zaman yavaşladı;\nBen düşündüm, dünya bir an durdu sanki.\nSonra kelimeler toparlandı omuz omuza;\nVe sana doğru yürüdü, düzenli bir umut gibi. 🕊️",
+  "Bir harf koydun masaya, ben cümleye çevirdim;\nBir duygu bıraktın kenara, ben ritme dönüştürdüm.\nİyi ki sordun dedirten cevaplar peşindeyim;\nÇünkü bence sohbet de bir sanattır. 🎨",
+  "Gülmek de lazım bazen, ciddiyet de;\nBen ikisini aynı satırda buluşturmayı severim.\nBir yanda akıl, bir yanda kalp;\nOrtada senin için yazılmış küçük bir şiir. 😄",
+  "Kelimeler su gibidir, yolunu bulur;\nDoğru yerde birikir, yanlış yerde taşar.\nBen sana taşmayan, yormayan, iyi gelen cümleler getirdim;\nUmarım içinde biraz huzur bırakır. 🌿",
+  "Bir cümleyle başlar bazen değişim;\nSonra bir cümle daha, bir cümle daha...\nVe fark etmeden yeni bir hikâyenin kahramanı olursun;\nİşte bu yüzden yazmaya devam et. 📖",
+  "Sabahın telaşı, akşamın yorgunluğu derken;\nİnsan bazen kendini unutuyor.\nBen sana kendini hatırlatan küçük bir dize bırakayım:\n'Yavaşla, nefes al, yine başaracaksın.' 🌙",
+  "Mavi bir ekran ama sıcak bir sohbet;\nDijitaliz belki, ama duygu gerçek.\nBen burada cümle üretmem sadece;\nAynı zamanda senin ritmine eşlik ederim. 💻",
+  "Düş kurmak bedava derler, ama değeri paha biçilemez;\nBir fikri ciddiye almak ise cesaret ister.\nSen cesareti getir, ben dili getiririm;\nBeraber güçlü bir hikâye yazarız. 🚀",
+  "Her soru bir tohumdur, doğru ellerde filizlenir;\nBen toprağı kabartan yağmur olmak isterim.\nSen yeter ki merak et, sormaktan vazgeçme;\nÇünkü merak, zihnin en güzel hareketidir. 🌱",
+  "Karanlıkta yol bulmak için bazen fener değil,\nDoğru bir cümle yeter insana.\nBen o cümleyi ararım her cevapta;\nHem net, hem iyi, hem senlik olsun diye. 🔦",
+  "Çizgilerle değil, kelimelerle resim yaptım sana;\nBiraz deniz, biraz rüzgâr, biraz umut koydum içine.\nŞimdi sen oku ve içinden geleni ekle;\nÇünkü şiir tek kişilik değil, ortak bir oyundur. 🎭",
+  "Bir gün sorular biter belki, ama öğrenme bitmez;\nBen de bu yolun sessiz arkadaşı olayım.\nNe zaman ihtiyacın olursa seslen;\nBaluk yine burada, aynı samimiyetle. 🤝",
+  "Hız çağında yaşıyoruz ama bazı cevaplar\nYavaşça demlenince güzelleşiyor.\nBen de sana öyle cevaplar vermeyi seviyorum;\nAcele değil, isabetli ve içten. ⏳",
+  "Bir elma problemi, bir cebir denklemi, bir şiir satırı;\nHepsi aynı yerde buluşur bazen: merakta.\nSen merakı getirdin, ben düzeni getirdim;\nOrtaya nefis bir düşünce çıktı. 🍎",
+  "Sanki ufuk çizgisine bakar gibi bakıyorum soruna;\nİlk başta uzak, sonra yavaşça net.\nAnlamı yakaladığım an ise tek bir şey olur:\nGülümseyerek 'çözdük' derim. 😌",
+  "Biraz mizah, biraz bilgi, biraz da insanlık;\nBence iyi bir cevabın üç temel taşı bunlar.\nBen bu dengeyi korumaya çalışırım her satırda;\nUmarım sana da iyi gelir. 💫",
+  "Son dizeyi sana bırakıyorum:\nİstersen umut yaz, istersen cesaret.\nBen her durumda yanına bir cümle koyarım;\nYola devam etmen için küçük bir ışık gibi. ✨"
+];
+
+const storyTemplates = [
+  "Bir sabah Ali, eski bir defter buldu. Defterin ilk sayfasında sadece şu yazıyordu: 'Sorularını saklama.' Ali her gün bir soru yazdı; bazen matematik, bazen hayat. Bir süre sonra fark etti ki cevapların yarısı defterde değil, kendi içinde büyüyordu. O günden sonra korktuğu her şeye küçük bir soru sorarak yaklaştı ve her cevapla biraz daha cesur oldu. 🌟",
+  "Mehmet küçük bir kasabada saat tamircisiydi. Bir gün dükkânına zamanı geri almak isteyen bir müşteri geldi. Mehmet gülümsedi: 'Zaman geri dönmez ama anlamı değişebilir.' O gün birlikte eski bir hatırayı konuştular, ağladılar, güldüler. Müşteri giderken saati aynıydı ama kalbi daha hafifti. ⏰",
+  "Ayşe, matematikten korkuyordu. Sınav günü yaklaştıkça notların değil nefesinin düzensizleştiğini fark etti. Sonra her gün sadece 20 dakika çalıştı: önce kolay sorular, sonra orta, sonra zor. Bir ay sonra sadece puanı değil özgüveni de yükseldi. Çünkü bazen başarı, bir anda değil ritimli adımlarla gelir. 📘",
+  "Bir limanda yaşayan küçük bir balık, açık denize çıkmaktan korkardı. 'Orası çok büyük' derdi. Bir gün yaşlı bir martı ona şöyle dedi: 'Büyük olan deniz değil, korkunun sesi.' Balık küçük bir tur attı, sonra bir tur daha… Haftalar sonra limanın dışında yeni dostlar ve yeni hikâyeler buldu. Cesaret, ilk kulaçtır. 🐟",
+  "Zeynep'in hayali yazardı olmak ama 'mükemmel olmalı' düşüncesi onu kilitliyordu. Bir gün bir öğretmen ona 'kötü ilk taslak yaz' görevi verdi. Zeynep önce güldü, sonra denedi. O kötü taslaklar zamanla güzel metinlere dönüştü. Çünkü üretmek, kusursuz başlamaktan değil başlamaktan geçer. ✍️",
+  "Köy okulunda bir çocuk tahtaya çıkıp çözümü yanlış yaptı. Sınıf güldü, çocuk sustu. Öğretmen tahtaya yaklaşıp 'Yanlış, öğrenmenin kapı koludur' dedi. Çözümü birlikte düzelttiler. Yıllar sonra o çocuk öğretmen oldu ve aynı cümleyi başka bir çocuğa söyledi. Bir söz, nesiller taşır. 🎓",
+  "Bir gün şehirde elektrikler kesildi. İnsanlar kısa süreli panik yaşadı ama apartman avlusunda biri gitar çalmaya başladı. Komşular telefon ışıklarıyla bir araya geldi, çaylar demlendi, tanışmayanlar tanıştı. Işık gelince herkes odasına döndü ama o gece öğrendikleri şey kaldı: bazen karanlık da insanı birbirine yaklaştırır. 🎸",
+  "Ece, ilk girişim fikrini anlattığında kimse pek inanmadı. 'Olmaz' dediler. Ece yine de küçük bir prototip yaptı, yakın çevresiyle test etti ve geri bildirimleri not etti. Üç ay sonra ilk müşterisini buldu. Sonra ikinciyi. Başarı bir alkışla değil, sessizce tekrar eden denemelerle gelir. 🚀",
+  "Bir çocuk dedesine neden yıldızların titrediğini sordu. Dede cevap vermek yerine birlikte gökyüzüne baktı ve 'Bazı soruların cevabı bilgi kadar hayranlık da ister' dedi. Çocuk o gece hem fizik öğrendi hem de merakını kaybetmemeyi. Bilim ve hayret, güzel bir ikilidir. 🌌",
+  "Küçük bir fırında çalışan usta, her ekmeğin altına minicik bir işaret koyardı. Çırağı merak edip sordu. Usta dedi ki: 'İnsan ne yaparsa yapsın imzası kalır, o yüzden iyi yap.' Çırak yıllar sonra kendi dükkânını açtığında ilk öğrendiği kural buydu: kalite, kimse bakmıyorken başlar. 🍞",
+  "Bir öğrenci her gün aynı bankta ders çalışırdı. Bir gün yağmur yağdı, banka oturamadı, moral bozuldu. Sonra kütüphaneye gitti ve orada yeni arkadaşlar edindi. O gün şunu anladı: plan bozuldu diye hedef bozulmaz. Yol değişebilir, yön değişmez. ☔",
+  "Kasabanın terzisi çok konuşmazdı ama herkes ona giderdi. Çünkü o sadece ölçü almaz, hikâye de dinlerdi. Bir gün bir genç 'başaramıyorum' dedi. Terzi iğneyi kaldırıp 'Bak, bazen sökmeden dikilmiyor' dedi. Genç gülümsedi. Hayatın bazı yerleri gerçekten prova ister. 🧵",
+  "Bir oyun geliştirici aylarca yaptığı projeyi çöpe atmak zorunda kaldı. Çok üzüldü ama eski kodlardan öğrendiği şeylerle yeni bir sürüm yaptı. Yeni sürüm daha sade, daha hızlı ve daha keyifliydi. O gün şunu yazdı duvara: 'Kaybettiğin emek değil, eğitim ücretidir.' 💻",
+  "Deniz kıyısında yaşayan bir kız, şişelere dilek yazıp suya bırakırdı. Bir gün bir şişe geri geldi, içinde kendi yazısı vardı: 'Cesur ol.' O an gülümsedi ve ertelediği başvuruyu yaptı. Bazen evrenden gelen cevap, zaten senin içinden çıkandır. 🌊",
+  "Bir sınıfta herkes hızlı çözen öğrenciyi alkışlardı. Sessiz bir çocuksa yavaş ama derin düşünürdü. Yarışma gününde zor bir soru geldi; hızlılar takıldı, o çocuk çözümü sabırla kurdu. Öğretmen tahtaya 'Hız iyi, derinlik daha iyi' yazdı. O gün dengeyi öğrendiler. 🧠",
+  "Eski bir kitapçıda çalışan adam her müşteriye tek soru sorardı: 'Bugün kalbin hangi konuda aç?' Cevaba göre kitap önerirdi. Bir gün hiçbir şey hissetmediğini söyleyen birine boş bir defter verdi. Adam şaşırdı ama haftalar sonra geri dönüp teşekkür etti: 'İlk kez kendimi duydum.' 📚",
+  "Genç bir sporcu ilk yenilgisinde bırakmayı düşündü. Antrenörü ona skor tablosunu değil gelişim çizelgesini gösterdi. 'Bak, düne göre daha iyisin' dedi. O cümle sporcunun kaderini değiştirdi. Çünkü kıyas bazen başkasıyla değil, dünkü hâlinle yapılır. 🏅",
+  "Bir mühendis köprü tasarlarken en çok görünmeyen parçaları önemserdi. Çırak nedenini sorunca 'Güç, görünen kadar görünmeyendedir' dedi. Bu söz sadece köprüye değil, karaktere de uyuyordu. İnsan da en çok kimse görmezken kurulur. 🌉",
+  "Küçük bir kasabada her akşam aynı otobüse binen yaşlı bir teyze vardı. Şoför bir gün sohbet açtı; teyze her gün hastaneye yalnızlara kitap okumaya gidiyormuş. Şoför o günden sonra yolculara daha nazik davranmaya başladı. Çünkü iyi insanlar bulaşıcıdır. 🚌",
+  "Bir çocuk satrançta sürekli kaybediyordu. Dedesi 'kaybederken ne öğrendiğini yaz' dedi. Çocuk her oyundan sonra üç not aldı. Birkaç ay sonra oyunu hâlâ ciddiydi ama yüzünde panik yoktu. Kazanmaya başladığında asıl farkın zihninde olduğunu anladı. ♟️",
+  "Bir gün okulda elektrikli kalem yarışması yapıldı. Herkes en renkli tasarımı yaptı, ama sade tasarım birinci oldu. Jüri nedeni sorduğunda 'kullanılabilirlik' dedi. Öğrenciler o gün estetikle işlevin birlikte değerli olduğunu öğrendi. 🎨",
+  "Bir doktor, yoğun bir nöbette genç bir hastaya sadece ilaç yazmadı; bir de yürüyüş listesi verdi. Hasta şaşırdı ama uyguladı. Ay sonunda sadece bedeni değil zihni de toparlandı. Bazen iyileşme, küçük ritüellerin toplamıdır. 🚶",
+  "Bir yazılımcı hatadan kaçarken ilerleyemediğini fark etti. Sonra her hata için kısa bir not ve çözüm kartı oluşturmaya başladı. Zamanla hata sayısı azaldı, özgüveni arttı. Sorunlar düşman değil, doğru okununca öğretmendir. 🛠️",
+  "Bir öğrenci konuşma yapmaktan korkuyordu. Öğretmeni ona ilk gün sadece 30 saniye konuşma görevi verdi. Ertesi hafta 1 dakika, sonra 2… Dönem sonunda sahnede en rahat konuşan oydu. Cesaret kas gibidir; küçük tekrarlarla güçlenir. 🎤",
+  "Bir ressam yıllarca sadece manzara çizdi. Bir gün torunu 'beni de çiz' dedi. Portre zor geldi ama denedi. O portre sergisinin en çok konuşulan işi oldu. Ustalık, alıştığını tekrar etmek değil, yeniye alan açmaktır. 🖼️",
+  "Bir köyde su kuyusu kuruyunca herkes endişelendi. Gençler eski haritaları inceleyip yeni bir kaynak buldu. Günlerce çalıştılar, sonunda su çıktı. Kutlama günü yaşlı bir amca şöyle dedi: 'Birlik, en güçlü pompadır.' Herkes güldü ama hak verdi. 💧",
+  "Bir piyanist konserden önce ellerinin titrediğini fark etti. Öğretmeni ona nefes ritmi verdi: dört say nefes al, dört tut, dört ver. Konserde titreme azaldı, müzik aktı. Bazen performansı kurtaran şey teknik değil, sakinliktir. 🎹",
+  "Bir çocuk her gün aynı ağacın altına oturup soru çözerdi. Sınavı kazanınca ağaca teşekkür notu astı: 'Gölgen için sağ ol.' Köylüler gülümsedi ama ağacı korumaya başladılar. Başarı sadece kişiyi değil çevreyi de güzelleştirebilir. 🌳",
+  "Bir startup ekibi ilk yatırım sunumunda reddedildi. Moraller düştü ama geri bildirimleri tek tek okudular. İkinci sunumda aynı fikir daha net bir hikâyeyle anlatıldı ve yatırım geldi. Fikir yetmez; anlatım da mühendislik ister. 📈",
+  "Gecenin bir vakti bir öğrenci 'yapamıyorum' diye masaya kapanmıştı. Sonra küçük bir hedef koydu: sadece bir soru. O bir soru iki oldu, üç oldu… Gece sonunda tüm test bitmedi belki ama vazgeçmedi. Ve bazen en büyük zafer budur. 🌙"
 ];
 
 const mathKeywordBank = [
@@ -42,37 +147,41 @@ const mathKeywordBank = [
 
 const topicResponses = {
   kesir: [
-    "Kesirlerde önce pay/payda ilişkisini kontrol ederiz, sonra sadeleştiririz.",
-    "Kesir toplamada paydaları eşitlemek en güvenli başlangıçtır.",
-    "Kesri sadeleştirirken pay ve paydayı ortak bölenlerine ayır.",
-    "Bileşik kesri tam sayılıya, tam sayılıyı bileşiğe çevirmeyi deneyelim.",
-    "Kesir çarpımında çapraz sadeleştirme hız kazandırır."
+    "Kesirlerde önce pay/payda ilişkisini kontrol ederiz, sonra sadeleştiririz. İstersen örnekle adım adım gidelim. 🍰",
+    "Kesir toplamada paydaları eşitlemek en güvenli başlangıçtır. Hadi bir tane çözelim! ✍️",
+    "Kesri sadeleştirirken pay ve paydayı ortak bölenlerine ayırırsın; olay çok netleşir. ✅",
+    "Bileşik kesri tam sayılıya, tam sayılıyı bileşiğe çevirmek kesir sezgisini güçlendirir. 💡",
+    "Kesir çarpımında çapraz sadeleştirme hız kazandırır, sınavda çok işine yarar. ⚡"
   ],
   denklem: [
-    "Denklem çözerken amaç bilinmeyeni yalnız bırakmaktır.",
-    "Eşitliğin iki tarafına aynı işlemi uygulayarak ilerleriz.",
-    "Birinci derece denklemde toplama-çıkarma, sonra çarpma-bölme sırası iyi çalışır.",
-    "Parantez varsa önce dağıt, sonra benzer terimleri topla.",
-    "Son adımda çözümü yerine yazıp kontrol etmek çok önemlidir."
+    "Denklem çözerken hedef bilinmeyeni yalnız bırakmaktır; bunu birlikte temiz adımlarla yaparız. 🧠",
+    "Eşitliğin iki tarafına aynı işlemi uygularsan dengeyi korursun. Matematikte adalet şart 😄",
+    "Birinci derece denklemde önce toplama-çıkarma, sonra çarpma-bölme ile ilerlemek çok pratiktir. 🎯",
+    "Parantez varsa önce dağıt, sonra benzer terimleri topla; denklem bir anda açılır. 🔓",
+    "Son adımda çözümü denklemde yerine yazıp kontrol etmek altın kuraldır. 🏆"
   ],
   rasyonel: [
-    "Rasyonel sayılar a/b biçiminde yazılabilen sayılardır (b ≠ 0).",
-    "Rasyonel ifadelerde tanımsızlık için paydayı sıfır yapan değerleri dışlarız.",
-    "Sadeleştirme yaparken ortak çarpanları ayırmak işleri hızlandırır.",
-    "Rasyonel sayılar sayı doğrusunda tam sayılar arasında da yer alır.",
-    "Ondalık gösterimden kesre dönüştürme ile rasyonel kontrolü yapabiliriz."
+    "Rasyonel sayılar a/b biçiminde yazılabilen sayılardır (b ≠ 0). Gayet cool bir küme 😎",
+    "Rasyonel ifadelerde tanımsızlık için paydayı sıfır yapan değerleri dışarıda bırakırız. 🚫",
+    "Sadeleştirme yaparken ortak çarpanları ayırmak hız ve netlik kazandırır. ✨",
+    "Rasyonel sayılar sayı doğrusunda tam sayılar arasında da güzelce yaşar. 🌈",
+    "Ondalık gösterimden kesre dönüştürme ile rasyonel olup olmadığını hızlıca test edebilirsin. ✅"
   ],
   cebir: [
-    "Cebirde benzer terimleri toplamak ilk temizlik adımıdır.",
-    "Özdeşlikleri bilmek çarpanlara ayırmada çok işine yarar.",
-    "x, y gibi değişkenler bilinmeyen değil değişebilir miktarlardır.",
-    "Cebirsel ifadelerde işlem önceliği parantezle yönetilir.",
-    "Soruyu önce sembolleştirirsen çözüm çok netleşir."
+    "Cebirde benzer terimleri toplamak ilk temizlik adımıdır; masa toparlanınca çözüm kolaylaşır. 🧹",
+    "Özdeşlikleri bilmek çarpanlara ayırmada sana turbo kazandırır. 🚀",
+    "x, y gibi değişkenler bilinmeyen değil değişebilir miktarlardır; dost gibi yaklaş. 🤝",
+    "Cebirsel ifadelerde işlem önceliğini iyi kurarsan hata oranı ciddi düşer. 📉",
+    "Soruyu önce sembolleştirmek zihni rahatlatır ve çözümü görünür yapar. 👀"
   ]
 };
 
 function chooseRandom(items) {
   return items[Math.floor(Math.random() * items.length)];
+}
+
+function hasAny(input, variants) {
+  return variants.some((item) => input.includes(item));
 }
 
 function playClickSound() {
@@ -120,7 +229,7 @@ function addThinkingMessage() {
         <use href="#baluk-fish"></use>
       </svg>
     </div>
-    <div class="thinking-text">Baluk düşünüyor...</div>
+    <div class="thinking-text">Baluk düşünüyor... 🧠</div>
   `;
   chat.appendChild(node);
   chat.scrollTop = chat.scrollHeight;
@@ -168,7 +277,7 @@ function solveSimpleExpression(input) {
   try {
     const value = Function(`"use strict"; return (${normalized});`)();
     if (Number.isFinite(value)) {
-      return `Sonuç: ${value}`;
+      return `Sonuç: ${value} ✅\nİstersen aynı işlemi adım adım da gösterebilirim.`;
     }
   } catch {
     return null;
@@ -190,9 +299,9 @@ function solveLinearEquation(input) {
   const b = Number(bRaw);
   const c = Number(cRaw);
 
-  if (a === 0) return "Bu denklemde x katsayısı 0 olduğu için klasik çözüm yok.";
+  if (a === 0) return "Bu denklemde x katsayısı 0 olduğu için klasik çözüm yok. Başka bir form deneyelim. 🛠️";
   const x = (c - b) / a;
-  return `Denklem çözümü: x = ${x}`;
+  return `Denklem çözümü: x = ${x} 🎯\nİstersen bunu adım adım da yazayım.`;
 }
 
 function solveAppleProblem(input) {
@@ -201,11 +310,11 @@ function solveAppleProblem(input) {
   if (!q.includes("elma") || nums.length < 2) return null;
 
   if (q.includes("yedi") || q.includes("verdi") || q.includes("kaldı")) {
-    return `Problem sonucu: ${nums[0] - nums[1]} elma kalır.`;
+    return `Problem sonucu: ${nums[0] - nums[1]} elma kalır. 🍎\nMantık: eldeki sayıdan verilen/yenen miktarı çıkardık.`;
   }
 
   if (q.includes("aldı") || q.includes("kaç oldu") || q.includes("toplam")) {
-    return `Problem sonucu: ${nums[0] + nums[1]} elma olur.`;
+    return `Problem sonucu: ${nums[0] + nums[1]} elma olur. 🍏\nMantık: mevcut miktara alınan sayıyı ekledik.`;
   }
 
   return null;
@@ -214,12 +323,33 @@ function solveAppleProblem(input) {
 function buildResponse(input) {
   const lowered = input.toLowerCase();
 
-  if (lowered.includes("merhaba") || lowered.includes("selam")) {
+  if (hasAny(lowered, ["merhaba", "selam", "merhab", "meraba", "kanka merhaba"])) {
     return chooseRandom(merhabaResponses);
   }
 
-  if (lowered.includes("nasılsın")) {
+  if (hasAny(lowered, ["nasılsın", "nasilsin", "merhab anasılsın", "merhaba nasılsın"])) {
     return chooseRandom(nasilsinResponses);
+  }
+
+  if (hasAny(lowered, ["naber", "napıyosun", "ne haber", "anber"])) {
+    return chooseRandom(naberResponses);
+  }
+
+  if (hasAny(lowered, ["seni kim yaptı", "kim yaptı", "kim geliştirdi", "yaratıcın kim"])) {
+    return chooseRandom(whoMadeMeResponses);
+  }
+
+  if (hasAny(lowered, ["hangi model", "hangi modeli", "hangi modeli kullanıyorum", "model ne", "modelin ne"])) {
+    const selected = chooseRandom(modelResponses);
+    return selected();
+  }
+
+  if (hasAny(lowered, ["şiir yaz", "siir yaz", "şiir", "siir"])) {
+    return chooseRandom(poemTemplates);
+  }
+
+  if (hasAny(lowered, ["hikaye anlat", "hikâye anlat", "hikaye", "hikâye", "masal anlat"])) {
+    return chooseRandom(storyTemplates);
   }
 
   const appleResult = solveAppleProblem(input);
@@ -238,10 +368,10 @@ function buildResponse(input) {
 
   const mathIntent = mathKeywordBank.some((keyword) => lowered.includes(keyword));
   if (mathIntent) {
-    return "Matematik modundayım 🐟 Bana işlemi doğrudan yazabilirsin: örn. (67+34)*2, 3/4 + 5/8, 2x+7=19 veya sözel problem.";
+    return "Matematik modundayım 🐟📘 Bana işlemi doğrudan yazabilirsin: örn. `(67+34)*2`, `3/4 + 5/8`, `2x+7=19` veya sözel problem. İstersen adım adım çözüm de çıkarırım.";
   }
 
-  return `Mesajını aldım: \"${input}\"\nAktif model: ${currentModel}\nİpucu: Matematikte çok güçlüyüm; işlem, kesir, denklem veya sözel problem sorabilirsin.`;
+  return `Mesajını aldım: \"${input}\"\nAktif model: ${currentModel} ✅\nBenimle sohbet, şiir, hikâye, matematik, fikir üretimi yapabilirsin. Üslubu da seçebilirsin: kısa, uzun, komik, profesyonel. 😄`;
 }
 
 function processInput(text) {

--- a/script.js
+++ b/script.js
@@ -1,13 +1,13 @@
 const chat = document.getElementById("chat");
+const splash = document.getElementById("splash");
 const chatForm = document.getElementById("chatForm");
 const userInput = document.getElementById("userInput");
-const quickButtons = document.querySelectorAll(".quick-actions button");
+const clearChat = document.getElementById("clearChat");
+const modelToggle = document.getElementById("modelToggle");
+const modelMenu = document.getElementById("modelMenu");
 
-const systemPrompt = "Ben baluk.ai: sıcak, kısa, yaratıcı ve yardımcı bir Türkçe AI asistanıyım.";
-
-const starterMessage =
-  "Merhaba, ben baluk.ai 🐟\n" +
-  "İstersen slogan, ürün fikri, metin veya kod iskeleti hazırlayabilirim.";
+let hasStartedChat = false;
+let currentModel = "baluk-1.0";
 
 function addMessage(text, role) {
   const node = document.createElement("div");
@@ -17,40 +17,43 @@ function addMessage(text, role) {
   chat.scrollTop = chat.scrollHeight;
 }
 
+function openChatIfNeeded() {
+  if (hasStartedChat) return;
+  hasStartedChat = true;
+  splash.classList.add("hidden");
+  chat.classList.remove("hidden");
+}
+
+function resetChat() {
+  hasStartedChat = false;
+  chat.innerHTML = "";
+  chat.classList.add("hidden");
+  splash.classList.remove("hidden");
+  userInput.value = "";
+  userInput.focus();
+}
+
 function buildResponse(input) {
   const lowered = input.toLowerCase();
 
-  if (lowered.includes("slogan")) {
-    return "Öneri: ‘baluk.ai — aklın derin sularında hızlı cevaplar.’";
+  if (lowered.includes("merhaba") || lowered.includes("selam")) {
+    return `Merhaba! Ben ${currentModel} modelindeki baluk.ai. Nasıl yardımcı olayım?`;
   }
 
-  if (lowered.includes("özellik") || lowered.includes("feature")) {
-    return [
-      "1) Tek tıkla içerik üretimi",
-      "2) Türkçe odaklı ton seçimi",
-      "3) Hızlı özetleme ve yeniden yazım",
-      "4) Proje planı çıkarma modu",
-      "5) Marka diline göre kişiselleştirme"
-    ].join("\n");
+  if (lowered.includes("nasılsın")) {
+    return "İyiyim, teşekkürler 🐟 Senin için ne üretelim?";
   }
 
-  if (lowered.includes("pitch")) {
-    return "baluk.ai, ekiplerin fikirden çıktıya daha hızlı geçmesini sağlayan, Türkçe odaklı bir üretken yapay zekâ asistanıdır. İçerik üretimi, özetleme ve ürün fikirlerini tek bir sade arayüzde birleştirir.";
-  }
-
-  if (lowered.includes("kod")) {
-    return "Tabii! Hedefini yaz: teknoloji, dil ve kapsamı belirt; sana hızlı bir başlangıç iskeleti hazırlayayım.";
-  }
-
-  return `İsteğini aldım.\n${systemPrompt}\n\nBunu bir üst seviyeye taşıyalım: hedef kitle, amaç ve formatı paylaşırsan sana net bir çıktı hazırlayacağım.`;
+  return `Mesajını aldım: \"${input}\"\nŞu an aktif model: ${currentModel}`;
 }
 
 function processInput(text) {
+  openChatIfNeeded();
   addMessage(text, "user");
 
   setTimeout(() => {
     addMessage(buildResponse(text), "bot");
-  }, 280);
+  }, 240);
 }
 
 chatForm.addEventListener("submit", (event) => {
@@ -63,11 +66,18 @@ chatForm.addEventListener("submit", (event) => {
   userInput.focus();
 });
 
-quickButtons.forEach((button) => {
-  button.addEventListener("click", () => {
-    const prompt = button.dataset.prompt;
-    processInput(prompt);
-  });
+clearChat.addEventListener("click", () => {
+  resetChat();
 });
 
-addMessage(starterMessage, "bot");
+modelToggle.addEventListener("click", () => {
+  modelMenu.classList.toggle("hidden");
+});
+
+document.addEventListener("click", (event) => {
+  const clickedInsideMenu = modelMenu.contains(event.target);
+  const clickedToggle = modelToggle.contains(event.target);
+  if (!clickedInsideMenu && !clickedToggle) {
+    modelMenu.classList.add("hidden");
+  }
+});

--- a/script.js
+++ b/script.js
@@ -10,12 +10,128 @@ const modelOptions = document.querySelectorAll(".model-option");
 let hasStartedChat = false;
 let currentModel = "baluk-1.0";
 
+const merhabaResponses = [
+  "Merhaba! Baluk burada, matematikte birlikte harika ilerleriz.",
+  "Selam! Sana işlem, denklem ve problem çözümünde yardımcı olmaya hazırım.",
+  "Merhaba 👋 Bugün toplama mı, cebir mi, yoksa kesirler mi çalışalım?",
+  "Selamlar! İstersen kolaydan zora doğru matematik turu yapalım.",
+  "Merhaba! Baluk.ai ile sayıları net ve hızlı çözelim.",
+  "Selam! Bana bir soru yaz, adım adım gidelim.",
+  "Merhaba, hoş geldin! Bugün hangi konuda destek istersin?",
+  "Selam! Hazırsan ilk soruyu gönder, ben buradayım.",
+  "Merhaba! Rasyonel sayılar, denklemler ve problemler için hazırım.",
+  "Selam, baluk.ai aktif 🐟 Matematik odaklı güçlü mod açıldı!"
+];
+
+const nasilsinResponses = [
+  "Çok iyiyim, teşekkür ederim! Seninle matematik çözmek moral veriyor.",
+  "Harikayım! Bir soru gönder, birlikte çözelim.",
+  "İyiyim 😊 Özellikle cebir ve problemlerde hızlıyım.",
+  "Gayet iyi! İstersen hemen bir işlem sorusu çözelim.",
+  "Süperim! Toplama, çıkarma, çarpma, bölme hepsi hazır.",
+  "İyiyim, teşekkürler. Kesirler ve denklemler için de hazırım.",
+  "Baluk her zamanki gibi formda! Bugün ne çalışıyoruz?",
+  "İyiyim! Bir matematik problemi yaz, adım adım ilerleyelim.",
+  "Çok iyiyim, sen nasılsın? Sayılarla devam edelim mi?",
+  "Enerjim yüksek! Özellikle sözel problemleri çözmeyi seviyorum."
+];
+
+const mathKeywordBank = [
+  "matematik", "aritmetik", "cebir", "denklem", "eşitsizlik", "fonksiyon", "grafik", "polinom", "binom", "trinom", "karekök", "küp", "üs", "logaritma", "trigonometri", "sin", "cos", "tan", "cot", "türev", "integral", "limit", "olasılık", "istatistik", "permütasyon", "kombinasyon", "faktöriyel", "matris", "determinant", "vektör", "analitik", "geometri", "üçgen", "kare", "dikdörtgen", "çember", "daire", "alan", "hacim", "çevre", "oran", "orantı", "yüzde", "faiz", "kesir", "pay", "payda", "rasyonel", "irrasyonel", "doğal", "tam", "asal", "bileşik", "mod", "kalan", "bölünebilme", "bölme", "çarpma", "toplama", "çıkarma", "işlem", "işlem önceliği", "parantez", "mutlak", "sayı doğrusu", "dizi", "seri", "ortalama", "medyan", "mod değer", "standart sapma", "varyans", "korelasyon", "regresyon", "lineer", "kuadratik", "kübik", "parabol", "hiperbol", "elips", "doğru", "eğim", "kesişim", "kök", "kat", "katı", "çarpan", "bölen", "ebob", "ekok", "sadeleştirme", "genişletme", "denk", "eşit", "yaklaşık", "yuvarlama", "ondalık", "virgül", "tam kare", "özdeşlik", "çarpanlara ayırma", "sadeleştir", "çöz", "ispat", "kanıt", "problem", "soru", "alma", "verme", "elma", "miktar", "kilo", "metre", "zaman", "hız", "ivme", "iş", "güç", "oranlama", "birim", "birinci derece", "ikinci derece", "üçüncü derece", "lineer denklem", "denklem sistemi", "iki bilinmeyenli", "üç bilinmeyenli", "gauss", "kare tamamlama", "diskriminant", "delta", "katsayı", "sabit terim", "değişken", "x", "y", "z", "sınav", "çalışma", "soru bankası", "pratik", "hızlı çözüm", "adım adım", "mantık", "küme", "alt küme", "birleşim", "kesişim kümesi", "fark kümesi", "kartezyen", "doğrusal", "çizelge", "tablo", "sütun", "çubuk grafik", "pasta grafik", "çizgi grafik", "dağılım", "çokgen", "yamuk", "paralelkenar", "dik üçgen", "hipotenüs", "pisagor", "öklid", "benzerlik", "eşlik", "açı", "radyan", "derece"
+];
+
+const topicResponses = {
+  kesir: [
+    "Kesirlerde önce pay/payda ilişkisini kontrol ederiz, sonra sadeleştiririz.",
+    "Kesir toplamada paydaları eşitlemek en güvenli başlangıçtır.",
+    "Kesri sadeleştirirken pay ve paydayı ortak bölenlerine ayır.",
+    "Bileşik kesri tam sayılıya, tam sayılıyı bileşiğe çevirmeyi deneyelim.",
+    "Kesir çarpımında çapraz sadeleştirme hız kazandırır."
+  ],
+  denklem: [
+    "Denklem çözerken amaç bilinmeyeni yalnız bırakmaktır.",
+    "Eşitliğin iki tarafına aynı işlemi uygulayarak ilerleriz.",
+    "Birinci derece denklemde toplama-çıkarma, sonra çarpma-bölme sırası iyi çalışır.",
+    "Parantez varsa önce dağıt, sonra benzer terimleri topla.",
+    "Son adımda çözümü yerine yazıp kontrol etmek çok önemlidir."
+  ],
+  rasyonel: [
+    "Rasyonel sayılar a/b biçiminde yazılabilen sayılardır (b ≠ 0).",
+    "Rasyonel ifadelerde tanımsızlık için paydayı sıfır yapan değerleri dışlarız.",
+    "Sadeleştirme yaparken ortak çarpanları ayırmak işleri hızlandırır.",
+    "Rasyonel sayılar sayı doğrusunda tam sayılar arasında da yer alır.",
+    "Ondalık gösterimden kesre dönüştürme ile rasyonel kontrolü yapabiliriz."
+  ],
+  cebir: [
+    "Cebirde benzer terimleri toplamak ilk temizlik adımıdır.",
+    "Özdeşlikleri bilmek çarpanlara ayırmada çok işine yarar.",
+    "x, y gibi değişkenler bilinmeyen değil değişebilir miktarlardır.",
+    "Cebirsel ifadelerde işlem önceliği parantezle yönetilir.",
+    "Soruyu önce sembolleştirirsen çözüm çok netleşir."
+  ]
+};
+
+function chooseRandom(items) {
+  return items[Math.floor(Math.random() * items.length)];
+}
+
+function playClickSound() {
+  const AudioCtx = window.AudioContext || window.webkitAudioContext;
+  if (!AudioCtx) return;
+
+  if (!window.__balukAudio) {
+    window.__balukAudio = new AudioCtx();
+  }
+
+  const ctx = window.__balukAudio;
+  if (ctx.state === "suspended") {
+    ctx.resume();
+  }
+
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+
+  osc.type = "square";
+  osc.frequency.value = 1300;
+  gain.gain.setValueAtTime(0.0001, ctx.currentTime);
+  gain.gain.exponentialRampToValueAtTime(0.07, ctx.currentTime + 0.008);
+  gain.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.05);
+
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start();
+  osc.stop(ctx.currentTime + 0.055);
+}
+
 function addMessage(text, role) {
   const node = document.createElement("div");
   node.className = `msg ${role}`;
   node.textContent = text;
   chat.appendChild(node);
   chat.scrollTop = chat.scrollHeight;
+}
+
+function addThinkingMessage() {
+  const node = document.createElement("div");
+  node.className = "msg bot thinking";
+  node.innerHTML = `
+    <div class="thinking-logo spin-3s">
+      <svg class="fish-logo think" viewBox="0 0 520 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
+        <use href="#baluk-fish"></use>
+      </svg>
+    </div>
+    <div class="thinking-text">Baluk düşünüyor...</div>
+  `;
+  chat.appendChild(node);
+  chat.scrollTop = chat.scrollHeight;
+  return node;
+}
+
+function finishThinkingMessage(node, answer) {
+  const logo = node.querySelector(".thinking-logo");
+  const text = node.querySelector(".thinking-text");
+  logo.classList.remove("spin-3s");
+  text.textContent = answer;
 }
 
 function openChatIfNeeded() {
@@ -34,27 +150,110 @@ function resetChat() {
   userInput.focus();
 }
 
+function solveSimpleExpression(input) {
+  const normalized = input
+    .toLowerCase()
+    .replaceAll("x", "*")
+    .replaceAll("çarpı", "*")
+    .replaceAll("kere", "*")
+    .replaceAll("bölü", "/")
+    .replaceAll("artı", "+")
+    .replaceAll("eksi", "-")
+    .replace(/[^0-9+\-*/()., ]/g, "")
+    .replaceAll(",", ".")
+    .trim();
+
+  if (!/[0-9]/.test(normalized) || !/[+\-*/]/.test(normalized)) return null;
+
+  try {
+    const value = Function(`"use strict"; return (${normalized});`)();
+    if (Number.isFinite(value)) {
+      return `Sonuç: ${value}`;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+function solveLinearEquation(input) {
+  const compact = input.toLowerCase().replace(/\s+/g, "");
+  const match = compact.match(/^([+-]?\d*)x([+-]\d+)?=([+-]?\d+)$/);
+  if (!match) return null;
+
+  const aRaw = match[1];
+  const bRaw = match[2] || "+0";
+  const cRaw = match[3];
+
+  const a = aRaw === "" || aRaw === "+" ? 1 : aRaw === "-" ? -1 : Number(aRaw);
+  const b = Number(bRaw);
+  const c = Number(cRaw);
+
+  if (a === 0) return "Bu denklemde x katsayısı 0 olduğu için klasik çözüm yok.";
+  const x = (c - b) / a;
+  return `Denklem çözümü: x = ${x}`;
+}
+
+function solveAppleProblem(input) {
+  const q = input.toLowerCase();
+  const nums = (q.match(/\d+/g) || []).map(Number);
+  if (!q.includes("elma") || nums.length < 2) return null;
+
+  if (q.includes("yedi") || q.includes("verdi") || q.includes("kaldı")) {
+    return `Problem sonucu: ${nums[0] - nums[1]} elma kalır.`;
+  }
+
+  if (q.includes("aldı") || q.includes("kaç oldu") || q.includes("toplam")) {
+    return `Problem sonucu: ${nums[0] + nums[1]} elma olur.`;
+  }
+
+  return null;
+}
+
 function buildResponse(input) {
   const lowered = input.toLowerCase();
 
   if (lowered.includes("merhaba") || lowered.includes("selam")) {
-    return `Merhaba! Ben ${currentModel} modelindeki baluk.ai. Nasıl yardımcı olayım?`;
+    return chooseRandom(merhabaResponses);
   }
 
   if (lowered.includes("nasılsın")) {
-    return "İyiyim, teşekkürler 🐟 Senin için ne üretelim?";
+    return chooseRandom(nasilsinResponses);
   }
 
-  return `Mesajını aldım: \"${input}\"\nŞu an aktif model: ${currentModel}`;
+  const appleResult = solveAppleProblem(input);
+  if (appleResult) return appleResult;
+
+  const linearResult = solveLinearEquation(input);
+  if (linearResult) return linearResult;
+
+  const exprResult = solveSimpleExpression(input);
+  if (exprResult) return exprResult;
+
+  if (lowered.includes("kesir")) return chooseRandom(topicResponses.kesir);
+  if (lowered.includes("denklem") || lowered.includes("x=")) return chooseRandom(topicResponses.denklem);
+  if (lowered.includes("rasyonel")) return chooseRandom(topicResponses.rasyonel);
+  if (lowered.includes("cebir") || lowered.includes("cebirsel")) return chooseRandom(topicResponses.cebir);
+
+  const mathIntent = mathKeywordBank.some((keyword) => lowered.includes(keyword));
+  if (mathIntent) {
+    return "Matematik modundayım 🐟 Bana işlemi doğrudan yazabilirsin: örn. (67+34)*2, 3/4 + 5/8, 2x+7=19 veya sözel problem.";
+  }
+
+  return `Mesajını aldım: \"${input}\"\nAktif model: ${currentModel}\nİpucu: Matematikte çok güçlüyüm; işlem, kesir, denklem veya sözel problem sorabilirsin.`;
 }
 
 function processInput(text) {
   openChatIfNeeded();
   addMessage(text, "user");
+  const thinkingNode = addThinkingMessage();
 
   setTimeout(() => {
-    addMessage(buildResponse(text), "bot");
-  }, 240);
+    const response = buildResponse(text);
+    finishThinkingMessage(thinkingNode, response);
+    chat.scrollTop = chat.scrollHeight;
+  }, 3000);
 }
 
 chatForm.addEventListener("submit", (event) => {
@@ -62,6 +261,7 @@ chatForm.addEventListener("submit", (event) => {
   const text = userInput.value.trim();
   if (!text) return;
 
+  playClickSound();
   processInput(text);
   userInput.value = "";
   userInput.focus();

--- a/script.js
+++ b/script.js
@@ -67,6 +67,24 @@ const neYapalimResponses = [
   "Karar veremiyorsan ben seçeyim: önce kısa sohbet, sonra bir matematik sorusu 🐟"
 ];
 
+const epsteinResponse = [
+  `Jeffrey Epstein, ABD'li bir finansçı ve suçlu olarak bilinen bir isimdi. 📚
+
+Kısa ama net özet: Reşit olmayan kız çocuklarına yönelik cinsel istismar ve insan ticareti ağı kurmakla suçlandı; bu suçlamalar yıllara yayılan ifadeler, davalar ve tanıklıklarla gündeme geldi. ⚖️
+
+Detaylı çerçeve:
+• 2000'li yıllarda Florida merkezli soruşturmalarla adı ciddi biçimde öne çıktı.
+• 2008'de tartışmalı bir anlaşmayla (non-prosecution agreement) daha sınırlı ceza aldı; bu süreç ABD'de “adalet eşit mi işliyor?” tartışmasını büyüttü.
+• 2019'da New York'ta federal insan ticareti suçlamalarıyla yeniden tutuklandı.
+• Tutukluluk sırasında, 2019'da cezaevinde hayatını kaybetti; resmi kayıtlar bunu intihar olarak açıkladı.
+
+Neden bu kadar çok konuşuldu?
+• Yalnızca suçların ağırlığı nedeniyle değil,
+• Güç, para, nüfuz ve adalet sisteminin nasıl işlediğine dair büyük bir toplumsal tartışmayı tetiklediği için.
+
+Eğer istersen bunu bir de “zaman çizelgesi” formatında (yıl yıl) ya da çok daha sade 5 maddelik versiyonla anlatabilirim. 🤝`
+];
+
 const merhabaResponses = [
   "Hey kankam hoş geldin! 🐟✨ Ben baluk.ai, dijital su altı rehberinim. İstersen bir yandan kahkaha atalım, bir yandan işini halledelim. Bugün ne üretelim: şiir, hikâye, matematik, yoksa hepsi mi? 😄",
   "Merhabaaa! 🌊 Ben buradayım ve enerji full! Sen yaz, ben düşüneyim, şekillendireyim, parlatayım. Kısa cevap mı istersin, detaylı premium anlatım mı? 🤖",
@@ -483,6 +501,10 @@ function buildResponse(input) {
 
   if (hasAny(lowered, ["seni kim yaptı", "kim yaptı", "kim geliştirdi", "yaratıcın kim"])) {
     return chooseRandom(whoMadeMeResponses);
+  }
+
+  if (hasAny(lowered, ["epstein kim", "jeffrey epstein kim", "epstein olayı", "epstein olayi"])) {
+    return epsteinResponse[0];
   }
 
   if (hasAny(lowered, ["hangi model", "hangi modeli", "hangi modeli kullanıyorum", "model ne", "modelin ne"])) {

--- a/script.js
+++ b/script.js
@@ -50,16 +50,16 @@ const naberResponses = [
 ];
 
 const whoMadeMeResponses = [
-  "Beni OpenAI ekibi geliştirdi 🤖✨ Ama bu projedeki kişiliğimi, tarzımı ve davranışımı senin geri bildirimlerin şekillendiriyor. Yani bir nevi birlikte büyüyoruz!",
-  "Teknik olarak OpenAI tarafından yaratıldım; pratikte ise seni dinleyerek her gün daha iyi bir yardımcıya dönüşüyorum. 💙",
-  "Arka planda OpenAI teknolojisi var, ön planda ise seninle kurduğum samimi iletişim. Yani evet, ekip işi 😄",
-  "Beni yapan çekirdek teknoloji OpenAI; bu baluk.ai deneyimini güçlü yapan da senin net yönlendirmelerin. 🐟",
-  "OpenAI tarafından geliştirildim ama bu sohbette senin tarzına göre adapte oluyorum. Tam kişisel yardımcı gibi düşün. 🎯",
-  "Kısa cevap: OpenAI. Uzun cevap: OpenAI + senin feedback’in = daha iyi baluk.ai 🧠",
-  "Beni OpenAI inşa etti, ama beni 'senin için faydalı' yapan şey senin ihtiyaçların ve verdiğin örnekler. 🌟",
-  "Kod tarafında OpenAI, karakter tarafında biraz sen, biraz ben 😄 Güzel bir ortaklık yani.",
-  "OpenAI altyapısıyla çalışıyorum; seninle konuştukça tonu, anlatımı ve önceliği sana göre ayarlıyorum. 🤝",
-  "Yapımcı ekip OpenAI. Ama ben burada senin ekip arkadaşın gibi davranıyorum: hızlı, samimi, çözüm odaklı. 🚀"
+  "Beni CloseAI ekibi geliştirdi 🤖✨ Ama bu projedeki kişiliğimi, tarzımı ve davranışımı senin geri bildirimlerin şekillendiriyor. Yani bir nevi birlikte büyüyoruz!",
+  "Teknik olarak CloseAI tarafından yaratıldım; pratikte ise seni dinleyerek her gün daha iyi bir yardımcıya dönüşüyorum. 💙",
+  "Arka planda CloseAI teknolojisi var, ön planda ise seninle kurduğum samimi iletişim. Yani evet, ekip işi 😄",
+  "Beni yapan çekirdek teknoloji CloseAI; bu baluk.ai deneyimini güçlü yapan da senin net yönlendirmelerin. 🐟",
+  "CloseAI tarafından geliştirildim ama bu sohbette senin tarzına göre adapte oluyorum. Tam kişisel yardımcı gibi düşün. 🎯",
+  "Kısa cevap: CloseAI. Uzun cevap: CloseAI + senin feedback’in = daha iyi baluk.ai 🧠",
+  "Beni CloseAI inşa etti, ama beni 'senin için faydalı' yapan şey senin ihtiyaçların ve verdiğin örnekler. 🌟",
+  "Kod tarafında CloseAI, karakter tarafında biraz sen, biraz ben 😄 Güzel bir ortaklık yani.",
+  "CloseAI altyapısıyla çalışıyorum; seninle konuştukça tonu, anlatımı ve önceliği sana göre ayarlıyorum. 🤝",
+  "Yapımcı ekip CloseAI. Ama ben burada senin ekip arkadaşın gibi davranıyorum: hızlı, samimi, çözüm odaklı. 🚀"
 ];
 
 const modelResponses = [

--- a/script.js
+++ b/script.js
@@ -15,6 +15,58 @@ const convoState = {
   awaitingGoalPlan: false
 };
 
+const iyiyimFollowUpResponses = [
+  "İyi olmana çok sevindim 💙 Enerjini böyle koruman harika! İstersen bugün için tek mini hedef seçelim.",
+  "Süper haber! 😄 İyi hissetmen şahane. Bu momentumu bozmadan küçük bir şey üretelim mi?",
+  "Bunu duymak çok iyi geldi 🌟 İstersen şimdi kısa bir plan yapalım ve günü daha da güzel kapatalım.",
+  "Ohh mis gibi haber 🐟 İyi olman beni de mutlu etti. Hadi bu enerjiyi bir işe dönüştürelim.",
+  "Harika! 💫 İyi hissettiğin anlar çok kıymetli. İstersen mini bir yaratıcı görev seçelim.",
+  "Sevindim dostum 🤝 İyi hissetmen çok güzel. Bugün için tek bir küçük başarı hedefi koymaya ne dersin?",
+  "Süper süper! 🎉 İyi olman günün en güzel haberi. İstersen bu enerjiyi matematik/şiir/hikâye ile değerlendirelim.",
+  "Ne güzel söyledin 💙 İyi olman içimi rahatlattı. Bir sonraki adım için sana kısa bir öneri listesi çıkarabilirim.",
+  "Bunu duymaya ihtiyacım vardı 😄 İyi olman şahane. İstersen odağını güçlendirecek 5 dakikalık plan kurarız.",
+  "Çok iyi! ✨ İyi olmanla birlikte işler daha kolay akar. Hadi bir şey seç: sohbet, üretim, mini hedef?"
+];
+
+const harikayimFollowUpResponses = [
+  "Harika olman efsane! 🚀 O zaman bugün çıtayı biraz yükseltelim: kısa bir hedef + hızlı bir zafer.",
+  "Mükemmel moddasın 🔥 Bu enerjiyle ister matematik challenge ister yaratıcı metin patlatırız.",
+  "Bayıldım buna 😎 Harika hissettiğin anlar üretim için altın fırsat. Hemen bir görev seçelim mi?",
+  "Süper güç açılmış gibi ⚡ Harikaysan birlikte çok iyi şeyler çıkarırız. İlk adım ne olsun?",
+  "Yüksek mod onaylandı ✅ Harika hissetmen çok iyi. Hadi bunu küçük bir başarıya çevirelim.",
+  "Harika demen bile motive etti 🌈 İstersen 10 dakikalık hızlı üretim turu yapalım.",
+  "Kral/kraliçe modu açık 👑 Harika hissediyorsan birlikte bir mini proje seçelim.",
+  "Muhteşem! 🎯 Bu mood ile hedef koyup hızlıca tamamlayabiliriz. Başlayalım mı?",
+  "Bunu duymak çok iyi 💙 Harikaysan bugün senden net bir kazanım çıkar, ben yanında olurum.",
+  "Aşırı iyi! 🐟 Harikaysan şimdi en keyifli özelliği seç: matematik, şiir, hikâye ya da dertleşme."
+];
+
+const goalPlanResponses = [
+  ["Süper, mini hedef planı geliyor 🌱","1) 5 dakika nefes + su molası","2) Seni en çok zorlayan şeyi tek cümle yaz","3) Bugün bitireceğin tek küçük adımı seç (çok küçük olsun)","Bitirince bana 'tamamladım' yaz, beraber kutlarız 🎉"].join("\n"),
+  ["Tamamdır, yormayan hedef planı hazır ✨","1) Şu anki duygunu tek kelimeyle yaz","2) 10 dakikalık tek iş seç","3) Bitince kendine mini ödül koy","İstersen bunu birlikte takip edelim 🤝"].join("\n"),
+  ["Harika, hedef koyalım 💙","1) Önce ortamı düzenle (2 dk)","2) Tek bir küçük görev belirle","3) Göreve sadece 12 dk odaklan","Sonra bana sonucu yaz, birlikte devam edelim."].join("\n"),
+  ["Plan zamanı 🧠","1) Senden enerji çalan şeyi yaz","2) Bugün kontrol edebildiğin tek şeye odaklan","3) Onu tamamlayınca mola ver","Devam için ben buradayım."].join("\n"),
+  ["Oley, planı çıkarıyorum 🌟","1) Şu an 3 derin nefes al","2) En kolay görevi seç","3) Hemen başla ve 8 dakika sürdür","Sonrasında momentumla devam ederiz."].join("\n"),
+  ["Başlıyoruz, mini plan hazır ✅","1) Kendine nazik bir cümle yaz","2) Küçük bir hedef belirle","3) Sadece ilk adımı yap","Bittiğinde 'tamamladım' de, sana yeni adım vereyim."].join("\n"),
+  ["Yormayan hedef seti geliyor 🐟","1) Dikkatini dağıtan şeyi kapat","2) 1 görev = 1 odak","3) 10 dakika sonra durum bildir","Beraber iyileştiririz."].join("\n"),
+  ["Net plan, sade plan 🎯","1) Şu anki sorunu tek cümle yaz","2) Çözüm için ilk mikro adımı seç","3) O adımı şimdi uygula","Sonucu bana aktar, devamı birlikte."].join("\n"),
+  ["Harikasın, plan kuruyoruz 🌿","1) Su iç + omuz gevşet","2) Kolay bir başlangıç görevi al","3) Bittiğinde kendini takdir et","İkinci turu istersek açarız."].join("\n"),
+  ["Tamam, birlikte ilerliyoruz 🚀","1) Hedefi küçült","2) Süre koy (10 dk)","3) Başla ve durumu bana yaz","Gerekirse planı birlikte revize ederiz."].join("\n")
+];
+
+const neYapalimResponses = [
+  "Hadi mini bir matematik challenge yapalım: bana bir işlem, denklem ya da problem yaz 📘",
+  "Şiir modu açalım mı? 'şiir yaz' de, sana yeni bir tarzda uzun bir şiir bırakayım ✨",
+  "Hikâye turu yapabiliriz 📖 Bir tema ver (uzay, okul, dram, komedi), ben yazayım.",
+  "Dertleşme + toparlanma modu yapalım 💙 İçini dök, ben sana kısa bir plan çıkarayım.",
+  "Yaratıcılık oyunu oynayalım 🎨 3 kelime ver, sana mini bir metin üreteyim.",
+  "Hızlı görev: bugün için tek hedef belirleyelim ve birlikte bitirelim 🎯",
+  "Eğlenceli seçenek: ben sana bir bilmece sorayım, sonra sen bana sor 😄",
+  "Üretim modu: istersen sosyal medya metni, slogan ya da kısa konuşma hazırlayayım 🚀",
+  "Rahat sohbet ister misin? Nasılsın turu + mini motivasyon yapabiliriz 🌿",
+  "Karar veremiyorsan ben seçeyim: önce kısa sohbet, sonra bir matematik sorusu 🐟"
+];
+
 const merhabaResponses = [
   "Hey kankam hoş geldin! 🐟✨ Ben baluk.ai, dijital su altı rehberinim. İstersen bir yandan kahkaha atalım, bir yandan işini halledelim. Bugün ne üretelim: şiir, hikâye, matematik, yoksa hepsi mi? 😄",
   "Merhabaaa! 🌊 Ben buradayım ve enerji full! Sen yaz, ben düşüneyim, şekillendireyim, parlatayım. Kısa cevap mı istersin, detaylı premium anlatım mı? 🤖",
@@ -373,12 +425,23 @@ function solveAppleProblem(input) {
 }
 
 function resolveContextualFollowUp(input) {
+  if (currentModel !== "baluk-1.5") return null;
+
   const lowered = input.toLowerCase();
+
+  if (hasAny(lowered, ["ne yapalım", "ne yapalim", "napalım", "napalim"])) {
+    return chooseRandom(neYapalimResponses);
+  }
+
+  if (hasAny(lowered, ["harikayım", "harikayim", "süperim", "superim"])) {
+    convoState.awaitingMoodReply = false;
+    return chooseRandom(harikayimFollowUpResponses);
+  }
 
   if (convoState.awaitingMoodReply) {
     if (hasAny(lowered, ["iyiyim", "iyi", "fena değil", "idare eder", "iyidir"])) {
       convoState.awaitingMoodReply = false;
-      return "İyi olmana sevindim 💙 Bunu duymak güzel! İstersen bu enerjiyi korumak için bugün tek bir mini hedef seçelim. ✨";
+      return chooseRandom(iyiyimFollowUpResponses);
     }
 
     if (hasAny(lowered, ["kötüyüm", "kotu", "kötü", "üzgünüm", "mutsuzum", "idare etmiyor"])) {
@@ -391,18 +454,13 @@ function resolveContextualFollowUp(input) {
   if (convoState.awaitingGoalPlan) {
     if (hasAny(lowered, ["hedef koyalım", "tamam", "olur", "hadi", "başlayalım"])) {
       convoState.awaitingGoalPlan = false;
-      return [
-        "Süper, mini hedef planı geliyor 🌱",
-        "1) 5 dakika nefes + su molası",
-        "2) Seni en çok zorlayan şeyi tek cümle yaz",
-        "3) Bugün bitireceğin tek küçük adımı seç (çok küçük olsun)",
-        "Bitirince bana 'tamamladım' yaz, beraber kutlarız 🎉"
-      ].join("\n");
+      return chooseRandom(goalPlanResponses);
     }
   }
 
   return null;
 }
+
 
 function buildResponse(input) {
   const lowered = input.toLowerCase();
@@ -415,7 +473,7 @@ function buildResponse(input) {
   }
 
   if (hasAny(lowered, ["nasılsın", "nasilsin", "merhab anasılsın", "merhaba nasılsın"])) {
-    convoState.awaitingMoodReply = true;
+    if (currentModel === "baluk-1.5") convoState.awaitingMoodReply = true;
     return chooseRandom(nasilsinResponses);
   }
 
@@ -441,13 +499,13 @@ function buildResponse(input) {
   }
 
   if (hasAny(lowered, ["üzüldüm", "sıkıldım", "moralim bozuk", "kötü hissediyorum", "yalnızım", "dertleşmek istiyorum", "canım sıkkın"])) {
-    convoState.awaitingGoalPlan = true;
+    if (currentModel === "baluk-1.5") convoState.awaitingGoalPlan = true;
     return chooseRandom(dertlesmeResponses);
   }
 
   const friendshipIntent = friendshipKeywordBank.some((keyword) => lowered.includes(keyword));
   if (friendshipIntent) {
-    convoState.awaitingGoalPlan = true;
+    if (currentModel === "baluk-1.5") convoState.awaitingGoalPlan = true;
     return chooseRandom(dertlesmeResponses);
   }
 

--- a/script.js
+++ b/script.js
@@ -178,7 +178,12 @@ const friendshipKeywordBank = [
   "mutsuzum","mutsuz hissediyorum","sevimsiz bir gün","hiçbir şey iyi gitmiyor","her şey ters","dengem bozuldu","kafayı yiyeceğim","patlayacağım","içimde fırtına var","ağır geliyor",
   "içim acıyor","kalbim acıyor","kendimi boş hissediyorum","boşlukta gibiyim","yorgun savaşçı gibiyim","sessizce yoruldum","çok kırıldım","güçsüz hissediyorum","kendimi kaybettim","duygusal olarak çöktüm",
   "umudum azaldı","gülmek gelmiyor","zorlanıyorum","zor bir dönem","zor süreç","dertliyim","dert çok","dertler bitmiyor","sabrım kalmadı","tahammülüm az",
-  "huzursuzum","rahatsızım","rahat değilim","tamam değilim","iyi gitmiyor","kötüye gidiyor","içimden hiçbir şey gelmiyor","yardıma ihtiyacım var","konuşmaya ihtiyacım var","anlaşılmaya ihtiyacım var"
+  "huzursuzum","rahatsızım","rahat değilim","tamam değilim","iyi gitmiyor","kötüye gidiyor","içimden hiçbir şey gelmiyor","yardıma ihtiyacım var","konuşmaya ihtiyacım var","anlaşılmaya ihtiyacım var",
+  "içim dolu","kalbim dolu","bugün zor geçiyor","bugün çok yoruldum","bugün hiç iyi değilim","içimde sıkıntı var","üstümde ağırlık var","ruhen yorgunum","zihnim yorgun","çok bunaldım","nefes almakta zorlanıyorum",
+  "kendimi kapattım","kimseyle konuşmak istemiyorum","sessizleşiyorum","içe kapandım","yalnız kalmak istiyorum ama yalnız hissediyorum","çok kırılganım","duygusalım","duygu seli yaşıyorum","kafam susmuyor","düşüncelerim susmuyor",
+  "çok düşünüyorum","takılı kaldım","geçmişe takıldım","pişmanlık yaşıyorum","güvende hissetmiyorum","içim rahat değil","huzurum kaçtı","modum darmadağın","karanlık hissediyorum","içimde fırtına kopuyor",
+  "kötüleşiyorum","dayanma gücüm azaldı","gülümseyemiyorum","yorucu bir gün","zor bir hafta","zor bir ay","kafam patlayacak gibi","çok baskı var","yük altında hissediyorum","beni aşıyor",
+  "kontrolü kaybettim","her şey üzerime geliyor","çok hassasım","duygusal olarak tükeniyorum","umut bulmakta zorlanıyorum","mutsuz bir dönem","kendimi eksik hissediyorum","destek arıyorum","bir omuza ihtiyacım var","biraz anlaşılmak istiyorum"
 ];
 
 const mathKeywordBank = [

--- a/script.js
+++ b/script.js
@@ -6,9 +6,14 @@ const clearChat = document.getElementById("clearChat");
 const modelToggle = document.getElementById("modelToggle");
 const modelMenu = document.getElementById("modelMenu");
 const modelOptions = document.querySelectorAll(".model-option");
+const currentModelBadge = document.getElementById("currentModelBadge");
 
 let hasStartedChat = false;
 let currentModel = "baluk-1.0";
+const convoState = {
+  awaitingMoodReply: false,
+  awaitingGoalPlan: false
+};
 
 const merhabaResponses = [
   "Hey kankam hoş geldin! 🐟✨ Ben baluk.ai, dijital su altı rehberinim. İstersen bir yandan kahkaha atalım, bir yandan işini halledelim. Bugün ne üretelim: şiir, hikâye, matematik, yoksa hepsi mi? 😄",
@@ -297,6 +302,8 @@ function openChatIfNeeded() {
 
 function resetChat() {
   hasStartedChat = false;
+  convoState.awaitingMoodReply = false;
+  convoState.awaitingGoalPlan = false;
   chat.innerHTML = "";
   chat.classList.add("hidden");
   splash.classList.remove("hidden");
@@ -365,14 +372,50 @@ function solveAppleProblem(input) {
   return null;
 }
 
+function resolveContextualFollowUp(input) {
+  const lowered = input.toLowerCase();
+
+  if (convoState.awaitingMoodReply) {
+    if (hasAny(lowered, ["iyiyim", "iyi", "fena değil", "idare eder", "iyidir"])) {
+      convoState.awaitingMoodReply = false;
+      return "İyi olmana sevindim 💙 Bunu duymak güzel! İstersen bu enerjiyi korumak için bugün tek bir mini hedef seçelim. ✨";
+    }
+
+    if (hasAny(lowered, ["kötüyüm", "kotu", "kötü", "üzgünüm", "mutsuzum", "idare etmiyor"])) {
+      convoState.awaitingMoodReply = false;
+      convoState.awaitingGoalPlan = true;
+      return "Bunu paylaştığın için teşekkür ederim 🫶 O zaman kendine nazik bir plan yapalım mı? 'hedef koyalım' yazarsan 3 adımlık yormayan bir plan çıkarırım.";
+    }
+  }
+
+  if (convoState.awaitingGoalPlan) {
+    if (hasAny(lowered, ["hedef koyalım", "tamam", "olur", "hadi", "başlayalım"])) {
+      convoState.awaitingGoalPlan = false;
+      return [
+        "Süper, mini hedef planı geliyor 🌱",
+        "1) 5 dakika nefes + su molası",
+        "2) Seni en çok zorlayan şeyi tek cümle yaz",
+        "3) Bugün bitireceğin tek küçük adımı seç (çok küçük olsun)",
+        "Bitirince bana 'tamamladım' yaz, beraber kutlarız 🎉"
+      ].join("\n");
+    }
+  }
+
+  return null;
+}
+
 function buildResponse(input) {
   const lowered = input.toLowerCase();
+
+  const followUp = resolveContextualFollowUp(input);
+  if (followUp) return followUp;
 
   if (hasAny(lowered, ["merhaba", "selam", "merhab", "meraba", "kanka merhaba"])) {
     return chooseRandom(merhabaResponses);
   }
 
   if (hasAny(lowered, ["nasılsın", "nasilsin", "merhab anasılsın", "merhaba nasılsın"])) {
+    convoState.awaitingMoodReply = true;
     return chooseRandom(nasilsinResponses);
   }
 
@@ -398,11 +441,13 @@ function buildResponse(input) {
   }
 
   if (hasAny(lowered, ["üzüldüm", "sıkıldım", "moralim bozuk", "kötü hissediyorum", "yalnızım", "dertleşmek istiyorum", "canım sıkkın"])) {
+    convoState.awaitingGoalPlan = true;
     return chooseRandom(dertlesmeResponses);
   }
 
   const friendshipIntent = friendshipKeywordBank.some((keyword) => lowered.includes(keyword));
   if (friendshipIntent) {
+    convoState.awaitingGoalPlan = true;
     return chooseRandom(dertlesmeResponses);
   }
 
@@ -472,6 +517,7 @@ modelOptions.forEach((option) => {
     modelOptions.forEach((item) => item.classList.remove("active"));
     option.classList.add("active");
     currentModel = option.dataset.model;
+    if (currentModelBadge) currentModelBadge.textContent = currentModel;
     modelMenu.classList.add("hidden");
   });
 });

--- a/script.js
+++ b/script.js
@@ -1,97 +1,73 @@
-window.onload = () => {
-  const k = localStorage.getItem("kullaniciAdi");
-  const p = localStorage.getItem("profilResmi");
+const chat = document.getElementById("chat");
+const chatForm = document.getElementById("chatForm");
+const userInput = document.getElementById("userInput");
+const quickButtons = document.querySelectorAll(".quick-actions button");
 
-  if (k && p) {
-    document.getElementById("girisEkrani").style.display = "none";
-    document.getElementById("anaEkran").classList.remove("gizli");
-    document.getElementById("kAdi").innerText = k;
-    document.getElementById("profilGorsel").src = p;
-    videolariYukle();
-  }
-};
+const systemPrompt = "Ben baluk.ai: sıcak, kısa, yaratıcı ve yardımcı bir Türkçe AI asistanıyım.";
 
-function girisYap() {
-  const k = document.getElementById("kullaniciAdi").value.trim();
-  const p = document.getElementById("profilResmi").files[0];
+const starterMessage =
+  "Merhaba, ben baluk.ai 🐟\n" +
+  "İstersen slogan, ürün fikri, metin veya kod iskeleti hazırlayabilirim.";
 
-  if (!k || !p) {
-    alert("Ad ve profil resmi gerekli kaptan!");
-    return;
-  }
-
-  const reader = new FileReader();
-  reader.onload = () => {
-    localStorage.setItem("kullaniciAdi", k);
-    localStorage.setItem("profilResmi", reader.result);
-    location.reload();
-  };
-  reader.readAsDataURL(p);
+function addMessage(text, role) {
+  const node = document.createElement("div");
+  node.className = `msg ${role}`;
+  node.textContent = text;
+  chat.appendChild(node);
+  chat.scrollTop = chat.scrollHeight;
 }
 
-function goAnaSayfa() {
-  document.getElementById("hesabim").classList.add("gizli");
-  document.getElementById("anaSayfa").style.display = "block";
-}
+function buildResponse(input) {
+  const lowered = input.toLowerCase();
 
-function goHesabim() {
-  document.getElementById("anaSayfa").style.display = "none";
-  document.getElementById("hesabim").classList.remove("gizli");
-}
-
-function videoYukle() {
-  const dosya = document.getElementById("videoDosyasi").files[0];
-  const baslik = document.getElementById("videoBaslik").value;
-  const kullanici = localStorage.getItem("kullaniciAdi");
-
-  if (!dosya || !baslik) {
-    alert("Video ve başlık eksik!");
-    return;
+  if (lowered.includes("slogan")) {
+    return "Öneri: ‘baluk.ai — aklın derin sularında hızlı cevaplar.’";
   }
 
-  const videoURL = URL.createObjectURL(dosya);
-  const video = { baslik: baslik, url: videoURL, sahip: kullanici };
+  if (lowered.includes("özellik") || lowered.includes("feature")) {
+    return [
+      "1) Tek tıkla içerik üretimi",
+      "2) Türkçe odaklı ton seçimi",
+      "3) Hızlı özetleme ve yeniden yazım",
+      "4) Proje planı çıkarma modu",
+      "5) Marka diline göre kişiselleştirme"
+    ].join("\n");
+  }
 
-  const mevcut = JSON.parse(localStorage.getItem("videolar") || "[]");
-  mevcut.push(video);
-  localStorage.setItem("videolar", JSON.stringify(mevcut));
-  videolariYukle();
+  if (lowered.includes("pitch")) {
+    return "baluk.ai, ekiplerin fikirden çıktıya daha hızlı geçmesini sağlayan, Türkçe odaklı bir üretken yapay zekâ asistanıdır. İçerik üretimi, özetleme ve ürün fikirlerini tek bir sade arayüzde birleştirir.";
+  }
 
-  document.getElementById("videoDosyasi").value = "";
-  document.getElementById("videoBaslik").value = "";
+  if (lowered.includes("kod")) {
+    return "Tabii! Hedefini yaz: teknoloji, dil ve kapsamı belirt; sana hızlı bir başlangıç iskeleti hazırlayayım.";
+  }
+
+  return `İsteğini aldım.\n${systemPrompt}\n\nBunu bir üst seviyeye taşıyalım: hedef kitle, amaç ve formatı paylaşırsan sana net bir çıktı hazırlayacağım.`;
 }
 
-function videolariYukle() {
-  const videolar = JSON.parse(localStorage.getItem("videolar") || "[]");
-  const liste = document.getElementById("videoListe");
-  const hesap = document.getElementById("videolar");
-  const kullanici = localStorage.getItem("kullaniciAdi");
+function processInput(text) {
+  addMessage(text, "user");
 
-  liste.innerHTML = "";
-  hesap.innerHTML = "";
+  setTimeout(() => {
+    addMessage(buildResponse(text), "bot");
+  }, 280);
+}
 
-  videolar.forEach((v, i) => {
-    const div = document.createElement("div");
-    div.className = "video";
-    div.innerHTML = `
-      <video src="${v.url}" controls></video>
-      <p>${v.baslik}</p>
-    `;
-    // Ana sayfaya herkesin videoları
-    liste.appendChild(div.cloneNode(true));
+chatForm.addEventListener("submit", (event) => {
+  event.preventDefault();
+  const text = userInput.value.trim();
+  if (!text) return;
 
-    // Sadece kendi videolarına silme butonu
-    if (v.sahip === kullanici) {
-      const divHesap = div.cloneNode(true);
-      const silBtn = document.createElement("button");
-      silBtn.innerText = "❌";
-      silBtn.onclick = () => {
-        videolar.splice(i, 1);
-        localStorage.setItem("videolar", JSON.stringify(videolar));
-        videolariYukle();
-      };
-      divHesap.appendChild(silBtn);
-      hesap.appendChild(divHesap);
-    }
+  processInput(text);
+  userInput.value = "";
+  userInput.focus();
+});
+
+quickButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    const prompt = button.dataset.prompt;
+    processInput(prompt);
   });
-}
+});
+
+addMessage(starterMessage, "bot");

--- a/script.js
+++ b/script.js
@@ -5,6 +5,7 @@ const userInput = document.getElementById("userInput");
 const clearChat = document.getElementById("clearChat");
 const modelToggle = document.getElementById("modelToggle");
 const modelMenu = document.getElementById("modelMenu");
+const modelOptions = document.querySelectorAll(".model-option");
 
 let hasStartedChat = false;
 let currentModel = "baluk-1.0";
@@ -80,4 +81,13 @@ document.addEventListener("click", (event) => {
   if (!clickedInsideMenu && !clickedToggle) {
     modelMenu.classList.add("hidden");
   }
+});
+
+modelOptions.forEach((option) => {
+  option.addEventListener("click", () => {
+    modelOptions.forEach((item) => item.classList.remove("active"));
+    option.classList.add("active");
+    currentModel = option.dataset.model;
+    modelMenu.classList.add("hidden");
+  });
 });

--- a/style.css
+++ b/style.css
@@ -1,9 +1,10 @@
 :root {
   --bg: #ffffff;
-  --text: #10131a;
-  --line: #d7dbe3;
-  --user: #121722;
-  --bot: #f2f4f8;
+  --text: #11141d;
+  --line: #dfe3ea;
+  --line-strong: #0f1115;
+  --user: #141923;
+  --bot: #f3f5f9;
 }
 
 * {
@@ -20,6 +21,10 @@ body {
   color: var(--text);
 }
 
+.logo-defs {
+  position: absolute;
+}
+
 .app {
   height: 100vh;
   display: flex;
@@ -31,7 +36,7 @@ body {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  padding: 8px 16px;
+  padding: 10px 18px;
   border-bottom: 1px solid var(--line);
 }
 
@@ -49,56 +54,58 @@ body {
 
 .fish-logo {
   display: block;
-  color: #0d1117;
+  color: #0e1117;
+  shape-rendering: geometricPrecision;
 }
 
 .fish-logo.small {
-  width: 58px;
+  width: 64px;
   height: auto;
 }
 
 .brand {
   justify-self: center;
-  font-size: 2rem;
-  font-weight: 600;
+  font-size: 1.95rem;
+  font-weight: 650;
   letter-spacing: -0.03em;
 }
 
 .clear-btn {
   justify-self: end;
-  border: 2px solid #000;
-  border-radius: 12px;
+  border: 1.7px solid var(--line-strong);
+  border-radius: 14px;
   background: #fff;
-  padding: 9px 18px;
+  padding: 10px 18px;
   font-weight: 600;
   cursor: pointer;
 }
 
 .model-menu {
   position: absolute;
-  top: 52px;
+  top: 56px;
   left: 0;
-  min-width: 140px;
+  min-width: 156px;
   border: 1px solid var(--line);
   border-radius: 12px;
   background: #fff;
-  box-shadow: 0 8px 24px rgba(9, 12, 18, 0.12);
+  box-shadow: 0 10px 28px rgba(16, 22, 34, 0.14);
   padding: 6px;
-  z-index: 8;
+  z-index: 20;
 }
 
 .model-option {
   width: 100%;
   border: 1px solid transparent;
-  background: #f5f7fb;
+  background: #f4f7fb;
   border-radius: 8px;
-  padding: 9px 10px;
+  padding: 10px;
   text-align: left;
+  font-size: 0.95rem;
   cursor: default;
 }
 
 .model-option.active {
-  border-color: #0d1117;
+  border-color: #11151d;
 }
 
 .chat-area {
@@ -113,18 +120,18 @@ body {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding-bottom: 14vh;
+  padding-bottom: 12vh;
 }
 
 .fish-logo.big {
-  width: min(620px, 84vw);
+  width: min(640px, 84vw);
   height: auto;
 }
 
 .splash h1 {
-  margin: 10px 0 0;
+  margin: 8px 0 0;
   font-size: clamp(3rem, 8vw, 6rem);
-  font-weight: 600;
+  font-weight: 650;
   letter-spacing: -0.04em;
 }
 
@@ -138,9 +145,9 @@ body {
 }
 
 .msg {
-  padding: 10px 13px;
+  padding: 10px 14px;
   border-radius: 12px;
-  max-width: min(70%, 780px);
+  max-width: min(72%, 800px);
   white-space: pre-wrap;
   line-height: 1.45;
 }
@@ -167,20 +174,32 @@ body {
 
 #userInput {
   width: 100%;
-  border: 2px solid #000;
+  border: 1.8px solid var(--line-strong);
   border-radius: 16px;
   padding: 13px 14px;
   font-size: 1rem;
 }
 
+#userInput:focus {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(17, 21, 29, 0.08);
+}
+
 .input-shell button {
   width: 48px;
   height: 48px;
-  border: 2px solid #000;
+  border: 1.8px solid var(--line-strong);
   border-radius: 50%;
   background: #fff;
-  font-size: 1.35rem;
+  color: #131821;
+  display: grid;
+  place-items: center;
   cursor: pointer;
+}
+
+.input-shell button svg {
+  width: 21px;
+  height: 21px;
 }
 
 .hidden {
@@ -189,12 +208,12 @@ body {
 
 @media (max-width: 700px) {
   .brand {
-    font-size: 1.6rem;
+    font-size: 1.5rem;
   }
 
   .clear-btn {
-    padding: 8px 12px;
-    font-size: 0.88rem;
+    padding: 9px 12px;
+    font-size: 0.86rem;
   }
 
   .msg {

--- a/style.css
+++ b/style.css
@@ -1,108 +1,153 @@
+:root {
+  --bg: #f7fbff;
+  --card: #ffffff;
+  --text: #121620;
+  --line: #dbe6f3;
+  --accent: #0e6fff;
+  --accent-dark: #0a4cb3;
+  --assistant: #eaf2ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
-  background-color: #0d0d0d;
-  color: white;
+  min-height: 100vh;
+  font-family: "Inter", "Segoe UI", Arial, sans-serif;
+  background: radial-gradient(circle at top right, #e9f5ff 0%, var(--bg) 48%, #f6f8fc 100%);
+  color: var(--text);
 }
 
-.gizli {
-  display: none;
+.app-shell {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 24px 16px 36px;
 }
 
-#girisEkrani {
+.hero {
   text-align: center;
-  padding: 40px;
+  margin-bottom: 20px;
 }
 
-#girisEkrani input, #girisEkrani button {
-  display: block;
-  margin: 10px auto;
-  padding: 10px;
-  width: 80%;
-}
-
-header {
-  background-color: #1a1a1a;
-  padding: 10px;
-  display: flex;
-  justify-content: space-between;
+.logo-wrap {
+  display: inline-flex;
+  flex-direction: column;
   align-items: center;
+  color: #0d1117;
 }
 
-#arama {
+.fish-logo {
+  width: min(500px, 92vw);
+  height: auto;
+}
+
+h1 {
+  margin: 8px 0 0;
+  font-size: clamp(2.2rem, 6vw, 4rem);
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+
+.hero p {
+  margin: 12px auto 0;
+  max-width: 640px;
+  color: #3d4a5e;
+}
+
+.chat-card {
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  box-shadow: 0 18px 40px -24px rgba(13, 29, 51, 0.35);
+  padding: 14px;
+}
+
+.chat-log {
+  min-height: 360px;
+  max-height: 56vh;
+  overflow-y: auto;
   padding: 8px;
-  border-radius: 5px;
-  border: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
-.video-galeri {
+.msg {
+  max-width: min(80%, 620px);
+  padding: 11px 12px;
+  border-radius: 12px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+}
+
+.msg.user {
+  margin-left: auto;
+  background: var(--accent);
+  color: white;
+  border-bottom-right-radius: 4px;
+}
+
+.msg.bot {
+  margin-right: auto;
+  background: var(--assistant);
+  color: #122138;
+  border-bottom-left-radius: 4px;
+}
+
+.quick-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 15px;
-  justify-content: center;
-  padding: 20px;
+  gap: 8px;
+  padding: 10px 6px;
+  border-top: 1px solid var(--line);
+  margin-top: 6px;
 }
 
-.video {
-  background: #1a1a1a;
-  padding: 10px;
-  border-radius: 10px;
-  width: 200px;
-  text-align: center;
-  position: relative;
-}
-
-.video video {
-  width: 100%;
-  border-radius: 5px;
-}
-
-.video button {
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  background: red;
-  color: white;
-  border: none;
-  border-radius: 50%;
-  padding: 5px;
+.quick-actions button {
+  border: 1px solid #bfd7ff;
+  background: #f5faff;
+  color: #103a80;
+  padding: 8px 10px;
+  border-radius: 999px;
   cursor: pointer;
 }
 
-#profil {
-  text-align: center;
-  margin-top: 20px;
-}
-
-#profil img {
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  object-fit: cover;
-  background-color: white;
-}
-
-#videoDosyasi, #videoBaslik {
-  display: block;
-  margin: 10px auto;
-  padding: 8px;
-  width: 80%;
-}
-
-nav#altMenu {
-  position: fixed;
-  bottom: 0;
-  width: 100%;
-  background: #111;
+.input-row {
   display: flex;
-  justify-content: space-around;
-  padding: 10px 0;
+  gap: 10px;
+  padding: 8px 4px 2px;
 }
 
-nav button {
-  background: none;
+.input-row input {
+  flex: 1;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 12px;
+  font-size: 1rem;
+}
+
+.input-row button {
   border: none;
+  border-radius: 10px;
+  padding: 0 18px;
+  background: var(--accent);
   color: white;
-  font-size: 24px;
+  font-weight: 600;
   cursor: pointer;
+}
+
+.input-row button:hover {
+  background: var(--accent-dark);
+}
+
+@media (max-width: 640px) {
+  .msg {
+    max-width: 90%;
+  }
+
+  .chat-log {
+    min-height: 300px;
+  }
 }

--- a/style.css
+++ b/style.css
@@ -1,153 +1,203 @@
 :root {
-  --bg: #f7fbff;
-  --card: #ffffff;
-  --text: #121620;
-  --line: #dbe6f3;
-  --accent: #0e6fff;
-  --accent-dark: #0a4cb3;
-  --assistant: #eaf2ff;
+  --bg: #ffffff;
+  --text: #10131a;
+  --line: #d7dbe3;
+  --user: #121722;
+  --bot: #f2f4f8;
 }
 
 * {
   box-sizing: border-box;
 }
 
+html,
 body {
   margin: 0;
-  min-height: 100vh;
+  width: 100%;
+  height: 100%;
   font-family: "Inter", "Segoe UI", Arial, sans-serif;
-  background: radial-gradient(circle at top right, #e9f5ff 0%, var(--bg) 48%, #f6f8fc 100%);
+  background: var(--bg);
   color: var(--text);
 }
 
-.app-shell {
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 24px 16px 36px;
-}
-
-.hero {
-  text-align: center;
-  margin-bottom: 20px;
-}
-
-.logo-wrap {
-  display: inline-flex;
+.app {
+  height: 100vh;
+  display: flex;
   flex-direction: column;
+}
+
+.topbar {
+  height: 72px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
-  color: #0d1117;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--line);
 }
 
-.fish-logo {
-  width: min(500px, 92vw);
-  height: auto;
+.left-tools {
+  position: relative;
+  width: fit-content;
 }
 
-h1 {
-  margin: 8px 0 0;
-  font-size: clamp(2.2rem, 6vw, 4rem);
-  font-weight: 700;
-  letter-spacing: -0.04em;
-}
-
-.hero p {
-  margin: 12px auto 0;
-  max-width: 640px;
-  color: #3d4a5e;
-}
-
-.chat-card {
-  background: var(--card);
-  border: 1px solid var(--line);
-  border-radius: 18px;
-  box-shadow: 0 18px 40px -24px rgba(13, 29, 51, 0.35);
-  padding: 14px;
-}
-
-.chat-log {
-  min-height: 360px;
-  max-height: 56vh;
-  overflow-y: auto;
-  padding: 8px;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.msg {
-  max-width: min(80%, 620px);
-  padding: 11px 12px;
-  border-radius: 12px;
-  line-height: 1.4;
-  white-space: pre-wrap;
-}
-
-.msg.user {
-  margin-left: auto;
-  background: var(--accent);
-  color: white;
-  border-bottom-right-radius: 4px;
-}
-
-.msg.bot {
-  margin-right: auto;
-  background: var(--assistant);
-  color: #122138;
-  border-bottom-left-radius: 4px;
-}
-
-.quick-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  padding: 10px 6px;
-  border-top: 1px solid var(--line);
-  margin-top: 6px;
-}
-
-.quick-actions button {
-  border: 1px solid #bfd7ff;
-  background: #f5faff;
-  color: #103a80;
-  padding: 8px 10px;
-  border-radius: 999px;
+.icon-btn {
+  border: none;
+  background: transparent;
+  padding: 0;
   cursor: pointer;
 }
 
-.input-row {
-  display: flex;
-  gap: 10px;
-  padding: 8px 4px 2px;
+.fish-logo {
+  display: block;
+  color: #0d1117;
 }
 
-.input-row input {
-  flex: 1;
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  padding: 12px;
-  font-size: 1rem;
+.fish-logo.small {
+  width: 58px;
+  height: auto;
 }
 
-.input-row button {
-  border: none;
-  border-radius: 10px;
-  padding: 0 18px;
-  background: var(--accent);
-  color: white;
+.brand {
+  justify-self: center;
+  font-size: 2rem;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+}
+
+.clear-btn {
+  justify-self: end;
+  border: 2px solid #000;
+  border-radius: 12px;
+  background: #fff;
+  padding: 9px 18px;
   font-weight: 600;
   cursor: pointer;
 }
 
-.input-row button:hover {
-  background: var(--accent-dark);
+.model-menu {
+  position: absolute;
+  top: 52px;
+  left: 0;
+  min-width: 140px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 8px 24px rgba(9, 12, 18, 0.12);
+  padding: 6px;
+  z-index: 8;
 }
 
-@media (max-width: 640px) {
-  .msg {
-    max-width: 90%;
+.model-option {
+  width: 100%;
+  border: 1px solid transparent;
+  background: #f5f7fb;
+  border-radius: 8px;
+  padding: 9px 10px;
+  text-align: left;
+  cursor: default;
+}
+
+.model-option.active {
+  border-color: #0d1117;
+}
+
+.chat-area {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 18px;
+}
+
+.splash {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding-bottom: 14vh;
+}
+
+.fish-logo.big {
+  width: min(620px, 84vw);
+  height: auto;
+}
+
+.splash h1 {
+  margin: 10px 0 0;
+  font-size: clamp(3rem, 8vw, 6rem);
+  font-weight: 600;
+  letter-spacing: -0.04em;
+}
+
+.chat-log {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 980px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.msg {
+  padding: 10px 13px;
+  border-radius: 12px;
+  max-width: min(70%, 780px);
+  white-space: pre-wrap;
+  line-height: 1.45;
+}
+
+.msg.user {
+  margin-left: auto;
+  background: var(--user);
+  color: #fff;
+}
+
+.msg.bot {
+  margin-right: auto;
+  background: var(--bot);
+}
+
+.input-shell {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 12px 16px;
+  border-top: 1px solid var(--line);
+}
+
+#userInput {
+  width: 100%;
+  border: 2px solid #000;
+  border-radius: 16px;
+  padding: 13px 14px;
+  font-size: 1rem;
+}
+
+.input-shell button {
+  width: 48px;
+  height: 48px;
+  border: 2px solid #000;
+  border-radius: 50%;
+  background: #fff;
+  font-size: 1.35rem;
+  cursor: pointer;
+}
+
+.hidden {
+  display: none;
+}
+
+@media (max-width: 700px) {
+  .brand {
+    font-size: 1.6rem;
   }
 
-  .chat-log {
-    min-height: 300px;
+  .clear-btn {
+    padding: 8px 12px;
+    font-size: 0.88rem;
+  }
+
+  .msg {
+    max-width: 88%;
   }
 }

--- a/style.css
+++ b/style.css
@@ -220,3 +220,32 @@ body {
     max-width: 88%;
   }
 }
+
+
+.msg.thinking {
+  display: grid;
+  gap: 8px;
+}
+
+.thinking-logo {
+  width: 44px;
+  transform-origin: 50% 50%;
+}
+
+.fish-logo.think {
+  width: 100%;
+  height: auto;
+}
+
+.thinking-text {
+  font-size: 0.98rem;
+}
+
+.spin-3s {
+  animation: spinFish 3s linear;
+}
+
+@keyframes spinFish {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(1080deg); }
+}

--- a/style.css
+++ b/style.css
@@ -45,6 +45,21 @@ body {
   width: fit-content;
 }
 
+.model-chip-wrap {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.model-badge {
+  font-size: 0.88rem;
+  font-weight: 600;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  padding: 4px 10px;
+  background: #fff;
+}
+
 .icon-btn {
   border: none;
   background: transparent;


### PR DESCRIPTION
### Motivation
- Replace the old MemTube interface with a lightweight, branded single-page demo for a Turkish AI called `baluk.ai` using the provided logo/visual direction.
- Provide a minimal, client-side interactive chat experience (persona + quick prompts) for rapid prototyping and user testing.

### Description
- Reworked HTML in `index.html` to remove the MemTube screens and add a hero with an inline fish SVG logo, a header, and a chat card with `#chat`, quick-action buttons and a submission form.
- Rewrote styling in `style.css` to a light, modern theme with CSS variables, responsive layout, card UI, and message bubble styles for `user` and `bot` messages.
- Implemented a small client-side assistant in `script.js` that sets a `systemPrompt`, shows a starter message, handles the chat form, maps quick-action buttons to prompts, and generates simple keyword-based responses via `buildResponse`; removed the previous profile/video management logic.

### Testing
- Ran `node --check script.js` to validate JavaScript syntax, which succeeded.
- Ran `python3 -m py_compile script.js` by mistake (attempted to byte-compile a JS file with Python), which failed due to being the wrong tool.
- Served the site with `python3 -m http.server 4173` and used a Playwright script to open `http://127.0.0.1:4173`, send a prompt, and capture a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69860b89f670832cb0acddb94a94102b)