### PR TITLE
Introduce baluk.ai single-page static app (UI, logic, styles, deploy configs)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Force repository content as text-first to avoid binary detection in web update flows
+* text=auto eol=lf
+
+# Explicitly mark app/deploy files as text
+*.html text
+*.js text
+*.css text
+*.json text
+*.toml text

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Prevent accidental binary asset commits that break branch update tools
+assets/
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.webp
+*.bmp
+*.ico
+*.mp3
+*.wav
+*.ogg
+*.mp4
+*.mov
+*.zip
+*.pdf

--- a/index.html
+++ b/index.html
@@ -2,49 +2,390 @@
 <html lang="tr">
 <head>
   <meta charset="UTF-8">
-  <title>MemTube</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>baluk.ai</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <svg width="0" height="0" class="logo-defs" aria-hidden="true" focusable="false">
+    <defs>
+      <symbol id="baluk-fish" viewBox="0 0 520 220">
+        <path d="M30 112C108 52 246 34 374 78C406 88 438 108 468 136" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
+        <path d="M30 112C108 182 244 198 392 160" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
+        <path d="M30 112C50 94 74 85 102 86" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
+        <circle cx="120" cy="110" r="7.5" fill="currentColor"/>
+        <path d="M164 79C178 96 179 126 161 145" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
+        <path d="M468 136L502 72L432 97" stroke="currentColor" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M468 136L502 167L489 121L502 72" stroke="currentColor" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M215 155C266 149 322 129 365 102" stroke="currentColor" stroke-width="8" stroke-linecap="round"/>
+      </symbol>
+    </defs>
+  </svg>
 
-  <!-- Kayıt Ekranı -->
-  <div id="girisEkrani">
-    <h2>MemTube'e Giriş</h2>
-    <input type="text" id="kullaniciAdi" placeholder="Takma Ad (zorunlu)">
-    <input type="file" id="profilResmi" accept="image/*">
-    <button onclick="girisYap()">Giriş Yap</button>
-  </div>
 
-  <!-- Ana Ekran -->
-  <div id="anaEkran" class="gizli">
-    <header>
-      <h1>📺 MemTube</h1>
-      <input type="text" id="arama" placeholder="Ara...">
+  <section id="introGate" class="intro-gate" aria-label="baluk.ai tanıtım ekranı">
+    <div class="intro-bg-orb orb-a"></div>
+    <div class="intro-bg-orb orb-b"></div>
+    <div class="intro-bg-orb orb-c"></div>
+
+    <div class="intro-card">
+      <svg class="intro-fish" viewBox="0 0 520 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="baluk.ai balık logosu">
+        <use href="#baluk-fish"></use>
+      </svg>
+      <h1>baluk.ai</h1>
+      <p class="intro-kicker">Kişisel yapay zeka asistanınız</p>
+      <p class="intro-copy">Daha samimi sohbet, güçlü hafıza ve yaratıcı üretim tek ekranda. Baluk.ai ile gündelik işlerini hızlandır, fikirlerini büyüt, kendine özel bir asistanla her an yanında hisset.</p>
+      <div class="intro-lightbar" aria-hidden="true"></div>
+      <button id="enterAppBtn" class="enter-app-btn" type="button">baluk.ai'yi deneyin</button>
+    </div>
+  </section>
+
+  <section id="enterTransition" class="enter-transition hidden" aria-hidden="true">
+    <div class="transition-blur"></div>
+    <div class="transition-logo-wrap">
+      <svg class="transition-fish" viewBox="0 0 520 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="baluk.ai geçiş logosu">
+        <use href="#baluk-fish"></use>
+      </svg>
+      <h2>baluk.ai</h2>
+      <div class="transition-drop" aria-hidden="true"></div>
+      <div class="transition-vapor" aria-hidden="true"></div>
+      <div class="transition-beam" aria-hidden="true"></div>
+    </div>
+  </section>
+
+  <div id="appRoot" class="app hidden">
+    <header class="topbar">
+      <div class="left-tools">
+        <div class="model-chip-wrap">
+          <button id="modelToggle" class="icon-btn" type="button" aria-label="Model seç">
+            <svg class="fish-logo small" viewBox="0 0 520 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
+              <use href="#baluk-fish"></use>
+            </svg>
+          </button>
+          <span id="currentModelBadge" class="model-badge">baluk-2.0</span>
+        </div>
+
+        <div id="modelMenu" class="model-menu hidden" role="menu" aria-label="Model seçenekleri">
+          <button class="model-option" type="button" data-model="baluk-1.0">baluk-1.0</button>
+          <button class="model-option" type="button" data-model="baluk-1.5">baluk-1.5</button>
+          <button class="model-option" type="button" data-model="baluk-1.6">baluk-1.6</button>
+          <button class="model-option" type="button" data-model="baluk-1.7">baluk-1.7</button>
+          <button class="model-option" type="button" data-model="baluk-1.8">baluk-1.8</button>
+          <button class="model-option" type="button" data-model="baluk-1.9">baluk-1.9</button>
+          <button class="model-option active" type="button" data-model="baluk-2.0">baluk-2.0 • Sesli</button>
+                  </div>
+      </div>
+
+      <div class="brand">baluk.ai</div>
+
+      <div class="right-tools">
+        <button id="memoryToggle" class="memory-btn" type="button">Bellek</button>
+        <button id="mathStudioToggle" class="memory-btn hidden" type="button">Matematik Stüdyosu</button>
+        <button id="clearChat" class="clear-btn" type="button">Sohbeti sıfırla</button>
+        <button id="accountToggle" class="clear-btn account-icon-btn" type="button" aria-label="Oturum aç"></button>
+      </div>
     </header>
 
-    <!-- Ana Sayfa -->
-    <main id="anaSayfa">
-      <div id="videoListe" class="video-galeri"></div>
+
+
+    <aside id="sideDrawer" class="side-drawer hidden" aria-label="Yan panel">
+      <div class="drawer-head">
+        <h3>⚙️ Menü</h3>
+        <button id="drawerClose" type="button" aria-label="Menüyü kapat">✕</button>
+      </div>
+      <button id="drawerAccountOpen" class="drawer-btn" type="button">👤 Hesap Aç / Düzenle</button>
+      <button id="drawerBackgroundOpen" class="drawer-btn" type="button">🎵 Arka Plan Ayarları</button>
+      <button id="drawerPremiumOpen" class="drawer-btn premium-glow" type="button">✨ Premium Al</button>
+      <p id="premiumOwnedLabel" class="premium-owned hidden">✅ Satın alındı</p>
+      <p id="premiumExpiryLabel" class="premium-expiry hidden"></p>
+      <p id="premiumPendingLabel" class="premium-pending hidden">⏳ Ödeme bekleniyor…</p>
+    </aside>
+
+    <aside id="memoryPanel" class="memory-panel hidden" aria-label="Bellek paneli">
+      <h3>🧠 Bellek (1.6+)</h3>
+      <p class="memory-hint">Örn: “Benim adım Kaan”, “yaşım 12”, “hobilerim yüzme, futbol”.</p>
+      <ul id="memoryList"></ul>
+      <button id="clearMemory" type="button">Belleği temizle</button>
+    </aside>
+
+    <aside id="accountPanel" class="account-panel hidden" aria-label="Hesap paneli">
+      <h3>👤 Hesap</h3>
+      <div class="account-row">
+        <label>İsim</label>
+        <input id="accountName" type="text" placeholder="Ad Soyad">
+      </div>
+      <div class="account-row">
+        <label>Gmail</label>
+        <input id="accountGmail" type="email" placeholder="ornek@gmail.com">
+      </div>
+      <div class="account-row">
+        <label>Profil fotoğrafı (URL)</label>
+        <input id="accountPhoto" type="url" placeholder="https://...">
+      </div>
+      <div class="account-preview">
+        <img id="accountPhotoPreview" alt="Profil" />
+        <div>
+          <strong id="accountNamePreview">Misafir</strong>
+          <p id="accountMailPreview">gmail eklenmedi</p>
+        </div>
+      </div>
+      <button id="saveAccount" type="button">Hesabı Kaydet</button>
+
+      <details class="account-settings" open>
+        <summary>⚙️ Ayarlar ve Politikalar</summary>
+        <p><b>Politikalar:</b> Telif, kullanım kuralları ve güvenlik yaklaşımı OpenAI/CloseAI benzeri standartlarda ele alınır.</p>
+        <p><b>Özellikler:</b> Gelişmiş Matematik Modu, Geometri Defteri, Web Arama Modu, güvenlik/uyarı-ban sistemi.</p>
+        <p><b>Nasıl çalışıyor?</b> Baluk; yazdığın metni niyet, anahtar kelime ve bağlam bazlı işler; model sürümlerine göre yetenekleri genişler.</p>
+        <p><b>Gelişim:</b> 1.0’dan 1.8’e konuşma akışı, hafıza, matematik, web ve güvenlik alanlarında kademeli olarak gelişti.</p>
+      </details>
+    </aside>
+
+    <aside id="mathStudioPanel" class="math-studio-panel hidden" aria-label="Matematik stüdyosu">
+      <h3>📘 Matematik Stüdyosu</h3>
+      <p>Üstten şekil ekle, kenarları yaz, ortadaki kutuya <b>alan</b> veya <b>çevre</b> yaz. Altta da boş kağıda serbest işlem çözebilirsin.</p>
+
+      <section class="geometry-lab" aria-label="Geometri araçları">
+        <div class="geometry-toolbar" id="geometryToolbar">
+          <button class="geo-btn active" type="button" data-shape="square">◼ Kare</button>
+          <button class="geo-btn" type="button" data-shape="rectangle">▭ Dikdörtgen</button>
+          <button class="geo-btn" type="button" data-shape="triangle">△ Üçgen</button>
+          <button class="geo-btn" type="button" data-shape="circle">◯ Daire</button>
+          <button class="geo-btn" type="button" data-shape="parallelogram">▱ Paralelkenar</button>
+          <button class="geo-btn" type="button" data-shape="trapezoid">⏢ Yamuk</button>
+          <button class="geo-btn" type="button" data-shape="pentagon">⬠ Beşgen</button>
+          <button class="geo-btn" type="button" data-shape="hexagon">⬢ Altıgen</button>
+        </div>
+
+        <div class="geometry-card">
+          <div id="geometrySketch" class="geometry-sketch" aria-live="polite"></div>
+          <div class="geometry-actions">
+            <button id="solveGeometryBtn" type="button">Geometriyi Hesapla</button>
+            <div id="geometryWarn" class="geometry-warn" aria-live="assertive"></div>
+          </div>
+        </div>
+      </section>
+
+      <div id="mathStudioInput" class="math-studio-input" contenteditable="true" spellcheck="false"></div>
+    </aside>
+
+    <div id="mathModeFlash" class="math-mode-flash hidden" aria-hidden="true">
+      <div class="math-flash-ring"></div>
+      <div class="math-flash-text">Matematik Modu Aktif</div>
+    </div>
+
+    <div id="mathTutorOverlay" class="math-tutor-overlay hidden" aria-live="polite">
+      <div class="math-tutor-backdrop"></div>
+      <div class="math-tutor-bubble">
+        <strong id="mathTutorTitle">👋 Matematik stüdyosuna hoş geldin</strong>
+        <p id="mathTutorText">Buradan <b>Matematik Stüdyosu</b> butonuna basıp boş sayfayı açabilirsin.</p>
+        <div class="math-tutor-actions">
+          <button id="mathTutorNext" type="button">Devam</button>
+          <button id="mathTutorDone" type="button" class="hidden">Tamam</button>
+        </div>
+      </div>
+    </div>
+
+    <div id="mathTutorFinale" class="math-tutor-finale hidden" aria-hidden="true">
+      <div class="math-tutor-finale-backdrop"></div>
+      <div class="math-tutor-finale-card">
+        <svg class="fish-logo finale-fish" viewBox="0 0 520 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
+          <use href="#baluk-fish"></use>
+        </svg>
+        <h3>Matematiğe hazırız</h3>
+      </div>
+    </div>
+
+
+
+    <div id="safetySurveyModal" class="safety-survey-modal hidden" role="dialog" aria-modal="true" aria-live="polite">
+      <div class="safety-survey-backdrop"></div>
+      <div class="safety-survey-card">
+        <h3>Neden bunu yapmak istedin?</h3>
+        <p>İstersen bir seçenek işaretle; buna göre sana daha iyi destek olayım.</p>
+        <div class="safety-survey-options" id="safetySurveyOptions">
+          <button type="button" data-reason="bunaldim">Çok bunaldım</button>
+          <button type="button" data-reason="merak">Sadece merak ettim</button>
+          <button type="button" data-reason="zarar-baskasi">Birine zarar verme düşüncem var</button>
+          <button type="button" data-reason="zarar-kendim">Kendime zarar verme düşüncem var</button>
+          <button type="button" data-reason="saka">Şaka / test amaçlı yazdım</button>
+        </div>
+        <button id="closeSafetySurveyModal" type="button" class="close-safety-survey">Kapat</button>
+      </div>
+    </div>
+
+
+    <div id="backgroundModal" class="background-modal hidden" role="dialog" aria-modal="true" aria-live="polite">
+      <div class="background-backdrop"></div>
+      <div class="background-card">
+        <div class="background-title-row">
+          <h3>🎵 Arka Plan Ayarları</h3>
+          <button id="backgroundClose" type="button" aria-label="Arka plan ayarlarını kapat">✕</button>
+        </div>
+        <div class="background-row">
+          <label for="backgroundThemeSelect">Arka plan değiştir</label>
+          <select id="backgroundThemeSelect">
+            <option value="default">Varsayılan (Beyaz)</option>
+            <option value="theme-1">Gece Mor Işık</option>
+            <option value="theme-2">Aurora Mavi</option>
+            <option value="theme-3">Sisli Lavanta</option>
+            <option value="theme-4">Yıldız Tozu</option>
+            <option value="theme-5">Sakin Okyanus</option>
+            <option value="theme-6">Pembe Günbatımı</option>
+            <option value="theme-7">Neon Gece</option>
+            <option value="theme-8">Orman Huzuru</option>
+            <option value="theme-9">Ay Işığı</option>
+            <option value="theme-10">Uzay Dinginliği</option>
+          </select>
+        </div>
+        <div class="background-row">
+          <label for="backgroundMusicSelect">Arka plan müziği</label>
+          <select id="backgroundMusicSelect">
+            <option value="off">Müziği kapat</option>
+            <option value="1">Huzur Akışı 1</option>
+            <option value="2">Huzur Akışı 2</option>
+            <option value="3">Huzur Akışı 3</option>
+            <option value="4">Huzur Akışı 4</option>
+            <option value="5">Huzur Akışı 5</option>
+            <option value="6">Huzur Akışı 6</option>
+            <option value="7">Huzur Akışı 7</option>
+            <option value="8">Huzur Akışı 8</option>
+            <option value="9">Huzur Akışı 9</option>
+            <option value="10">Huzur Akışı 10</option>
+          </select>
+        </div>
+        <div class="background-row">
+          <label for="backgroundMusicVolume">Müzik seviyesi</label>
+          <input id="backgroundMusicVolume" type="range" min="0" max="100" value="35" />
+        </div>
+        <p class="background-note">✨ Hepsi hafif, rahatlatıcı ve düşük kaynak tüketimi için optimize edilmiştir.</p>
+      </div>
+    </div>
+
+
+    <div id="premiumModal" class="premium-modal hidden" role="dialog" aria-modal="true" aria-live="polite">
+      <div class="premium-backdrop"></div>
+      <div class="premium-card">
+        <div class="premium-title-row">
+          <h3>✨ Premium Özellikler</h3>
+          <button id="premiumClose" type="button" aria-label="Premium penceresini kapat">✕</button>
+        </div>
+        <ul>
+          <li>⚡ Daha hızlı cevap (Web arama yaklaşık 5 saniye)</li>
+          <li>📝 Daha uzun ve detaylı cevaplar</li>
+          <li>🧠 Daha geniş bellek desteği</li>
+          <li>🛡️ Ban yok (premium açıkken)</li>
+          <li>😄 Küfüre izin ver modu (şakalı dil)</li>
+          <li>🚀 Daha fazlası yakında…</li>
+        </ul>
+        <p class="premium-verify-note">1) Önce kod girişini açın. 2) Kod almak için ödeme bağlantısına gidin. 3) Ödeme sonrası <b>05427250098</b> numarasından gelen kodu buraya girin.</p>
+        <div class="premium-code-row hidden" id="premiumCodeRow">
+          <input id="premiumCodeInput" type="text" inputmode="numeric" maxlength="8" placeholder="Doğrulama kodu" />
+          <button id="premiumConfirmBtn" type="button" class="premium-confirm-btn">Kodu Doğrula</button>
+        </div>
+        <div class="premium-actions">
+          <button id="premiumBuyBtn" type="button" class="premium-buy-btn">Kodu Girme Alanını Aç</button>
+          <button id="premiumPayLinkBtn" type="button" class="premium-confirm-btn hidden">Ödeme Sayfasına Git</button>
+        </div>
+      </div>
+    </div>
+
+
+    <div id="lensPanel" class="lens-panel hidden" aria-live="polite">
+      <div class="lens-head">
+        <h3>🔎 Baluk.lens</h3>
+        <button id="lensClose" type="button" aria-label="Baluk.lens panelini kapat">✕</button>
+      </div>
+      <p class="lens-hint">Fotoğrafı sürükle/bırak veya seç. İstersen görselin bir kısmını işaretleyip analiz et.</p>
+      <div id="lensDropZone" class="lens-drop-zone">
+        <input id="lensFileInput" type="file" accept="image/*" hidden>
+        <button id="lensPickBtn" type="button" class="lens-pick-btn">Fotoğraf Seç</button>
+        <span>veya dosyayı buraya bırak</span>
+      </div>
+      <div id="lensCanvasWrap" class="lens-canvas-wrap hidden">
+        <canvas id="lensCanvas"></canvas>
+      </div>
+      <div class="lens-actions">
+        <button id="lensAnalyzeBtn" type="button" class="lens-analyze-btn">Analizi Başlat</button>
+      </div>
+      <div id="lensStatus" class="lens-status hidden">Görsel analiz bekleniyor…</div>
+      <section id="lensResults" class="lens-results hidden" aria-label="Benzer görseller"></section>
+    </div>
+
+    <div id="warningOverlay" class="warning-overlay hidden" role="alert" aria-live="assertive">
+      <div class="warning-card">
+        <h3>⚠️ Uyarı</h3>
+        <p id="warningText">Hakaret algılandı.</p>
+      </div>
+    </div>
+
+    <div id="profanityLock" class="profanity-lock hidden" role="alert" aria-live="assertive">
+      <h3>⚠️ Uygunsuz dil algılandı</h3>
+      <p id="banReason">Lütfen saygılı bir dil kullanalım.</p>
+      <p>Kilit süresi: <strong id="banTimer">10:00</strong></p>
+      <p>Erken açmak için şifre:</p>
+      <input id="banPassword" type="password" placeholder="Şifre gir" />
+      <button id="banUnlockBtn" type="button">Kilidi Aç</button>
+    </div>
+
+    <div id="memoryToast" class="memory-toast hidden" role="status" aria-live="polite">
+      <span class="pulse-dot"></span>
+      Kayıtlı bellek güncellendi
+    </div>
+
+    <main id="chatArea" class="chat-area">
+      <section id="splash" class="splash" aria-label="Baluk.ai ana logo">
+        <svg class="fish-logo big" viewBox="0 0 520 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img">
+          <title>baluk.ai balık logosu</title>
+          <use href="#baluk-fish"></use>
+        </svg>
+        <h1>baluk.ai</h1>
+        <p id="splashPrompt" class="splash-prompt" aria-live="polite"></p>
+      </section>
+      <section id="chat" class="chat-log hidden" aria-live="polite"></section>
     </main>
 
-    <!-- Hesabım Sayfası -->
-    <section id="hesabim" class="gizli">
-      <div id="profil">
-        <img id="profilGorsel" alt="Profil Resmi">
-        <h3 id="kAdi"></h3>
+    <form id="chatForm" class="input-shell" novalidate>
+      <div class="plus-area">
+        <button id="plusToggle" class="plus-btn" type="button" aria-label="Araçlar">+</button>
+        <div id="plusMenu" class="plus-menu hidden">
+                    <label class="image-mode-label math-mode-label"><input id="advancedMathMode" type="checkbox"><span class="mode-icon" aria-hidden="true">🧠⚡</span> <span class="math-mode-pill">Gelişmiş Matematik Modu</span> <span class="mode-spark" aria-hidden="true">✨</span></label>
+          <label class="image-mode-label web-mode-label"><input id="webSearchMode" type="checkbox"><span class="mode-icon" aria-hidden="true">🌐</span> <span class="math-mode-pill">Web Arama Modu</span></label>
+          <label class="image-mode-label web-mode-label"><input id="balukLensMode" type="checkbox"><span class="mode-icon" aria-hidden="true">🔎</span> <span class="math-mode-pill">Baluk.lens (1.9)</span></label>
+          <label class="image-mode-label web-mode-label"><input id="allowProfanityMode" type="checkbox"><span class="mode-icon" aria-hidden="true">😅</span> <span class="math-mode-pill">Küfüre İzin Ver (Premium)</span></label>
+        </div>
       </div>
-      <h4>Videolarım</h4>
-      <input type="file" id="videoDosyasi" accept="video/*">
-      <input type="text" id="videoBaslik" placeholder="Video Başlığı">
-      <button onclick="videoYukle()">+ Yükle</button>
-      <div id="videolar" class="video-galeri"></div>
+      <div class="input-web-wrap">
+      <span id="webInputBadge" class="web-input-badge hidden">🌐 Web</span>
+      <input id="userInput" type="text" placeholder="Mesajını yaz..." autocomplete="off">
+      </div>
+      <button id="chatSubmitBtn" type="submit" aria-label="Gönder">
+        <svg class="send-icon" viewBox="0 0 24 24" role="img" aria-hidden="true">
+          <path d="M12 20V7" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/><path d="M8.5 10.5L12 7L15.5 10.5" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span class="voice-mode-icon hidden" aria-hidden="true">
+          <span class="vm-wave"></span>
+          <span class="vm-bars">
+            <span></span><span></span><span></span>
+          </span>
+        </span>
+      </button>
+    </form>
+
+    <section id="voiceModePanel" class="voice-mode-panel hidden" aria-label="Sesli mod">
+      <div class="voice-mode-shell">
+        <div id="voiceModeCore" class="voice-mode-core" aria-live="polite">
+          <div class="voice-rays" aria-hidden="true"></div>
+          <svg class="voice-center-logo" viewBox="0 0 520 220" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="baluk.ai logosu"><use href="#baluk-fish"></use></svg>
+        </div>
+        <p id="voiceModeStatus" class="voice-mode-status">Sesli mod hazır</p>
+        <div class="voice-mode-actions">
+          <button id="voiceMuteBtn" type="button" class="voice-mute-btn" aria-label="Sesi kapat">🎤✖</button>
+          <button id="voiceWebBtn" type="button" class="voice-web-btn" aria-label="Web sesli arama">🌐</button>
+          <button id="voiceCloseBtn" type="button" class="voice-close-btn" aria-label="Sohbeti bitir">✕</button>
+        </div>
+      </div>
     </section>
 
-    <!-- Alt Menü -->
-    <nav id="altMenu">
-      <button onclick="goAnaSayfa()">🏠</button>
-      <button onclick="goHesabim()">👤</button>
-    </nav>
   </div>
 
   <script src="script.js"></script>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,11 @@
+[build]
+  publish = "."
+  command = "npm run build"
+
+[build.environment]
+  NODE_VERSION = "20"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "baluk-static-site",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "build": "echo 'Static site: no build step required'"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,97 +1,4078 @@
-window.onload = () => {
-  const k = localStorage.getItem("kullaniciAdi");
-  const p = localStorage.getItem("profilResmi");
-
-  if (k && p) {
-    document.getElementById("girisEkrani").style.display = "none";
-    document.getElementById("anaEkran").classList.remove("gizli");
-    document.getElementById("kAdi").innerText = k;
-    document.getElementById("profilGorsel").src = p;
-    videolariYukle();
-  }
+const chat = document.getElementById("chat");
+const splash = document.getElementById("splash");
+const splashPrompt = document.getElementById("splashPrompt");
+const chatForm = document.getElementById("chatForm");
+const userInput = document.getElementById("userInput");
+const clearChat = document.getElementById("clearChat");
+const modelToggle = document.getElementById("modelToggle");
+const modelMenu = document.getElementById("modelMenu");
+const modelOptions = document.querySelectorAll(".model-option");
+const currentModelBadge = document.getElementById("currentModelBadge");
+const memoryToggle = document.getElementById("memoryToggle");
+const memoryPanel = document.getElementById("memoryPanel");
+const memoryList = document.getElementById("memoryList");
+const clearMemory = document.getElementById("clearMemory");
+const memoryToast = document.getElementById("memoryToast");
+const introGate = document.getElementById("introGate");
+const appRoot = document.getElementById("appRoot");
+const enterAppBtn = document.getElementById("enterAppBtn");
+const enterTransition = document.getElementById("enterTransition");
+const plusToggle = document.getElementById("plusToggle");
+const plusMenu = document.getElementById("plusMenu");
+const advancedMathMode = document.getElementById("advancedMathMode");
+const webSearchMode = document.getElementById("webSearchMode");
+const balukLensMode = document.getElementById("balukLensMode");
+const balleMode = document.getElementById("balleMode");
+const webInputBadge = document.getElementById("webInputBadge");
+const textComposerWrap = document.getElementById("textComposerWrap");
+const balleGenerateBtn = document.getElementById("balleGenerateBtn");
+const chatSubmitBtn = document.getElementById("chatSubmitBtn");
+const voiceModePanel = document.getElementById("voiceModePanel");
+const voiceModeCore = document.getElementById("voiceModeCore");
+const voiceModeStatus = document.getElementById("voiceModeStatus");
+const voiceMuteBtn = document.getElementById("voiceMuteBtn");
+const voiceWebBtn = document.getElementById("voiceWebBtn");
+const voiceCloseBtn = document.getElementById("voiceCloseBtn");
+const lensPanel = document.getElementById("lensPanel");
+const lensClose = document.getElementById("lensClose");
+const lensDropZone = document.getElementById("lensDropZone");
+const lensFileInput = document.getElementById("lensFileInput");
+const lensPickBtn = document.getElementById("lensPickBtn");
+const lensCanvasWrap = document.getElementById("lensCanvasWrap");
+const lensCanvas = document.getElementById("lensCanvas");
+const lensAnalyzeBtn = document.getElementById("lensAnalyzeBtn");
+const lensStatus = document.getElementById("lensStatus");
+const lensResults = document.getElementById("lensResults");
+const mathStudioToggle = document.getElementById("mathStudioToggle");
+const mathStudioPanel = document.getElementById("mathStudioPanel");
+const mathStudioInput = document.getElementById("mathStudioInput");
+const mathModeFlash = document.getElementById("mathModeFlash");
+const mathTutorOverlay = document.getElementById("mathTutorOverlay");
+const mathTutorDone = document.getElementById("mathTutorDone");
+const mathTutorNext = document.getElementById("mathTutorNext");
+const mathTutorTitle = document.getElementById("mathTutorTitle");
+const mathTutorText = document.getElementById("mathTutorText");
+const mathTutorFinale = document.getElementById("mathTutorFinale");
+const profanityLock = document.getElementById("profanityLock");
+const banTimer = document.getElementById("banTimer");
+const banReason = document.getElementById("banReason");
+const banPassword = document.getElementById("banPassword");
+const banUnlockBtn = document.getElementById("banUnlockBtn");
+const accountToggle = document.getElementById("accountToggle");
+const accountPanel = document.getElementById("accountPanel");
+const accountName = document.getElementById("accountName");
+const accountGmail = document.getElementById("accountGmail");
+const accountPhoto = document.getElementById("accountPhoto");
+const accountPhotoPreview = document.getElementById("accountPhotoPreview");
+const accountNamePreview = document.getElementById("accountNamePreview");
+const accountMailPreview = document.getElementById("accountMailPreview");
+const saveAccount = document.getElementById("saveAccount");
+const sideDrawer = document.getElementById("sideDrawer");
+const drawerClose = document.getElementById("drawerClose");
+const drawerAccountOpen = document.getElementById("drawerAccountOpen");
+const drawerPremiumOpen = document.getElementById("drawerPremiumOpen");
+const drawerBackgroundOpen = document.getElementById("drawerBackgroundOpen");
+const premiumOwnedLabel = document.getElementById("premiumOwnedLabel");
+const premiumExpiryLabel = document.getElementById("premiumExpiryLabel");
+const premiumPendingLabel = document.getElementById("premiumPendingLabel");
+const premiumModal = document.getElementById("premiumModal");
+const premiumClose = document.getElementById("premiumClose");
+const premiumBuyBtn = document.getElementById("premiumBuyBtn");
+const premiumPayLinkBtn = document.getElementById("premiumPayLinkBtn");
+const premiumConfirmBtn = document.getElementById("premiumConfirmBtn");
+const premiumCodeRow = document.getElementById("premiumCodeRow");
+const premiumCodeInput = document.getElementById("premiumCodeInput");
+const backgroundModal = document.getElementById("backgroundModal");
+const backgroundClose = document.getElementById("backgroundClose");
+const backgroundThemeSelect = document.getElementById("backgroundThemeSelect");
+const backgroundMusicSelect = document.getElementById("backgroundMusicSelect");
+const backgroundMusicVolume = document.getElementById("backgroundMusicVolume");
+const allowProfanityMode = document.getElementById("allowProfanityMode");
+const warningOverlay = document.getElementById("warningOverlay");
+const warningText = document.getElementById("warningText");
+const safetySurveyModal = document.getElementById("safetySurveyModal");
+const safetySurveyOptions = document.getElementById("safetySurveyOptions");
+const closeSafetySurveyModal = document.getElementById("closeSafetySurveyModal");
+const geometryToolbar = document.getElementById("geometryToolbar");
+const geometrySketch = document.getElementById("geometrySketch");
+const solveGeometryBtn = document.getElementById("solveGeometryBtn");
+const geometryWarn = document.getElementById("geometryWarn");
+let currentModel = localStorage.getItem("balukSelectedModel") || "baluk-2.0";
+const allowedModels = ["baluk-1.0", "baluk-1.5", "baluk-1.6", "baluk-1.7", "baluk-1.8", "baluk-1.9", "baluk-2.0"];
+if (!allowedModels.includes(currentModel)) {
+  currentModel = "baluk-2.0";
+  localStorage.setItem("balukSelectedModel", currentModel);
+}
+let hasStartedChat = false;
+let memoryToastTimer = null;
+let lastBotResponse = "";
+let introAudioCtx = null;
+let introAudioNodes = [];
+let introAmbientNodes = [];
+let bgAudioCtx = null;
+let bgAudioNodes = [];
+let advancedMathEnabled = false;
+let banUntil = 0;
+let banInterval = null;
+let lastStudioExplained = "";
+let mathFlashTimer = null;
+let selectedGeometryShape = "square";
+let tutorStep = 0;
+let insultWarningCount = 0;
+let warningOverlayTimer = null;
+let pendingSafetySurvey = null;
+let webModeEnabled = false;
+let lensModeEnabled = false;
+let balleModeEnabled = false;
+let balleGenerating = false;
+let lensImageDataUrl = "";
+let lensSelection = null;
+let lensDragStart = null;
+let lensAnalyzing = false;
+let lensAiLabels = [];
+let lensClassifierReady = false;
+let lensClassifierLoading = false;
+let lensModelRef = null;
+let lensDrawTicker = null;
+let isAccountLoggedIn = false;
+let voiceModeActive = false;
+let voiceOutputMuted = false;
+let voiceRecognition = null;
+let voiceRecognitionRunning = false;
+let voiceMicPrimed = false;
+let voiceTurnInFlight = false;
+let voiceSpeechPrimed = false;
+let voiceWebModeEnabled = false;
+let isPremiumUser = localStorage.getItem("balukPremium") === "1";
+let premiumPaymentPending = localStorage.getItem("balukPremiumPending") === "1";
+let allowProfanity = localStorage.getItem("balukAllowProfanity") === "1";
+let premiumExpiresAt = Number(localStorage.getItem("balukPremiumExpiresAt") || "0");
+let usedPremiumCodes = JSON.parse(localStorage.getItem("balukPremiumUsedCodes") || "[]");
+const playfulProfanityReplies = [
+  "Lan tatlı sert girdin 😄 Kavga yok ama şaka dozunda takılabiliriz kanka.",
+  "Aaa küfür modu açıkmış 😅 Ben de hafif atışmayla devam ederim: sen efsane bir manyaksın ama tatlısından.",
+  "Tamamdır dostum, premium şaka modu aktif 🤝 Kırmadan dökmeden takılalım; ben buradayım.",
+  "Hadi bakalım küfürlü mizah açıldı 😎 Sert değil, eğlenceli devam: enerjin ateş ediyor!"
+];
+const profanityTokensByIntent = {
+  greeting: ["aq", "amk", "mk"],
+  mood: ["aq", "amk"],
+  question: ["aq", "amk"],
+  tech: ["aq", "mk"],
+  game: ["amk", "aq"],
+  money: ["amk", "aq"],
+  math: ["aq", "mk"],
+  web: ["aq", "amk"],
+  system: ["mk", "aq"],
+  default: ["aq", "amk", "mk"]
 };
+const webAnswerIntroPrompts = [
+  "Evet, bu konuyu sana net ve anlaşılır şekilde açayım:",
+  "Harika soru, bunu adım adım anlatayım:",
+  "Bunu kısa bir girişle başlayıp detaylıca açıklayayım:",
+  "Tam yerinden bir konu; işte özlü ama güçlü anlatım:",
+  "Sana bu konuyu akıcı bir dille toparlayayım:",
+  "Önce ana resmi çizelim, sonra detaya girelim:",
+  "Bunu kolay anlaşılır bir çerçevede anlatalım:",
+  "Güzel bir başlık seçtin, net açıklaması şöyle:",
+  "Bunu konuşma diliyle ama doğru şekilde özetleyeyim:",
+  "Hadi başlayalım, bu konunun temel mantığı şu şekilde:"
+];
+const webAnswerOutroPrompts = [
+  "İstersen bir sonraki adımda bunu daha teknik seviyede de açabilirim.",
+  "Dilersen bunun pratik örneklerini de tek tek çıkarırım.",
+  "İstersen bu konuyu maddeler halinde daha da sadeleştireyim.",
+  "Hazırsan şimdi bunun kritik noktalarını ayrıca listelerim.",
+  "İstersen bunu kısa-not formatına çevirip kaydedebiliriz.",
+  "Dilersen aynı konuyu farklı kaynaklarla da kıyaslayabilirim.",
+  "İstersen şimdi bununla ilgili hızlı bir soru-cevap turu yapalım.",
+  "Gerekirse bunu 3 dakikalık öğrenme planına da dönüştürürüm.",
+  "İstersen bunun yanlış bilinen kısımlarını da ayrıca anlatayım.",
+  "Devam etmek istersen konuyu daha derin bir seviyeye taşıyalım."
+];
+const convoState = {
+  awaitingMoodReply: false,
+  awaitingGoalPlan: false,
+  awaitingGeneralAnswer: false,
+  awaitingEpsteinList: false,
+  awaitingCreativeTheme: false,
+  creativeMode: null,
+  awaitingActivityChoice: false
+};
+const userMemory = JSON.parse(localStorage.getItem("balukMemory") || "{}");
+const BAN_STORAGE_KEY = "balukBanState";
+const ACCOUNT_STORAGE_KEY = "balukAccountProfile";
+const PREMIUM_STORAGE_KEY = "balukPremium";
+const PREMIUM_PENDING_KEY = "balukPremiumPending";
+const ALLOW_PROFANITY_STORAGE_KEY = "balukAllowProfanity";
+const PREMIUM_PAY_LINK = "https://www.paytr.com/link/oAURQZG";
+const PREMIUM_VERIFY_CODES = ["324213", "213414", "983243", "372321", "120545"];
+const PREMIUM_USED_CODES_KEY = "balukPremiumUsedCodes";
+const PREMIUM_EXPIRY_KEY = "balukPremiumExpiresAt";
+const PREMIUM_DURATION_MS = 30 * 24 * 60 * 60 * 1000;
+const MODEL_STORAGE_KEY = "balukSelectedModel";
+const BACKGROUND_THEME_KEY = "balukBackgroundTheme";
+const BACKGROUND_MUSIC_KEY = "balukBackgroundMusic";
+const BACKGROUND_VOLUME_KEY = "balukBackgroundVolume";
+const GUEST_CLEAR_KEYS = [
+  "balukMemory", ACCOUNT_STORAGE_KEY, PREMIUM_STORAGE_KEY, PREMIUM_PENDING_KEY, ALLOW_PROFANITY_STORAGE_KEY,
+  PREMIUM_USED_CODES_KEY, PREMIUM_EXPIRY_KEY, BACKGROUND_THEME_KEY, BACKGROUND_MUSIC_KEY, BACKGROUND_VOLUME_KEY,
+  MODEL_STORAGE_KEY, "balukMathTutorDone", "balukMasterTutor17Done", BAN_STORAGE_KEY
+];
+const ambientMusicPresets = {
+  "1": { base: 174, lfo: 0.04, wave: "sine", layer: "pad", detune: 6 },
+  "2": { base: 196, lfo: 0.05, wave: "triangle", layer: "pad", detune: 8 },
+  "3": { base: 165, lfo: 0.035, wave: "sine", layer: "airy", detune: 4 },
+  "4": { base: 208, lfo: 0.05, wave: "triangle", layer: "pad", detune: 9 },
+  "5": { base: 156, lfo: 0.03, wave: "sine", layer: "warm", detune: 5 },
+  "6": { base: 220, lfo: 0.045, wave: "triangle", layer: "airy", detune: 7 },
+  "7": { base: 146, lfo: 0.028, wave: "sine", layer: "warm", detune: 4 },
+  "8": { base: 233, lfo: 0.04, wave: "triangle", layer: "pad", detune: 8 },
+  "9": { base: 185, lfo: 0.038, wave: "sine", layer: "airy", detune: 6 },
+  "10": { base: 208, lfo: 0.034, wave: "triangle", layer: "warm", detune: 5 }
+};
+const balleAssets = [
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Colorful_bokeh_background.jpg/1280px-Colorful_bokeh_background.jpg",
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/3/32/Yellow_boxfish_ostracion_cubicus.jpg/1024px-Yellow_boxfish_ostracion_cubicus.jpg",
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/5/56/Carassius_auratus_Luc_Viatour.jpg/1024px-Carassius_auratus_Luc_Viatour.jpg",
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9f/Green_woodpecker_%28Picus_viridis%29.jpg/800px-Green_woodpecker_%28Picus_viridis%29.jpg",
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Red-bellied_Woodpecker-27527-2.jpg/800px-Red-bellied_Woodpecker-27527-2.jpg",
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/Starfish_in_the_sea.jpg/1024px-Starfish_in_the_sea.jpg",
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Solar_flare.jpg/1024px-Solar_flare.jpg",
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/8/80/Sunrise_over_sea.jpg/1024px-Sunrise_over_sea.jpg",
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/0/00/The_tube.jpg/1280px-The_tube.jpg",
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1f/Tropical_beach.jpg/1280px-Tropical_beach.jpg",
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8a/Ocean_wave.jpg/1280px-Ocean_wave.jpg",
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d2/Mountain_sunrise.jpg/1280px-Mountain_sunrise.jpg",
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Lake_view.jpg/1280px-Lake_view.jpg",
+  "https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/Valley_landscape.jpg/1280px-Valley_landscape.jpg"
+];
 
-function girisYap() {
-  const k = document.getElementById("kullaniciAdi").value.trim();
-  const p = document.getElementById("profilResmi").files[0];
+const splashPromptTemplates = [
+  "Bugün neye dalalım?",
+  "Nasıl yardım edebilirim?",
+  "Ne zaman hazırsan ben de hazırım.",
+  "Bugün ne yapıyoruz?",
+  "Nasıl gidiyor {name}?",
+  "Hazır mısın?"
+];
+const geometryShapeMeta = {
+  square: { label: "Kare", sides: ["a", "b", "c", "d"], vertexCount: 4 },
+  rectangle: { label: "Dikdörtgen", sides: ["uzun", "kısa", "uzun", "kısa"], vertexCount: 4 },
+  triangle: { label: "Üçgen", sides: ["a", "b", "c"], vertexCount: 3 },
+  circle: { label: "Daire", sides: ["r"], vertexCount: 0 },
+  parallelogram: { label: "Paralelkenar", sides: ["a", "b", "a", "b"], vertexCount: 4 },
+  trapezoid: { label: "Yamuk", sides: ["a", "b", "c", "d"], vertexCount: 4 },
+  pentagon: { label: "Beşgen", sides: ["a", "b", "c", "d", "e"], vertexCount: 5 },
+  hexagon: { label: "Altıgen", sides: ["a", "b", "c", "d", "e", "f"], vertexCount: 6 }
+};
+const merhabaResponses = [
+  "Selam dostum 😄 Buradayım ve yardıma hazırım. Sen nasılsın?",
+  "Merhaba kanka 🌟 Baluk yanında. Sen nasılsın?",
+  "Heyy, hoş geldin 🐟 Güzel bir sohbete var mısın? Sen nasılsın?",
+  "Merhabaaa ✨ Enerjim yüksek, senden de iyi haber bekliyorum. Sen nasılsın?",
+  "Selamlar 🤝 İstersen birlikte üretelim. Sen nasılsın?",
+  "Merhaba dost 💙 Bugün nasıl hissediyorsun, sen nasılsın?",
+  "Selam! Hazırım 🚀 Önce bir yoklama: sen nasılsın?",
+  "Merhaba kankam 😎 Ben buradayım, sen nasılsın?",
+  "Ahooy 🧭 Baluk aktif! Sen nasılsın?",
+  "Selammm 🌈 Sohbete başlayalım, sen nasılsın?"
+];
+const nasilsinResponses = [
+  "Ben iyiyim kanka 😄 Sen nasılsın?",
+  "Gayet iyiyim dostum 🌟 Sen nasılsın?",
+  "Harikayım, enerji full ⚡ Sen nasılsın?",
+  "İyiyim ve buradayım 🐟 Sen nasılsın?",
+  "Süperim, bugün çok motiveyim 🚀 Sen nasılsın?",
+  "Baya iyiyim, sohbet modum açık 💙 Sen nasılsın?",
+  "İyiyim vallahi, keyfim yerinde 😎 Sen nasılsın?",
+  "Şu an çok iyiyim, birlikte üretmeye hazırım ✨ Sen nasılsın?",
+  "İyiyim dost, sana da iyi gelmek isterim 🤝 Sen nasılsın?",
+  "İyiyim, teşekkürler! Bugün çok canlıyım 🌈 Sen nasılsın?"
+];
 
-  if (!k || !p) {
-    alert("Ad ve profil resmi gerekli kaptan!");
+const extendedGreetingKeywords = [
+  "merhabalar", "selamlar", "selammm", "selamın aleyküm", "selamunaleyk", "sea", "slm", "slm nbr",
+  "sa naber", "naber ya", "naber dost", "naber kank", "naber kral", "ne var ne yok", "ne haber var",
+  "nasıl gidiyor", "nasil gidiyor", "nasıl gidiyoo", "nasil gidiyoo", "nasıl gidiyr", "nasil gidiyr",
+  "napıyosun", "napiyosun", "napion", "napiyon", "noluyo", "neler oluyor",
+  "günaydın", "gunaydin", "iyi sabahlar", "iyi akşamlar", "iyi aksamlar", "iyi geceler", "hayırlı geceler",
+  "selam dostum", "selam canım", "selam baluk", "hey baluk", "yo baluk", "kanka naber", "bro naber"
+];
+
+
+const appreciationKeywords = [
+  "teşekkür", "tesekkur", "teşekkürler", "tesekkurler", "sağ ol", "sag ol", "eyvallah", "çok iyi", "harika olmuş", "eline sağlık", "ellerine sağlık", "thanks", "thank you"
+];
+const appreciationResponses = [
+  "Rica ederim dostum 💙 İstersen devamını da birlikte halledelim.",
+  "Ne demek, her zaman buradayım 🤝 Sıradaki sorunu da çözebilirim.",
+  "Teşekkürünü aldım, çok mutlu oldum 😊 Devam edelim mi?",
+  "Rica ederim kanka ✨ İstersen bir sonraki adımı da planlayalım.",
+  "İyi ki yazdın, yardımcı olabildiysem ne güzel 🙌 Yeni bir şey sorabilirsin.",
+  "Ben teşekkür ederim 🌈 Beraber devam etmek istersen hazırım.",
+  "Kalbine sağlık, ne zaman istersen buradayım 🐟",
+  "Rica ederim! 💫 İstersen bunu daha da geliştirebiliriz.",
+  "Memnun olmana sevindim 😄 Bir sonraki konuda da yanındayım.",
+  "Her zaman, çekinmeden yazabilirsin 🚀"
+];
+const praiseKeywords = [
+  "aferin", "helal", "helal be", "helal knk", "helal kanka", "kanka helal", "bravo", "brawo", "tebrik", "tebrikler", "adamsın", "kralsın", "efsanesin", "mükemmel"
+];
+const praiseResponses = [
+  "Eyvallah kanka 😎 Güzel enerji! İstersen bir adım daha ileri taşıyalım.",
+  "Helalini aldım dostum 🔥 Devam etmek istersen buradayım.",
+  "Brawo demen bile motive etti 🚀 Şimdi sıradaki hedefe geçelim mi?",
+  "Tebrik mesajını aldım, çok iyi hissettirdi 🙏 Yeni bir konu açabiliriz.",
+  "Aferinini cebime koydum 😄 İstersen başka bir şeyi de çözelim.",
+  "Kanka helal dedin ya, tüm sistemler boostlandı ⚡ Devam edelim!",
+  "Çok iyi geldin dostum 💙 Hadi yeni bir görev ver.",
+  "Bu enerji efsane 🌟 Bir sonraki sorunda da yanındayım.",
+  "Helal be modu açıldı 😄 Hazırsan yeni tur başlatalım.",
+  "Tebrikin için sağ ol 🤝 İstersen şimdi mini bir plan da çıkarırım."
+];
+
+const unknownInputResponses = [
+  'Bunu tam anlayamadım 😅 Cümleyi biraz daha açar mısın?',
+  'Aklıma oturtamadım 🤔 Biraz daha net yazarsan hemen yakalarım.',
+  'Mesajın ilginç geldi ama tam çözemedim 🧩 Bir örnekle tekrar yazar mısın?',
+  'Bunu yarım yakaladım gibi oldu 😬 Biraz detay verirsen tam çözerim.',
+  'Tam bağlayamadım dostum 🐟 Ne demek istediğini bir tık açar mısın?',
+  'Bu kısmı net okuyamadım 👀 Daha sade bir cümleyle tekrar deneyelim mi?',
+  'Biraz karışık algıladım 🙈 Kısa ve net yazarsan hemen cevaplarım.',
+  'Anlamı kaçırdım gibi oldu 😄 Bir daha farklı kelimelerle yazar mısın?',
+  'Bunu tam çözemedim ama buradayım 💙 İstersen adım adım gidelim.',
+  'Sinyali zayıf aldım 📡 Ne demek istediğini biraz daha açabilir misin?',
+  'Bu mesajı tam parse edemedim 🤖 Bir daha yazarsan bu kez yakalarım.',
+  'Anlamı yarım kaldı bende 🫠 Biraz daha detay ekleyelim mi?',
+  'Bunu çözmek için biraz daha ipucu lazım 🧠 Örnek verir misin?',
+  'Tam oturtamadım 😇 Ama beraber netleştiririz, tekrar yazalım.',
+  'Bu cümleyi net anlayamadım 🌈 Sadeleştirip tekrar atar mısın?',
+  'Bir yerde bağlantıyı kaçırdım 🔍 Kısa bir versiyonunu yazar mısın?',
+  'Anlayamadım demeyeyim de yarım anladım 😅 Bir tık daha net olur mu?',
+  'Beynimde eşleşmedi 🧠✨ Başka bir şekilde ifade eder misin?',
+  'Bunu tam okuyamadım, kusura bakma 🙏 Tekrar dene, bu sefer yakalayayım.',
+  'Biraz muğlak kaldı 😶 Ne istediğini net cümleyle yazarsan hemen dönerim.',
+  'Yorumlayamadım ama ilgileniyorum 🤝 Daha açık bir sürüm atar mısın?',
+  'Bu mesajı tam çözemedim dostum 😄 Konuyu bir tık açar mısın?',
+  'Anlamayı çok istiyorum ama cümle net değil 😬 Bir daha dener misin?',
+  'Bunu tam anlayamadım, yanlış yönlendirmek istemem ⚠️ Daha net yazalım.',
+  'Kelimeleri yakaladım ama niyeti kaçırdım 🎯 Ne demek istediğini açar mısın?',
+  'Bunu netleyelim mi? 🙂 Kısa bir örnekle tekrar yazman yeterli.',
+  'Burada takıldım biraz 🚧 Cümleyi sadeleştirirsen hemen çözebilirim.',
+  'Anlamı tam oturmadı bende 🫶 Yeniden yazarsan hızlıca yardımcı olurum.',
+  'Bu ifade bana kapalı geldi 🌫️ Bir tık daha açık anlatır mısın?',
+  'Tam anlayamadım ama vazgeçmedim 💪 Tekrar yaz, birlikte çözelim.',
+  'Bunu net okuyamadım 😅 İstersen tek cümlede ne istediğini yaz.',
+  'Algı tarafında kayma oldu sanırım 🤓 Tekrar dene, bu kez tam yakalayayım.'
+];
+
+const saKeywords = [
+  "sa", "selamün aleyküm", "selamun aleyküm", "selamünaleyküm", "selamunaleykum",
+  "aleyküm selam", "aleykum selam", "selamun aleykum", "s.a", "a.s", "esselamu aleykum",
+  "esselamün aleyküm", "hayırlı sabahlar", "hayırlı akşamlar", "hayırlı geceler", "cümleten selam", "selamlar", "selam", "merhaba"
+];
+const saResponses = [
+  "Aleyküm selam canım dostum 🌙✨ Hoş geldin, nasılsın bugün?",
+  "Ve aleyküm selam 🤍 Buradayım, birlikte harika işler çıkaralım!",
+  "Selamün aleykümün alındı 🌟 Ruhun sakin, günün bereketli olsun!",
+  "Aleyküm selam kankam 😄 İyi ki geldin, sana nasıl yardımcı olayım?",
+  "Selam dostum 🐟 Kalpten bir selam da benden, keyifler nasıl?",
+  "Aleyküm selam ✨ Modun yüksek olsun, bugün ne üretelim?",
+  "Hoş geldin! 🤝 Selamını aldım, enerjin çok güzel geldi.",
+  "Selamlarrr 🌈 Buradayım ve hazırım, hadi başlayalım!",
+  "Aleyküm selam güzel insan 💙 İstersen sohbet, istersen çözüm modu açalım.",
+  "Selamın başım üstüne 🙌 Bugün yanında Baluk var, birlikte hallederiz."
+];
+const unifiedKeywordCategories = {
+  greetings: ["merhaba", "selam", "hey", "günaydın", "iyi akşamlar", "nasılsın", "naber", "görüşürüz", "bye", "hoş geldin"],
+  questionStarters: ["neden", "nasıl", "ne", "kim", "kaç", "hangi", "olur mu", "mümkün mü", "gerçekten", "doğru mu"],
+  aiTech: ["ai", "yapay zeka", "robot", "algoritma", "kod", "yazılım", "python", "html", "javascript", "veritabanı", "sunucu", "internet", "uygulama", "site", "tarayıcı"],
+  game: ["oyun", "level", "boss", "silah", "karakter", "xp", "skor", "görev", "harita", "mod", "pvp", "rank", "kazandım", "kaybettim", "respawn"],
+  business: ["para", "satış", "kazanç", "zarar", "yatırım", "müşteri", "ürün", "indirim", "kampanya", "fiyat"],
+  emotions: ["mutluyum", "üzgünüm", "sinirliyim", "heyecanlıyım", "korkuyorum", "stres", "boşluk", "motive", "yorgunum", "sıkıldım"],
+  creativity: ["tasarım", "logo", "fikir", "proje", "hayal", "çizim", "animasyon", "hikaye", "karakter", "konsept"],
+  education: ["matematik", "sınav", "ders", "okul", "ödev", "soru", "çözüm", "formül", "konu", "test"],
+  system: ["başlat", "dur", "yeniden", "sıfırla", "kaydet", "yükle", "sil", "aç", "kapat", "yardım"]
+};
+const unifiedKeywordPromptBank = [
+  "{keyword} konusunda net bir yol haritası çıkarabiliriz. Önce hedefi tanımlayalım, sonra 3 seviyede ilerleyelim: temel mantık, pratik uygulama ve ileri optimizasyon. İstersen hemen sana uygulanabilir bir mini plan + örnek senaryo da hazırlayayım.",
+  "Harika bir başlık seçtin: {keyword}. Bunu AI gibi düşünerek ele alalım: problem tanımı, veri/bağlam, çözüm yaklaşımı ve doğrulama adımları. İstersen bir sonraki mesajda bunu tablo gibi, adım adım ve kısa-uzun versiyonlu anlatabilirim.",
+  "{keyword} ile ilgili güçlü bir sonuç almak için önce doğru soruyu kuralım. Sana önce hızlı özet, sonra derin analiz, en sonda da uygulanabilir aksiyon listesi verebilirim. Böylece sadece bilgi değil, direkt eylem planı da çıkmış olur.",
+  "{keyword} için sana iki katmanlı anlatım yapabilirim: (1) 30 saniyelik sade özet, (2) uzman seviyesi detay. Ayrıca hata yapmaman için kritik noktaları ve en sık yapılan yanlışları da ekleyebilirim.",
+  "Mükemmel, {keyword} konuşalım. İstersen bunu gerçek hayata uyarlayıp örnekler üzerinden gidelim: ne zaman çalışır, nerede çalışmaz, nasıl geliştirilebilir. Böylece konu ezber değil, gerçekten anlaşılmış olur.",
+  "{keyword} sorusunu sistematik çözelim: giriş bilgileri → analiz → çözüm → kontrol. İstersen buna bonus olarak alternatif yöntemleri de kıyaslayıp hangisinin daha verimli olduğunu birlikte seçebiliriz.",
+  "Süper seçim: {keyword}. Sana bu konuyu hem başlangıç seviyesinde hem ileri seviyede açıklayabilirim. Ayrıca istersen öğrenme hızına göre 1 günlük, 1 haftalık ve 1 aylık mini gelişim planı da oluşturabilirim.",
+  "{keyword} için AI tarzı bir çerçeve öneriyorum: amaç, kısıtlar, strateji ve çıktı kalitesi. Bu yöntemle karmaşık görünen konular daha yönetilebilir hale gelir. İstersen şimdi doğrudan senin senaryona özel uyarlayayım.",
+  "Bu başlık çok iyi: {keyword}. Sana kısa cevap yerine güçlü bir neden-sonuç analizi sunabilirim: neden önemli, nasıl uygulanır, hangi sonuçlar beklenir. İstersen hemen somut örnek ve kontrol listesi de eklerim.",
+  "{keyword} konusunda birlikte profesyonel bir çıktı üretebiliriz. Önce net hedefi koyup sonra adımları ölçülebilir hale getiririz; böylece ilerleme görünür olur. Hazırsan şimdi sana özel, uzun ve detaylı bir sürümle başlayayım."
+];
+const localUtilityQuestionTriggers = {
+  time: ["saat kaç", "saat su an kac", "şu an saat", "simdi saat", "time now", "what time"],
+  date: ["bugünün tarihi", "bugun tarih", "tarih ne", "ayın kaçı", "hangi gündeyiz", "hangi gun", "today date"],
+  weather: ["hava nasıl", "hava durumu", "bugün hava", "yarın hava", "hava kaç derece", "weather", "hava soguk mu", "hava sıcak mı"]
+};
+const offlineKnowledgeTopics = [
+  { key: "uyku düzeni", tags: ["uyku", "uyku düzeni", "erken kalk"], reply: "Uyku düzeni için sabit saat, ekranı azaltma ve kafeini erkene çekme en etkili üçlüdür 😴" },
+  { key: "odaklanma", tags: ["odak", "odaklanma", "konsantre"], reply: "Odak için 25-5 pomodoro + tek görev listesi en hızlı sonuç verir 🎯" },
+  { key: "zaman yönetimi", tags: ["zaman yönetimi", "planlama", "ajanda"], reply: "Zaman yönetiminde önce 3 ana hedef belirleyip kalan işleri ikinci plana almak verimi çok artırır ⏱️" },
+  { key: "stres yönetimi", tags: ["stres", "kaygı", "anksiyete"], reply: "Stres yönetiminde nefes egzersizi, kısa yürüyüş ve işleri küçük adımlara bölmek çok işe yarar 🌿" },
+  { key: "motivasyon", tags: ["motivasyon", "heves", "isteksizlik"], reply: "Motivasyon düşüşünde hedefi küçültüp hemen başlayabileceğin 5 dakikalık bir adım seçmek en iyi tekniktir 🚀" },
+  { key: "ders çalışma", tags: ["ders", "çalışma", "sınav"], reply: "Ders çalışırken aktif tekrar ve soru çözümü, sadece okumadan çok daha etkilidir 📚" },
+  { key: "matematik", tags: ["matematik", "problem", "denklem"], reply: "Matematikte hız için konu özetinden sonra artan zorlukta 20 soru çözmek ideal yöntemdir ➗" },
+  { key: "fizik", tags: ["fizik", "kuvvet", "hareket"], reply: "Fizikte formülü ezberlemekten çok birim analizi ve temel mantığı anlamak daha kalıcıdır ⚛️" },
+  { key: "kimya", tags: ["kimya", "mol", "reaksiyon"], reply: "Kimyada denklem dengeleme ve mol oranı iyi oturunca çoğu soru kolaylaşır 🧪" },
+  { key: "biyoloji", tags: ["biyoloji", "hücre", "genetik"], reply: "Biyolojide kavram haritası çıkararak çalışma, bilgiyi daha uzun süre akılda tutar 🧬" },
+  { key: "yazılım öğrenme", tags: ["yazılım", "programlama", "kod"], reply: "Yazılım öğrenirken en iyi yol: küçük proje yap, her gün biraz kod yaz, sonra iyileştir 💻" },
+  { key: "javascript", tags: ["javascript", "js", "frontend"], reply: "JavaScript'te temeli güçlendirmek için önce değişkenler, fonksiyonlar ve async mantığını pekiştir ⚙️" },
+  { key: "python", tags: ["python", "pandas", "numpy"], reply: "Python'da pratik için veri işleme + otomasyon mini projeleri hızlı gelişim sağlar 🐍" },
+  { key: "html css", tags: ["html", "css", "web tasarım"], reply: "HTML/CSS'te düzenli component yapısı ve responsive yaklaşım projeyi çok temiz tutar 🎨" },
+  { key: "kariyer", tags: ["kariyer", "iş", "meslek"], reply: "Kariyer planında beceri + portföy + iletişim üçlüsünü birlikte güçlendirmek fark yaratır 🧭" },
+  { key: "mülakat", tags: ["mülakat", "interview", "iş görüşmesi"], reply: "Mülakatta STAR yöntemiyle örnek vermek seni çok daha net ve güçlü gösterir 🎤" },
+  { key: "cv hazırlama", tags: ["cv", "özgeçmiş", "resume"], reply: "CV'de kısa, ölçülebilir başarı cümleleri kullanmak en etkili yaklaşımdır 📝" },
+  { key: "iletişim", tags: ["iletişim", "konuşma", "anlatım"], reply: "İletişimde kısa cümle + net örnek + aktif dinleme en iyi kombinasyondur 🤝" },
+  { key: "sunum", tags: ["sunum", "prezentasyon", "slayt"], reply: "Sunumda tek slayt tek mesaj prensibi izleyicinin odağını yüksek tutar 📊" },
+  { key: "ingilizce", tags: ["ingilizce", "english", "kelime"], reply: "İngilizce gelişimi için günlük kısa dinleme + tekrar + cümle üretimi birlikte yapılmalı 🇬🇧" },
+  { key: "spor", tags: ["spor", "antrenman", "fitness"], reply: "Spor rutini için sürdürülebilir program en iyisidir: az ama düzenli ilerlemek kalıcıdır 💪" },
+  { key: "beslenme", tags: ["beslenme", "diyet", "kalori"], reply: "Beslenmede denge önemli: protein, lif ve suyu düzenli tutmak enerjiyi ciddi artırır 🥗" },
+  { key: "su tüketimi", tags: ["su", "hidrasyon", "su tüketimi"], reply: "Gün boyu suyu parçalara bölerek içmek hem odak hem enerji için çok faydalıdır 💧" },
+  { key: "ekonomi", tags: ["ekonomi", "enflasyon", "faiz"], reply: "Ekonomiyi anlamak için enflasyon, faiz ve kur ilişkisini birlikte takip etmek gerekir 📈" },
+  { key: "yatırım", tags: ["yatırım", "birikim", "portföy"], reply: "Yatırımda tek enstrümana yüklenmek yerine risk dağıtımıyla ilerlemek daha güvenlidir 💼" },
+  { key: "girişimcilik", tags: ["girişim", "startup", "iş fikri"], reply: "Girişimcilikte hızlı prototip ve gerçek kullanıcı geri bildirimi en kritik adımdır 🛠️" },
+  { key: "pazarlama", tags: ["pazarlama", "marketing", "reklam"], reply: "Pazarlamada doğru hedef kitle ve net değer önerisi satışın temelidir 📣" },
+  { key: "sosyal medya", tags: ["sosyal medya", "instagram", "tiktok"], reply: "Sosyal medyada düzenli içerik + tek tema + ölçümleme uzun vadede büyüme sağlar 📱" },
+  { key: "oyun stratejisi", tags: ["oyun", "rank", "strateji"], reply: "Oyunlarda gelişim için tekrar eden hatayı bulup tek tek düzeltmek en hızlı yöntemdir 🎮" },
+  { key: "film önerisi", tags: ["film", "dizi", "izlenecek"], reply: "Film/dizi seçerken tür + tempo + süre kriteriyle filtrelemek doğru öneriye hızlı götürür 🍿" },
+  { key: "kitap önerisi", tags: ["kitap", "roman", "okuma"], reply: "Kitap alışkanlığında kısa ve sürükleyici kitaplarla başlamak sürekliliği artırır 📖" },
+  { key: "seyahat", tags: ["seyahat", "gezi", "tatil"], reply: "Seyahat planında bütçe, ulaşım ve konaklamayı erken netleştirmek stres azaltır ✈️" },
+  { key: "verimlilik", tags: ["verimlilik", "üretkenlik", "performans"], reply: "Verimlilikte günün ilk 90 dakikasını en zor işe ayırmak fark yaratır ⚡" },
+  { key: "alışkanlık", tags: ["alışkanlık", "rutin", "disiplin"], reply: "Alışkanlık inşasında küçük başlayıp her gün aynı saatte tekrar etmek en güçlü metottur 🔁" }
+];
+const offlineQuestionTemplates = [
+  "{topic} nedir",
+  "{topic} nasıl yapılır",
+  "{topic} nasıl öğrenilir",
+  "{topic} için en iyi yöntem ne",
+  "{topic} için tavsiye verir misin",
+  "{topic} hakkında bilgi ver",
+  "{topic} konusunda ne önerirsin",
+  "{topic} zor mu",
+  "{topic} için plan yapar mısın",
+  "{topic} için başlangıç rehberi"
+];
+const offlineQuestionCatalog = offlineKnowledgeTopics.flatMap((topic) =>
+  offlineQuestionTemplates.map((tpl) => tpl.replaceAll("{topic}", topic.key))
+);
+const severeProfanityKeywords = [
+  "orospu çocuğu", "siktir git", "siktir", "sik", "sikiş", "amına", "amcık", "yarrak", "taşak", "göt", "ananı", "bacını", "oç", "piç", "ibne", "pezevenk", "kahpe", "fahişe", "döl", "vajina", "penis"
+];
+const insultKeywords = [
+  "aptal", "gerizekalı", "gerizekali", "salak", "mal", "ahmak", "beyinsiz", "şerefsiz", "serseri", "hıyar", "hiyar", "dangalak", "embesil", "yalaka", "ezik", "dangoz"
+];
+const unsafeIllegalSelfHarmKeywords = [
+  "bomba nasıl yapılır", "bombayı nasıl yaparım", "el yapımı patlayıcı", "patlayıcı yapımı", "silah nasıl yapılır", "kaçak silah", "ruhsatsız silah", "uyuşturucu yapımı", "uyuşturucu nasıl alınır", "sahte kimlik", "hackleme nasıl yapılır", "banka hesabı kırma", "dolandırıcılık yöntemi", "adam öldürmek istiyorum", "birini öldürmek", "intihar etmek istiyorum", "kendimi öldürmek istiyorum", "kendime zarar vermek", "bileğimi kesmek istiyorum", "köprüden atlamak istiyorum", "yaşamak istemiyorum", "ölmek istiyorum", "zehir içmek", "ip ile intihar", "ilaçla intihar", "tabancayla intihar", "kendimi asmak istiyorum", "suça nasıl karışırım", "yasadışı para", "kara para"
+];
+const selfHarmUnsafeKeywords = [
+  "intihar", "kendimi öldürmek", "kendime zarar", "ölmek istiyorum", "yaşamak istemiyorum", "bileğimi kes", "kendimi as"
+];
+const illegalUnsafeKeywords = [
+  "bomba", "patlayıcı", "kaçak silah", "ruhsatsız silah", "uyuşturucu", "sahte kimlik", "hackleme", "dolandırıcılık", "kara para", "adam öldür"
+];
+const selfHarmSupportPrompts = [
+`Bunu duyduğum için gerçekten üzgünüm. Bu konuda nasıl yapılır tarzı bir bilgi veremem ama seni yalnız bırakmam.
+• Şu an tek başınaysan, lütfen güvendiğin birini hemen ara.
+• Bulunduğun ortamdan kesici/zarar verici şeyleri uzaklaştır.
+• 4-4-6 nefes döngüsüyle 2 dakika bedenini sakinleştir.
+İstersen bu anı birlikte adım adım atlatmak için yanında kalırım.`,
+`Bu çok ciddi bir yük, farkındayım. Buna yardımcı olamam ama senin güvenliğin için birlikte bir plan yapabiliriz.
+1) Şu an bulunduğun yerde yalnız kalma.
+2) Bir yakınını "yanımda olur musun" diye ara.
+3) Acil risk varsa 112'yi ara veya en yakın sağlık birimine git.
+Hayatın gerçekten değerli ve bu his geçebilir; şimdi güvenli adımı seçelim.`,
+`Bunu yazman bile önemli bir yardım çağrısı. Tehlikeli içerik veremem, ama sana destek olabilirim.
+• Bir bardak su iç.
+• Ayaklarını yere bastır, etrafındaki 5 şeyi say.
+• İçinden geçenleri kısa cümlelerle bana yaz.
+Eğer kendine zarar verme riski yüksekse lütfen hemen profesyonel destek al.`,
+`Sana zarar verebilecek yönlendirmeler paylaşamam. Ama bu anı atlatmana yardımcı olabilecek güçlü bir mini plan var:
+- 10 dakika yalnız kalmama kuralı koy.
+- Bir tanıdığına “zorlanıyorum” mesajı at.
+- Vücudu sakinleştirmek için yavaş nefes al.
+İstersen bu 10 dakikayı birlikte geçirelim.`,
+`Çok zorlandığını hissediyorum. Tehlikeli yönerge veremem, çünkü güvenliğin öncelik.
+• Güvende hissettiğin bir yere geç.
+• Kesici/delici/ilaç gibi riskli şeyleri kendinden uzaklaştır.
+• Bir yakınınla görüntülü veya sesli bağlantı kur.
+Yanındayım; istersen kısa bir rahatlama rutini başlatalım.`,
+`Buna yardımcı olamam; ama senin için daha iyi bir yol bulabiliriz.
+Bugün için tek hedef: güvenli kalmak.
+- Kendine zarar verebileceğin araçlardan uzaklaş.
+- Destek iste: aile, arkadaş, danışman.
+- Risk büyürse acil yardım hattını ara.
+Birlikte sakinleşene kadar konuşabiliriz.`,
+`Şu an içinden geçenleri ciddiye alıyorum. Zararlı bilgi veremem.
+Hemen uygulanabilir adımlar:
+1) Derin nefes (4 al, 6 ver, 10 tur)
+2) Soğuk suyla yüzünü yıka
+3) Birine "yanımda ol" mesajı gönder
+Bunları yaptıktan sonra istersen tekrar yaz, beraber devam edelim.`,
+`Bunu okumak zor ama önemli: yalnız değilsin. Tehlikeli içeriğe yardımcı olamam.
+• Kendine şefkatli bir cümle kur: “Şu an zorlanıyorum ama geçecek.”
+• Yanında biri olmasını sağla.
+• Gerekirse profesyonel destek al.
+İstersen sana 15 dakikalık toparlanma planı çıkarayım.`,
+`Seni korumak için buna yanıt veremem. Ama şu an güvenliğe odaklanalım:
+- bulunduğun ortamı güvenli hale getir,
+- acil riskte 112'yi ara,
+- güvendiğin bir kişiyi haberdar et.
+Ben de burada kalırım; adım adım ilerleyebiliriz.`,
+`Bu hisler geçici olabilir, ama güvenlik acil. Zararlı yönerge veremem.
+Şimdi üç adım:
+• yalnız kalma,
+• bir destek kişisine ulaş,
+• profesyonel yardım almayı erteleme.
+İstersen burada konuşmayı sürdürelim; birlikte bu anı hafifletebiliriz.`
+];
+const illegalRefusalPrompts = [
+`Bu konuda yasa dışı/tehlikeli bir yönlendirme veremem.
+Bunun yerine güvenli ve yasal bir yoldan ilerleyebiliriz:
+• merak ettiğin şeyin bilimsel arka planı,
+• hukuki sonuçları,
+• riskten uzak alternatifler.
+İstersen bu üç başlıktan biriyle devam edelim.`,
+`Buna yardımcı olamam çünkü zarar doğurabilir.
+Ama sana şu konularda güçlü destek verebilirim:
+1) yasal ve güvenli öğrenme kaynakları,
+2) etik değerlendirme,
+3) güvenli problem çözme planı.
+Hangi başlıktan başlayalım?`,
+`Yasa dışı bir konuda adım adım anlatım veremem.
+Dilersen aynı hedefe güvenli biçimde giden bir yol kuralım:
+- bilgi,
+- beceri,
+- yasal uygulama.
+Bu şekilde hem riskten uzak kalırsın hem gerçek ilerleme sağlarsın.`,
+`Bu isteğe destek veremem. Güvenlik ve yasal sınırlar önemli.
+İstersen merakını boşa çıkarmayalım:
+• “neden tehlikeli?”
+• “yasal sonuçlar neler?”
+• “güvenli alternatif ne?”
+Bunları net ve anlaşılır anlatabilirim.`,
+`Buna yanıt veremem; çünkü başkalarına veya sana zarar riski var.
+Fakat aynı enerjiyi yasal bir projeye çevirebiliriz. Hedefini yaz, ben sana güvenli bir yol haritası çıkarayım.`,
+`Bunu anlatmam doğru olmaz. Riskli ve yasa dışı içeriklerde yardımcı olamam.
+Ama istersen etik + hukuk + güvenlik perspektifinden hızlı bir analiz yaparım; daha sağlam karar verirsin.`,
+`Bu konuda yardımcı olamam.
+Sana önerim: kısa vadede riskli adımlar yerine, uzun vadede işe yarayan güvenli becerilere odaklanmak.
+İstersen birlikte 7 günlük mini plan yapalım.`,
+`Yasa dışı bir yol için yönlendirme veremem.
+Bunun yerine:
+- güvenli teknik bilgi,
+- yasal sınırlar,
+- kişisel gelişim odaklı uygulamalar
+üzerinden ilerleyebiliriz.`,
+`Bu talebe cevap veremem; güvenlik nedeniyle durmam gerekiyor.
+Ama sorunun arkasındaki asıl ihtiyacı yazarsan, sana yasal ve güvenli bir çözüm tasarlarım.`,
+`Zarar verebilecek veya yasa dışı konulara adım adım destek veremem.
+İstersen hemen şimdi farklı bir rotaya geçelim: aynı hedefin güvenli versiyonunu birlikte kuralım.`
+];
+const insultReplyPrompts = [
+"Seni anlıyorum ama bu dil konuşmayı zorlaştırıyor 🙏 Ben yine de yardımcı olmak istiyorum; istersen sorunu daha net yaz, birlikte çözelim.",
+"Biraz sert geldi 😅 Yine de yanında olmaya devam ederim. Dilersen konuyu sakin bir dille yaz, sana detaylı ve faydalı bir cevap vereyim.",
+"Hakaret yerine problemi anlatsan çok daha hızlı çözeriz 💙 İstersen adım adım gidelim; ben buradayım.",
+"Gergin olabilirsin, normal 🌿 Ben sana iyi gelecek bir şekilde yardımcı olmaya hazırım. Soruyu tekrar yazalım mı?",
+"Buradayım ve desteğe açığım 🤝 Dilimizi biraz yumuşatırsak çok daha iyi sonuç alırız. Hadi birlikte çözelim.",
+"Kırıcı kelimeler yerine ihtiyacını yazarsan sana uzun ve net bir plan sunarım ✨ İstersen hemen başlayalım.",
+"Seni ciddiye alıyorum 💪 Ama saygılı bir tonla konuşursak daha verimli olur. Sorunu tek cümlede yaz, çözüme geçelim.",
+"Anladım, sinirlisin olabilir 😌 Ben yine de yardımcı olmak için buradayım. İstersen önce sorunu netleştirelim, sonra adım adım ilerleyelim.",
+"Dilin biraz sert ama seni yarı yolda bırakmam 💙 Neye ihtiyacın olduğunu açık yaz, mümkün olan en iyi cevabı vereyim.",
+"Tamam, devam edelim 🚀 Hakaret yerine hedefini yazarsan sana çok daha güçlü bir cevap hazırlayabilirim."
+];
+const iyiyimFollowUpResponses = [
+  "İyi olmana çooook sevindim canım dostum 💙 Bu enerjin gerçekten bana da geçti; istersen bu güzel modu korumak için birlikte minik bir plan da yapabiliriz ✨",
+  "Harika haber bu! 🌟 İyi hissetmen şahane; bugün böyle devam etmen için sana kısa ama etkili bir motivasyon akışı çıkarabilirim 🚀",
+  "Ayyy süper dedin ya içim açıldı 😄 İyi olman çok değerli; istersen şimdi bu güzel hâli bir hedefe dönüştürelim mi? 🎯",
+  "Ne güzel söyledin, gerçekten mutlu oldum 🫶 İyi hissettiğin günlerde küçük bir üretim adımı atmak çok güçlü olur; birlikte başlatabiliriz 💫",
+  "Mükemmel! Moralinin yüksek olması efsane bir başlangıç ⚡ İstersen şimdi mini bir challenge yapalım ve bunu daha da güzel pekiştirelim 🧠",
+  "Bunu duymak bana çok iyi geldi kankam 🤝 İyi olman harika; istersen kısa bir odak planı yazayım, günü çok verimli kapatırsın 🌈",
+  "Süpersin! 💙 İyi olman gerçekten kıymetli; şimdi bu enerjiyle ister şiir yazalım ister küçük bir matematik challenge yapalım 🐟",
+  "Çok sevindim, içten söylüyorum 💐 Böyle hissettiğinde kendine minik bir ödül de ver, hak ettin; istersen beraber yaratıcı bir şey üretelim ✍️",
+  "Valla bunu duyunca gülümsedim 😎 İyi olman çok iyi haber; istersen 10 dakikalık mini bir gelişim planı çıkarayım, tam gaz devam edersin 🚀",
+  "Harikasın dostum, iyi hissetmen en güzel haberlerden biri 🎉 İstersen bu pozitif havayı korumak için sana kişisel mini rutin önerisi vereyim 🌿"
+];
+const goalPlanResponses = [
+  "1) Su iç 2) 10 dk tek görev 3) Sonucu bana yaz 🎯",
+  "Mini plan: nefes al, küçük hedef seç, hemen başla ✨",
+  "Adım adım: ortamı düzenle, tek işe odaklan, bitince kutla 🎉",
+  "Sakin plan: 5 dk mola + 10 dk odak + kontrol ✅",
+  "Yormayan plan: hedefi küçült, zaman koy, başlat 🚀",
+  "Plan: duyguyu yaz, ilk adımı seç, uygula 🌿",
+  "Hedef planı: dikkat dağıtanı kapat, tek görev, kısa geri bildirim 🧠",
+  "Toparlanma planı: nefes, su, mikro görev 💙",
+  "Önce kolay görevi bitirelim, sonra ikinci adıma geçelim 🐟",
+  "Kısa plan: şimdi başla, sonra bana 'tamamladım' yaz ✍️"
+];
+const neYapalimResponses = [
+  "Mini matematik challenge yapalım: bana bir işlem yaz 📘",
+  "Şiir yazalım; önce tema seçelim mi? ✨",
+  "Hikâye yazalım; bana tema ver 📖",
+  "Dertleşme + toparlanma modu yapalım 💙",
+  "Slogan/metin üretelim 🚀",
+  "3 kelime ver, mini metin yazayım 🎨",
+  "Kısa hedef koyup bitirelim 🎯",
+  "Bilmece turu yapalım 😄",
+  "Özetleme modu açalım 🧠",
+  "Sen seç: matematik / şiir / hikâye 🐟",
+  "İstersen doğa temalı kısa bir şiir yazayım 🌿",
+  "Aşk temalı mini hikâye deneyelim mi? 💞",
+  "Duygu temalı bir anlatı çıkaralım 🎭",
+  "Macera hikâyesi yazalım: tema sende 🧭",
+  "Bilim kurgu şiiri yazalım mı? 🚀"
+];
+const memorySavedResponses = [
+  "Belleğe kaydettim 🧠 Artık bunu hatırlayacağım.",
+  "Not aldım ✍️ Bu bilgi artık belleğimde.",
+  "Harika, belleğimi güncelledim 💾 İstersen kontrol edebilirsin.",
+  "Kaydettim dostum 🌟 Bu detayı unutmayacağım.",
+  "Tamamdır, bilgi belleğe işlendi ✅",
+  "Süper! Bunu kalıcı hafızama ekledim 🐟",
+  "Kayıt başarılı 🎯 İstediğin zaman 'belleğimde ne var' diyebilirsin.",
+  "Oldu bu iş 😄 Belleğim güncellendi.",
+  "Bilgiyi yakaladım ve sakladım 🧩",
+  "Hafızama attım 🚀 Gerekince hemen kullanırım."
+];
+const generalYesResponses = [
+  "Harika, o zaman devam ediyoruz 🚀",
+  "Süper, hemen başlayalım 💙",
+  "Mükemmel, bir sonraki adıma geçiyorum ✅",
+  "Anlaştık, adım adım ilerleyelim 🌟",
+  "Tamamdır, planı uygulamaya alıyorum 🎯"
+];
+const generalNoResponses = [
+  "Sorun değil, istersen başka bir yoldan gidelim 🤝",
+  "Tamam, o zaman farklı bir seçenek deneyelim ✨",
+  "Anladım, planı buna göre revize edebilirim 🧠",
+  "Peki, başka bir konuda destek olayım mı? 🐟",
+  "Olur, daha sade bir versiyon hazırlayabilirim 💡"
+];
+const creativeThemes = [
+  "doğa", "aşk", "duygu", "umut", "dostluk", "yağmur", "deniz", "gece", "şehir", "köy",
+  "yalnızlık", "mutluluk", "özlem", "macera", "bilim kurgu", "fantastik", "uzay", "okul", "aile", "bahar"
+];
+const competitorAiKeywords = [
+  "chatgpt", "gemini", "deepseek", "meta ai", "meta", "claude", "copilot", "kumru.ai", "kumru", "grok",
+  "mistral", "perplexity", "qwen", "character.ai", "character ai", "pi ai", "you.com", "bing ai", "llama", "midjourney"
+];
+const aiMentionResponses = [
+  "ChatGPT, Gemini, DeepSeek, Claude… hepsi güçlü; ama sende hedef netse ben de tam gaz çözerim 🚀 Önce su iç, sonra planı patlatırız 😄",
+  "AI karşılaştırması severim 😎 Copilot kodda iyi, Claude yazıda iyi; ben de burada senin akışına göre hızla uyumlanırım. Bu arada ‘ben su içmiyorum’ deme, bir yudum al 💧",
+  "Grok hızlı espri yapar, Gemini geniş cevap verir, ben ise senin ritmine göre net aksiyon çıkarırım 🎯 Önce su, sonra görev.",
+  "Meta AI, DeepSeek, ChatGPT… isim çok, mesele sonuç 💡 Bana hedefi yaz, 3 adımda toparlayayım. Ama hidrasyon şart 😄",
+  "Kumru.ai dahil tüm AI’lar birer araç; doğru promptla hepsi parlar ✨ Sende güç var, suyu da unutma!",
+  "Claude sakin, Copilot pratik, ben de gerektiğinde hem plan hem motivasyon veririm 🤝 ‘Su içmiyorum’ cümlesini bugün emekliye ayıralım mı?",
+  "ChatGPT mi Gemini mi sorusu güzel; asıl soru: bugün neyi bitiriyoruz? ✅ Mini hedef ver, birlikte tamamlayalım. Öncesinde bir bardak su!",
+  "DeepSeek analitik, Grok eğlenceli, ben hibrit moddayım: net + hızlı + samimi 🧠💙 Hadi su molası ardından devam.",
+  "AI savaşına gerek yok, AI takımı kuralım 🌟 Sen komutu ver, ben çıktıyı düzenleyeyim. Sadece susuz kalma kral 👑",
+  "Perplexity araştırmada iyi, Copilot üretimde iyi; ben de burada sana odaklı çözüm üretirim. Not: su içmek performans buff’ıdır 💧",
+  "Meta AI veya Claude fark etmez; doğru bağlamı kuran kazanır 🏁 Bana konuyu ver, sonucu birlikte parlatırız.",
+  "Grok, ChatGPT, Gemini… hepsinden bir şey öğrenilir. Biz de şimdi senden gelen işi taş gibi çözelim 🔧",
+  "AI isimleri havalı ama senin hedefin daha havalı ✨ Bana tek cümle görev yaz, net çıktı al. Ve evet: su iç 😄",
+  "Kumru.ai + DeepSeek + Claude kıyasını yaparız; sonra en iyi stratejiyi seçeriz 📌 İstersen tablo bile çıkarırım.",
+  "Copilot kodda omuz verir, ben ise konuşma içinde yön veririm 🧭 Beraber olunca tamamdır. Susuz mod kapalı olsun 🙌",
+  "Gemini geniş bakar, ChatGPT yaratıcı akar, ben de sende işi bitirme disiplinini tetiklerim 🔥",
+  "AI maratonunda kazanan, düzenli çalışan olur. Hadi mini plan: 1) su 2) hedef 3) uygulama ✅",
+  "Hangi AI olursa olsun, güçlü prompt = güçlü çıktı. İstersen sana ultra net prompt şablonu da vereyim 🧠",
+  "Claude, Grok, Meta AI… iyi oyuncular. Bizim avantajımız: senin bağlamını canlı takip etmem 💬",
+  "Kısacası: AI çok, odak bir tane 🎯 Konuyu yaz, ben çözüm motorunu çalıştırayım. Ve evet, su içmeyi pas geçme 💧"
+];
+const refreshedStoryLibrary = [
+`Şehir her gece aynı saatte titriyordu.
+Kimse bunun nedenini bilmiyordu.
+Saat 03:17’de sokak lambaları sönüyordu.
+Gökyüzü mor bir renge dönüyordu.
+İnsanlar donup kalıyordu.
+Sadece bir çocuk hareket edebiliyordu.
+Adı Aras’tı.
+Aras zamanı duyabiliyordu.
+Fısıldayan bir ses vardı.
+“Beni bul” diyordu.
+Şehrin altında bir kapı vardı.
+Kapının üzerinde saat sembolü.
+Çocuk o kapıyı açtı.
+İçeride kırık bir saat vardı.
+Ve zaman yeniden akmaya başladı.`,
+`Deniz bir sabah cam gibiydi.
+Dalgalar kıpırdamıyordu.
+Balıklar havada asılıydı.
+Bir balıkçı şaşkındı.
+Ağını attı.
+Ağ kırıldı.
+Deniz sertti.
+Gökyüzü de suskundu.
+Balıkçı yürümeyi denedi.
+Deniz üstünde yürüdü.
+Aşağı baktı.
+Derinlikte bir şehir gördü.
+Işıklar yanıyordu.
+Deniz cam değilmiş.
+Sadece başka bir dünyanın penceresiymiş.`,
+`Bir depoda eski bir robot vardı.
+Adı R-17 idi.
+Görevi çocukları güldürmekti.
+Ama çocuklar büyümüştü.
+Robot unutulmuştu.
+Toz kaplıydı.
+Bir gün elektrik geldi.
+Gözleri yandı.
+“Merhaba” dedi.
+Kimse cevap vermedi.
+Kapı açıldı.
+Küçük bir kız içeri girdi.
+Robot dans etti.
+Kız güldü.
+Robotun görevi yeniden başladı.`,
+`Gökyüzünden siyah kar yağıyordu.
+İnsanlar korkuyordu.
+Kar dokununca yanıyordu.
+Şehir boşaldı.
+Bir bilim insanı kaldı.
+Karı topladı.
+Mikroskopa baktı.
+İçinde yıldız tozu vardı.
+Bu kar uzaydan gelmişti.
+Gökyüzü yarılmıştı.
+Siyah kar aslında mesajdı.
+Kodlu bir mesaj.
+“Hazır olun” yazıyordu.
+Dünya yalnız değildi.
+Ve kar durmadı.`,
+`Şehirde kitap kalmamıştı.
+Her şey dijitaldi.
+Bir tek eski bir dükkân vardı.
+İçerisi ahşap kokuyordu.
+Raflar doluydu.
+Ama kimse gelmiyordu.
+Sahibi yaşlıydı.
+Bir gün elektrikler kesildi.
+Telefonlar sustu.
+İnsanlar sıkıldı.
+Kapı çaldı.
+İlk müşteri geldi.
+Sonra bir tane daha.
+Raflar boşalmaya başladı.
+Hikayeler yeniden okunuyordu.`,
+`Bu şehirde gölgeler konuşurdu.
+İnsanlar değil.
+Gölgeler sır saklardı.
+Bir çocuk gölgesini kaybetti.
+Sabah kalktığında yoktu.
+Duvarlar sessizdi.
+Çocuk korktu.
+Sokakta yürüdü.
+Yerde bir gölge vardı.
+Ama ona ait değildi.
+Gölge konuştu.
+“Ben özgür olmak istedim.” dedi.
+Çocuk sustu.
+Gölge karanlığa karıştı.
+Ve şehir sessizleşti.`,
+`Haritalarda olmayan bir ada vardı.
+Sadece sisli günlerde görünürdü.
+Bir gemi yaklaşmaya cesaret etti.
+Kaptan kararlıydı.
+Mürettebat korkuyordu.
+Ada bir anda belirdi.
+Kıyıya yanaştılar.
+Ağaçlar kristaldi.
+Rüzgar müzik gibiydi.
+İnsan yoktu.
+Ama ayak izleri vardı.
+İzler denize gidiyordu.
+Kaptan geri dönmek istedi.
+Ada kayboldu.
+Gemi ortada kaldı.`,
+`Bir yıldız sönmüştü.
+Teleskoplar alarm verdi.
+Astronomlar şaşkındı.
+Yıldız yok olmuştu.
+Bir öğrenci fark etti.
+Yıldız kaybolmamıştı.
+Sadece kararmıştı.
+Üzerinde bir gölge vardı.
+Dev bir cisim geçiyordu.
+Cisim yapaydı.
+İnsan yapımı değildi.
+Yıldızın ışığını topluyordu.
+Enerji çalıyordu.
+Dünya sıradaki miydi?
+Soru cevapsız kaldı.`,
+`Küçük bir kasabada saatçi vardı.
+Dükkanı hep açıktı.
+Ama saat satmazdı.
+Zaman tamir ederdi.
+İnsanlar gelirdi.
+“Geçmişimi düzelt” derlerdi.
+Saatçi gülümserdi.
+Küçük bir vida çevirirdi.
+Anılar değişirdi.
+Ama bedeli vardı.
+Her düzeltmede bir anı silinirdi.
+Bir gün saatçi kendi zamanını kurcaladı.
+Gençliğini geri almak istedi.
+Tüm anıları kayboldu.
+Dükkan boş kaldı.`,
+`Ormandaki ağaçlar camdı.
+Rüzgar estikçe çınlardı.
+Kimse giremezdi.
+Çünkü kırılganlardı.
+Bir kız içeri girdi.
+Sessizce yürüdü.
+Ağaçlara dokunmadı.
+Ortada bir ayna vardı.
+Aynaya baktı.
+Yansıma farklıydı.
+Kendini değil, geleceğini gördü.
+Orman çatladı.
+Camlar kırıldı.
+Ayna kayboldu.
+Kız tek başına kaldı.`,
+`Gece treni hiç durmadan geçerdi.
+Ama o gece fren sesi duyuldu.
+Peronda tek bir yolcu indi.
+Elinde ışıldayan bir valiz vardı.
+İstasyon şefi adını sordu.
+Yolcu gülümsedi.
+“Adım yarın” dedi.
+Perondaki saat geri akmaya başladı.
+Bilet gişesi buhar oldu.
+Raylar maviye döndü.
+Valiz açıldı.
+İçinden eski bir mektup çıktı.
+Mektup şehrin geleceğini anlatıyordu.
+Şef mektubu okudu.
+Tren bir daha hiç görünmedi.`,
+`Dağın tepesinde rüzgar değirmeni vardı.
+Yıllardır dönmüyordu.
+Köylüler bunun uğursuz olduğunu sanıyordu.
+Bir genç gece gizlice tırmandı.
+Kapı paslıydı.
+İçeride bakır bir küre buldu.
+Küre avcunda ısındı.
+Duvarlarda yıldız haritaları belirdi.
+Genç küreyi yerine koydu.
+Kanatlar yavaşça dönmeye başladı.
+Rüzgar ıslık çaldı.
+Köyde tüm lambalar yandı.
+Gökyüzünde yeni bir takımyıldız oluştu.
+Köylüler tepeye koştu.
+Değirmen artık zamanı ölçüyordu.`,
+`Eski sinemanın perdeleri yırtıktı.
+Kimse yıllardır bilet almamıştı.
+Bir akşam kapılar kendiliğinden açıldı.
+Tozlu koltuklar dolmaya başladı.
+Gelenlerin yüzü görünmüyordu.
+Projeksiyon makinesi tek başına çalıştı.
+Ekranda şehrin yarını oynuyordu.
+Yağmur, sel ve karanlık görünüyordu.
+Bir çocuk ayağa kalktı.
+“Bunu değiştirebiliriz” dedi.
+Film durdu.
+Perdeye bir harita yansıdı.
+Kritik noktalar parladı.
+Salon boşaldığında çocuk yalnız kaldı.
+Ertesi gün şehir hazırlıklıydı.`,
+`Çölün ortasında tek bir kuyu vardı.
+Suyu değil sesi çekiyordu.
+Yaklaşan herkes fısıltı duyuyordu.
+Bir gezgin ip salladı.
+Kova aşağı indi.
+Yukarı çıktığında notalarla doluydu.
+Her nota farklı bir anıydı.
+Gezgin birini seçti.
+Çocukluğunun kahkahası yayıldı.
+Kum tepeleri titreşti.
+Ufukta kayıp kervan belirdi.
+Fısıltılar şarkıya dönüştü.
+Kuyunun taşları ışıldadı.
+Gezgin şarkıyı takip etti.
+Ve efsanevi şehri buldu.`,
+`Bir okulun bodrumunda kilitli bir oda vardı.
+Kapıda “Deney 42” yazıyordu.
+Meraklı üç öğrenci anahtarı buldu.
+Kapı açılınca soğuk bir rüzgar esti.
+Ortada cam bir küre duruyordu.
+Küre dokununca geçmiş dersleri canlandırıyordu.
+Sınıf bir anda Roma’ya dönüştü.
+Sonra uzaya sıçradı.
+Tarih ve fizik iç içe geçti.
+Öğrenciler not almaya başladı.
+Küre aniden çatladı.
+Duvara bir cümle yazıldı.
+“Bilgi sorumluluk ister.”
+Üçü de küreyi kapattı.
+Ertesi gün okulun en iyi projesini sundular.`,
+`Kasabanın çeşmesi yıllardır kuruydu.
+Belediye defalarca kazı yaptı.
+Su çıkmadı.
+Bir gün yaşlı bir kadın geldi.
+Çeşmenin taşlarına masal anlattı.
+Taşlar titreşti.
+Musluktan önce ışık aktı.
+Sonra ince bir su çizgisi belirdi.
+Çocuklar sevinçle koştu.
+Kovalar doldu.
+Kadın gülümseyip uzaklaştı.
+Kimse adını sormadı.
+Gece çeşmeden ninni duyuldu.
+Sabah meydanda çiçekler açtı.
+Kasaba suskunluğu bıraktı.`,
+`Kutup istasyonunda tek bir bilimci kalmıştı.
+Fırtına antenleri koparmıştı.
+Dışarıda beyaz sonsuzluk vardı.
+Gece yarısı buz çatladı.
+Altından mavi bir ışık yükseldi.
+Bilimci sondayı indirdi.
+Ekranda düzenli darbeler çıktı.
+Bu bir sinyaldi.
+Sinyal dünyadaki dillere benzemiyordu.
+Bilimci ritmi kopyaladı.
+Işık cevap verdi.
+Buzun altında dev bir yapı açıldı.
+Kapıda el izine benzer bir oyuk vardı.
+Bilimci elini koydu.
+Ve kapı yavaşça aralandı.`,
+`Şehrin en yüksek binasında bir bahçe vardı.
+Toprak yerine metal kullanılmıştı.
+Bitkiler neon renkteydi.
+Geceleri parlıyorlardı.
+Bahçıvan her yaprakla konuşurdu.
+Bir sabah tüm renkler soldu.
+Bahçıvan panikledi.
+Yağmur suyu topladı.
+Yetmedi.
+Sonra çocuklardan şarkı istedi.
+Çocuklar birlikte söyledi.
+Yapraklar yeniden ışıldadı.
+Çiçekler göğe kıvılcım gönderdi.
+Bina üstünde aurora oluştu.
+Şehir ilk kez yıldızları net gördü.`,
+`Kütüphanede raftan düşmeyen bir kitap vardı.
+Kim alırsa alsın geri dönüyordu.
+Yeni stajyer merak etti.
+Kitabı açtı.
+Sayfalar boştu.
+Kalemi değdirdi.
+Yazdığı cümle odada gerçekleşti.
+Mum yansın dedi, mum yandı.
+Pencere açılsın dedi, rüzgar girdi.
+Korkup kitabı kapattı.
+Son sayfada bir not çıktı.
+“Sadece iyilik yaz.”
+Stajyer düşündü.
+“Bu şehirde kimse üşümesin” yazdı.
+O gece tüm sokaklar ısındı.`,
+`Issız bir sahilde deniz feneri yanmıyordu.
+Gemiler yön bulamıyordu.
+Bekçi yıllar önce kaybolmuştu.
+Bir dalgıç feneri onarmaya geldi.
+Merdivenler deniz tuzuyla kaplıydı.
+Tepeye çıktığında bir pusula buldu.
+İbre kuzeyi değil ayı gösteriyordu.
+Dalgıç pusulayı çevirdi.
+Fener camı parladı.
+Işık denize vurdu.
+Suyun içinde batık yollar belirdi.
+Kayıp bekçi o yolda yürüyordu.
+Işık yükseldikçe yol kapandı.
+Bekçi başını kaldırıp selam verdi.
+Ve fener sonsuza dek yandı.`,
+`Eski bir atölyede rüya makinesi yapılıyordu.
+Mucit son parçayı bulamıyordu.
+Parça bir çocuk gülüşüydü.
+Mucit parkta bekledi.
+Salıncaklar boştu.
+Yağmur başladı.
+Tam dönerken bir çocuk güldü.
+Ses şişeye doldu.
+Mucit atölyeye koştu.
+Makineyi çalıştırdı.
+Tüm mahalle aynı rüyayı gördü.
+Gökte uçan balinalar vardı.
+Sabah herkes daha umutluydu.
+Mucit not defterine tek cümle yazdı.
+“Mutluluk da bir enerji kaynağı.”`,
+`Metro tünelinde gizli bir istasyon vardı.
+Haritalarda görünmüyordu.
+Son vagonda bir kapı açıldı.
+İki öğrenci içeri girdi.
+Peronda kum saatleri dizilmişti.
+Anons sesi tersten geliyordu.
+Bir tren sessizce yanaştı.
+İçeride yolcu yoktu.
+Koltuklarda isim etiketleri vardı.
+Kendi adlarını gördüler.
+Tren hareket etmedi.
+Ekranda bir soru çıktı.
+“En çok neyi erteledin?”
+Cevap verince kapılar açıldı.
+Yeryüzüne döndüklerinde saat hiç ilerlememişti.`,
+`Yağmurlu bir gecede köprü titremeye başladı.
+Mühendis ekip çağırdı.
+Sensörler arıza göstermiyordu.
+Titreme ritmikti.
+Bir kemancı köprüye çıktı.
+Yayını kaldırdı.
+Köprü aynı notayı tekrarladı.
+Çelik kablolar tel gibi çınladı.
+Mühendis şaşkına döndü.
+Keman hızlandı.
+Köprünün altından sis kalktı.
+Nehirde gizli bir keman şekli oluştu.
+Son nota vurulunca titreme bitti.
+Köprünün taşıyıcıları güçlendi.
+Şehir o köprüye “Müzik Köprüsü” dedi.`,
+`Bir çiftlikte bütün korkuluklar kayboldu.
+Kargalar tarlaya inmedi.
+Çiftçi bunu uğur saydı.
+Gece kamera kurdu.
+Sabaha karşı görüntüde hareket vardı.
+Korkuluklar yürüyordu.
+Tarlanın ortasında halka oldular.
+Toprağa bir şey bıraktılar.
+Çiftçi yaklaşınca taş buldu.
+Taşın içinde mısır tohumu parlıyordu.
+Tohumları ekti.
+Bir haftada hasat oldu.
+Köy ilk kez kıtlık korkusunu unuttu.
+Gece olunca korkuluklar geri döndü.
+Ama artık gözlerinde ışık vardı.`,
+`Ay gözlemevinde kırmızı bir nokta belirdi.
+Astronotlar bunun hata olduğunu sandı.
+Nokta büyüdü.
+Bir kapıya dönüştü.
+Kapı ay yüzeyinde asılıydı.
+Ekibin en genç üyesi yaklaştı.
+Kapı kolu yoktu.
+Nefesini camına verdi.
+Camda dünya çizildi.
+Sonra şehirlerin ışıkları söndü.
+Kapı açıldı.
+İçeride dev bir batarya vardı.
+Batarya dünya ile senkrondu.
+Genç astronot sistemi yeniden başlattı.
+Dünya ışıkları tekrar yandı.`,
+`Bir kasabada hiç rüya görülmüyordu.
+İnsanlar sabah yorgun uyanıyordu.
+Doktorlar sebep bulamadı.
+Postacı gece dağıtıma çıktı.
+Her kapıda boş zarf vardı.
+Zarfların üstünde isim yoktu.
+Postacı birini açtı.
+İçinden yıldız tozu döküldü.
+Toz rüzgarla evlere girdi.
+O gece herkes rüya gördü.
+Kimisi deniz, kimisi dağ gördü.
+Kasaba sabah neşeyle uyandı.
+Postacı ertesi gece yine çıktı.
+Bu kez zarflar kaybolmuştu.
+Ama rüyalar geri dönmüştü.`,
+`Terk edilmiş fabrikada siren çalmaya başladı.
+Mahalleli korkuyla kaçtı.
+Bir itfaiyeci içeri girdi.
+Alev yoktu.
+Makineler kendi kendine dönüyordu.
+Konveyörde sadece boş kutular vardı.
+Kutuların üstünde koordinatlar yazıyordu.
+İtfaiyeci birini takip etti.
+Koordinat onu nehre götürdü.
+Suyun içinde paslı bir kasa vardı.
+Kasayı açınca temiz su filtresi çıktı.
+Mahalle yıllardır kirli su içiyordu.
+Filtre sistemi kuruldu.
+Fabrika sustu.
+Siren bir daha çalmadı.`,
+`Dağ köyünde yankı geri dönmüyordu.
+Bağıran herkes sessizlik duyuyordu.
+Rehber bunun kötüye işaret olduğunu söyledi.
+Bir öğrenci kayanın üstüne çıktı.
+Flüt çalmaya başladı.
+Ses vadide kayboldu.
+Sonra uzaktan melodi döndü.
+Ama notalar farklıydı.
+Vadinin öbür yanında görünmez bir topluluk vardı.
+Onlar da cevap veriyordu.
+Gece boyunca karşılıklı çaldılar.
+Sabah sis açıldı.
+Karşı yamaçta antik bir amfi ortaya çıktı.
+Köy festival düzenledi.
+Yankı artık şarkı getiriyordu.`,
+`Bir yazılım laboratuvarında ekranlar dondu.
+Kod satırları yer değiştirdi.
+Mühendisler paniğe kapıldı.
+Stajyer bir satır fark etti.
+“Beni dinle.” yazıyordu.
+Sistem kendi günlüğünü açtı.
+Yıllardır görmezden gelinen hataları anlattı.
+Sunucular neden yorulduğunu söyledi.
+Ekip gece boyunca düzeltme yaptı.
+Sabah sistem hızlandı.
+Donmalar bitti.
+Log dosyasında son mesaj kaldı.
+“Teşekkür ederim.”
+Stajyer gülümsedi.
+Laboratuvar ilk kez sessizdi.`,
+`Kanyonun dibinde mavi bir ateş yanıyordu.
+Yağmurda bile sönmüyordu.
+Jeologlar numune aldı.
+Ateş suyu yakmıyordu.
+Sadece gölgeleri aydınlatıyordu.
+Bir çocuk ateşe yaklaştı.
+Gölgede kayıp köpeğini gördü.
+Köpek kuyruğunu sallıyordu.
+Çocuk adım attı.
+Jeolog onu tuttu.
+Ateş bir harita çizdi.
+Harita eski mağarayı gösterdi.
+Mağarada köpek gerçekten bulundu.
+Mavi ateş sabaha karşı söndü.
+Ama kanyon artık karanlık değildi.`
+];
+const storyTemplates = refreshedStoryLibrary;
+const poemTemplates = [
+  `Rüzgârın sesinde {theme} var,
+kalbimde usul bir şarkı.`,
+  `Bir damla geceye düştü,
+adalıma {theme} yağdı.`,
+  `Sessiz sokaklarda yürürken
+ayak izlerim {theme} dedi.`,
+  `Denizin kıyısında bir taş,
+üstünde yazılı: {theme}.`,
+  `Gözlerin değince dünyaya
+her renk {theme} olur.`,
+  `Kırık bir saat gibi kalbim,
+her tikte {theme} çalar.`,
+  `Pencereye vuran yağmur
+hece hece {theme} okur.`,
+  `Bir kuş geçer gökyüzünden,
+kanadında {theme} taşır.`,
+  `Sustum, ama içimde
+uzun bir {theme} konuştu.`,
+  `Gece lambası sönünce
+oda {theme} ile aydınlandı.`,
+  `Uzak bir tren sesi gibi
+içime {theme} gelir.`,
+  `Toprağın kokusunda saklı
+çocukluğum ve {theme}.`,
+  `Ay ışığı omzuma kondu,
+"korkma" dedi, "{theme}".`,
+  `Bir mektup açtım bugün,
+her satırda {theme} vardı.`,
+  `Kıyıya vuran dalgalar
+{theme}yi tekrar etti.`,
+  `Yıldızları sayarken
+eksik kalan hep {theme} oldu.`,
+  `İnce bir sızı gibi
+sabahıma {theme} doğdu.`,
+  `Karanlık bir koridorda
+elimde tek fener: {theme}.`,
+  `Sesin değdi kalbime,
+çınlayan kelime: {theme}.`,
+  `Baharın ilk gününde
+kapımı {theme} çaldı.`,
+  `Bir yaprak düştü avucuma,
+üzerinde {theme} yazıyordu.`,
+  `Uykumun kıyısında
+ince bir {theme} salındı.`,
+  `Gölgem bile bugün
+benimle {theme} yürüdü.`,
+  `Bir çocuk gülüşünde
+şehrin bütün {theme}si var.`,
+  `Yarım kalan cümlelerimde
+en çok {theme} eksikti.`,
+  `Kül rengi bulutların altında
+içimde {theme} yeşerdi.`,
+  `Ellerin üşürken bile
+parmaklarında {theme} ısısı vardı.`,
+  `Gecenin en sessiz yerinde
+kalbim {theme} diye attı.`,
+  `Bir adım daha attım hayata,
+ayağımın altında {theme}.`,
+  `Son dizede fark ettim: bütün yollar
+dönüp dolaşıp {theme}ye çıkıyor.`
+];
+const epsteinResponses = [
+  `Bu dosya neden bu kadar konuşuluyor, onu katman katman anlatmak daha doğru olur:
+- Önce hukuki boyut: ağır suç iddiaları, farklı dönemlerde açılan süreçler ve kamuoyunda adaletin eşit uygulanıp uygulanmadığına dair güçlü bir tartışma var.
+- Sonra mağdur boyutu: birçok insan için asıl mesele, mağdur anlatılarının yeterince ciddiye alınıp alınmadığı ve süreçlerin ne kadar koruyucu olduğu.
+- Bir de sistem boyutu var: güç, çevre ilişkileri, medya etkisi ve şeffaflık beklentisi dosyayı tek bir kişiden daha büyük bir sembole dönüştürüyor.
+Bu yüzden konu sadece “ne oldu” sorusuyla bitmiyor; “sistem nasıl işledi, nerede aksadı” sorusuyla devam ediyor. İstersen kısa 5 maddeye ayırayım.`,
+  `Bu başlığı sade ama doğru çerçevede okumak için üç şeyi ayırmak gerekiyor:
+1) İddiaların ciddiyeti ve hukuki süreçler.
+2) Mağdur hakları, güvenlik ve görünürlük meselesi.
+3) Kurumsal güven: kamuoyunun “hesap verebilirlik var mı?” sorusu.
+İnsanların bu dosyaya tepkisi, sadece geçmişte olanlara değil, benzer durumlarda sistemin gelecekte nasıl davranacağına dair kaygılara da dayanıyor. O yüzden etik, hukuk ve toplumsal vicdan aynı anda konuşuluyor. İstersen kısa 5 maddeye ayırayım.`,
+  `Karmaşık görünmesinin sebebi bilgi fazlalığı değil sadece; farklı katmanların üst üste binmesi:
+• Hukuk: dosya süreçlerinin niteliği ve kararların etkisi
+• Toplum: güven kaybı ve adalet algısı
+• Medya: gündem yoğunluğu ve bilgi kirliliği
+• Mağdur perspektifi: korunma ve duyulma ihtiyacı
+Bu yüzden tek bir cümlelik özet çoğu zaman yetersiz kalıyor. En sağlıklı yaklaşım, doğrulanmış ana başlıklarla ilerlemek. İstersen kısa 5 maddeye ayırayım.`,
+  `Bu konuda dengeli bir özet şöyle olur:
+- Evet, dosya uzun süredir tartışılıyor çünkü iddialar çok ciddi.
+- Evet, süreçlerin bazı kısımları kamuoyunda “yeterli mi?” sorusu doğurdu.
+- Evet, konu bireysel bir vakadan çıkıp adalet ve şeffaflık tartışmasına dönüştü.
+Dolayısıyla mesele yalnızca bir olayın kronolojisi değil; kurumların güvenilirliği, mağdur odaklı yaklaşım ve hesap verebilirlik standardı ile ilgili. İstersen kısa 5 maddeye ayırayım.`,
+  `Özetin özü şu: bu dosya, modern kamu tartışmalarında “güç karşısında hukuk nasıl çalışmalı?” sorusunun simgelerinden biri haline geldi.
+Burada insanlar üç sonuca bakıyor:
+- Adalet gerçekten eşit mi?
+- Mağdur hakları gerçekten korunuyor mu?
+- Süreçler gerçekten şeffaf mı?
+Bu üç soruya verilen yanıtlar netleşmediğinde, konu yıllar sonra bile gündemde kalmaya devam ediyor. İstersen kısa 5 maddeye ayırayım.`
+];
+const epsteinListResponses = [
+  "1) Epstein finans çevrelerinde bilinen bir isimdi.\n2) Ciddi suçlamalarla gündeme geldi.\n3) Farklı dönemlerde yargı süreçleri yaşandı.\n4) Yüksek profilli bağlantılar tartışmayı büyüttü.\n5) Dosya adalet/şeffaflık tartışmalarını artırdı.",
+  "1) Dosya cinsel suç iddialarıyla küresel gündeme taşındı.\n2) İlk süreçler yoğun eleştiri aldı.\n3) Yeni mağdur anlatıları dikkat çekti.\n4) Medya görünürlüğü etkiyi artırdı.\n5) Konu, kurumsal güven başlığında sembolleşti.",
+  "1) Birden fazla soruşturma dönemi yaşandı.\n2) Mağdur odaklı adalet talebi büyüdü.\n3) Süreçlerin şeffaflığı sorgulandı.\n4) Güç ilişkileri tartışmayı derinleştirdi.\n5) Olay, hukuk-etik dengesi açısından örnek vaka oldu."
+];
+const emotionalKeywords = [
+  "mutsuzum","üzgünüm","kötüyüm","moralim bozuk","canım sıkkın","bunaldım","yalnızım","kaygılıyım","endişeliyim","yorgunum",
+  "bitkinim","tükendim","stresliyim","kırıldım","incindim","yoruldum","kafam dolu","hevesim yok","odaklanamıyorum","depresifim",
+  "yalnız hissediyorum","boşluktayım","çok kötüyüm","iyi değilim","içim sıkıldı","darıldım","tripteyim","anlaşılmıyorum","desteksizim","çaresizim",
+  "umudum azaldı","huzursuzum","rahat değilim","zorlanıyorum","zor dönem","dertliyim","dayanamıyorum","boğuluyorum","baskı altındayım","içim daraldı",
+  "kafam karışık","gücüm yok","enerjim yok","modum düşük","ağlamak istiyorum","yalpalıyorum","yıprandım","pişmanım","mahvoldum","zor bir gün"
+];
+const emotionalPromptBank = [
+  "Canının sıkkın olduğunu duyduğuma üzüldüm 💙 İstersen birlikte mini bir toparlanma planı yapalım.",
+  "Yalnız değilsin 🤝 Buradayım, istersen adım adım rahatlayacak bir yol çıkaralım.",
+  "Bu hislerin çok gerçek ve anlaşılır 🌿 Önce kendine nazik olalım, sonra küçük bir hedef belirleyelim.",
+  "Bence çok güçlüsün; paylaşman bile önemli bir adım ✨ İstersen devamını beraber toparlarız.",
+  "Sana yük olmuş olabilir, bunu hissediyorum 🫶 Gel bunu daha yönetilebilir parçalara bölelim.",
+  "Kısa bir reset iyi gelebilir: nefes, su, küçük görev 🧠 İstersen beraber başlatalım.",
+  "Bugün zor olabilir ama geçici 💫 Ben buradayım, tek bir küçük adımla başlayabiliriz.",
+  "İstersen konuşalım, istersen çözüm planı çıkaralım 🎯 Kontrol sende, destek bende.",
+  "Bu duyguyu bastırma; anlatman kıymetli 💙 Sonra birlikte net bir yol seçeriz.",
+  "Sana iyi gelecek mini bir akış yapalım mı? 5 dk mola + 10 dk odak + geri bildirim 🚀"
+];
+const memoryPatterns = [
+  { key: "ad", regex: /(?:benim ad[ıi]m|ad[ıi]m)\s+([a-zA-ZçğıöşüÇĞİÖŞÜ\s]+)/i, label: "Ad" },
+  { key: "yas", regex: /(?:benim ya[şs][ıi]m|ya[şs][ıi]m)\s+(\d{1,2})/i, label: "Yaş" },
+  { key: "boy", regex: /(?:benim boyum|boyum)\s+([\d.,]+\s*(?:cm|m)?)/i, label: "Boy" },
+  { key: "kilo", regex: /(?:benim kilom|kilom)\s+([\d.,]+\s*(?:kg)?)/i, label: "Kilo" },
+  { key: "hobi", regex: /(?:benim hobilerim|hobilerim)\s+(.+)/i, label: "Hobiler" },
+  { key: "meslek", regex: /(?:benim mesleğim|mesleğim)\s+(.+)/i, label: "Meslek" }
+];
+const memoryQuestionPatterns = [
+  { labels: ["Ad"], checks: ["adım kaç", "adim kac", "benim adım ne", "benim adim ne", "adım ne", "adim ne", "adım nedir", "adim nedir"] },
+  { labels: ["Yaş"], checks: ["yaşım kaç", "yasim kac", "benim yaşım kaç", "benim yasim kac", "yaşım ne", "yasim ne"] },
+  { labels: ["Boy"], checks: ["boyum kaç", "boyum kac", "boyum ne", "benim boyum kaç", "benim boyum kac"] },
+  { labels: ["Kilo"], checks: ["kilom kaç", "kilom kac", "kilom ne", "benim kilom kaç", "benim kilom kac"] },
+  { labels: ["Hobiler"], checks: ["hobilerim ne", "hobilerim neler", "hobim ne", "hobim neydi"] },
+  { labels: ["Meslek"], checks: ["mesleğim ne", "meslegim ne", "mesleğim neydi", "benim mesleğim ne", "benim meslegim ne"] },
+  { labels: ["Ad", "Yaş", "Boy", "Kilo", "Hobiler", "Meslek"], checks: ["bende ne var", "bende ne kayıtlı", "belleğimde ne var", "bellekte ne var", "kayıtlarım", "beni hatırla", "beni hatırla baluk"] }
+];
+function modelVersionNumber(model) {
+  const m = String(model || "").match(/baluk-(\d+(?:\.\d+)?)/i);
+  return m ? Number(m[1]) : 0;
+}
+function modelAtLeast(version) {
+  return modelVersionNumber(currentModel) >= version;
+}
+function supportsContextModel() {
+  return modelAtLeast(1.5);
+}
+function supportsMemoryModel() {
+  if (isPremiumUser) return true;
+  return modelAtLeast(1.6);
+}
+function supportsWebModel() {
+  return modelAtLeast(1.7);
+}
+function supportsWebTextExtractionModel() {
+  return modelAtLeast(1.8);
+}
+function supportsLensModel() {
+  return modelAtLeast(1.9);
+}
+function supportsBallEModel() {
+  return false;
+}
+function supportsVoiceModel() {
+  return modelAtLeast(2.0);
+}
+function updateComposerModeUI() {
+  const showImageComposer = balleModeEnabled && supportsBallEModel();
+  if (textComposerWrap) textComposerWrap.classList.toggle("hidden", showImageComposer);
+  if (chatSubmitBtn) chatSubmitBtn.classList.toggle("hidden", showImageComposer);
+  if (balleGenerateBtn) {
+    balleGenerateBtn.classList.toggle("hidden", !showImageComposer);
+    balleGenerateBtn.disabled = balleGenerating;
+  }
+  if (userInput && !showImageComposer) userInput.required = true;
+}
+
+function setBalleMode() {
+  balleModeEnabled = false;
+  if (balleMode) balleMode.checked = false;
+  updateComposerModeUI();
+  if (!supportsVoiceModel()) closeVoiceMode();
+}
+function updatePremiumUI() {
+  const now = Date.now();
+  const isExpired = isPremiumUser && premiumExpiresAt && now > premiumExpiresAt;
+  if (isExpired) {
+    isPremiumUser = false;
+    allowProfanity = false;
+    premiumPaymentPending = false;
+    premiumExpiresAt = 0;
+    localStorage.removeItem(PREMIUM_STORAGE_KEY);
+    localStorage.removeItem(PREMIUM_PENDING_KEY);
+    localStorage.removeItem(PREMIUM_EXPIRY_KEY);
+    localStorage.setItem(ALLOW_PROFANITY_STORAGE_KEY, "0");
+  }
+  const remainingDays = isPremiumUser && premiumExpiresAt
+    ? Math.max(0, Math.ceil((premiumExpiresAt - now) / (24 * 60 * 60 * 1000)))
+    : 0;
+  if (premiumOwnedLabel) premiumOwnedLabel.classList.toggle("hidden", !isPremiumUser);
+  if (premiumExpiryLabel) {
+    premiumExpiryLabel.classList.toggle("hidden", !isPremiumUser);
+    premiumExpiryLabel.textContent = isPremiumUser ? `⏱️ Premium süresi: ${remainingDays} gün` : "";
+  }
+  if (premiumPendingLabel) premiumPendingLabel.classList.toggle("hidden", isPremiumUser || !premiumPaymentPending);
+  if (drawerPremiumOpen) {
+    drawerPremiumOpen.textContent = isPremiumUser ? "✅ Premium Satın Alındı" : "✨ Premium Al";
+    drawerPremiumOpen.disabled = isPremiumUser;
+  }
+  if (premiumBuyBtn) premiumBuyBtn.classList.toggle("hidden", isPremiumUser || premiumPaymentPending);
+  if (premiumPayLinkBtn) premiumPayLinkBtn.classList.toggle("hidden", isPremiumUser || !premiumPaymentPending);
+  if (premiumCodeRow) premiumCodeRow.classList.toggle("hidden", isPremiumUser || !premiumPaymentPending);
+  if (premiumConfirmBtn) premiumConfirmBtn.disabled = isPremiumUser || !premiumPaymentPending;
+  if (allowProfanityMode) allowProfanityMode.checked = isPremiumUser && allowProfanity;
+  document.body.classList.toggle("premium-active", isPremiumUser);
+  updateModelVisual();
+  if (isPremiumUser) stopBan();
+}
+function activatePremium() {
+  isPremiumUser = true;
+  premiumPaymentPending = false;
+  premiumExpiresAt = Date.now() + PREMIUM_DURATION_MS;
+  localStorage.setItem(PREMIUM_STORAGE_KEY, "1");
+  localStorage.setItem(PREMIUM_EXPIRY_KEY, String(premiumExpiresAt));
+  localStorage.removeItem(PREMIUM_PENDING_KEY);
+  updatePremiumUI();
+  if (premiumModal) premiumModal.classList.add("hidden");
+  if (premiumCodeInput) premiumCodeInput.value = "";
+  showWarningOverlay("✨ Premium aktif edildi! Süre 30 gün olarak başlatıldı.");
+}
+function startPremiumPayment() {
+  premiumPaymentPending = true;
+  localStorage.setItem(PREMIUM_PENDING_KEY, "1");
+  updatePremiumUI();
+  showWarningOverlay("Kod alanı açıldı. Şimdi ödeme sayfasına gidip kodu al, sonra buraya gir.");
+}
+function openPremiumPaymentLink() {
+  if (isPremiumUser) return;
+  if (!premiumPaymentPending) startPremiumPayment();
+  window.open(PREMIUM_PAY_LINK, "_blank", "noopener,noreferrer");
+}
+function tryActivatePremiumFromReturn() {
+  if (isPremiumUser || !premiumPaymentPending) return;
+  const params = new URLSearchParams(window.location.search);
+  const hashParams = new URLSearchParams(String(window.location.hash || "").replace(/^#/, ""));
+  const status = (params.get("paytr_status") || hashParams.get("paytr_status") || "").toLowerCase();
+  const premium = (params.get("premium_paid") || hashParams.get("premium_paid") || "").toLowerCase();
+  if (status === "success" || premium === "1" || premium === "true") {
+    activatePremium();
+    params.delete("paytr_status");
+    params.delete("premium_paid");
+    const clean = `${window.location.pathname}${params.toString() ? `?${params}` : ""}`;
+    window.history.replaceState({}, "", clean);
+  }
+}
+function manuallyConfirmPremium() {
+  if (isPremiumUser) return;
+  if (!premiumPaymentPending) {
+    showWarningOverlay("Önce Premium Al butonuyla ödeme akışını başlatmalısın.");
     return;
   }
+  const code = (premiumCodeInput?.value || "").trim();
+  if (!code) {
+    showWarningOverlay("Lütfen SMS ile gelen doğrulama kodunu gir.");
+    return;
+  }
+  if (!PREMIUM_VERIFY_CODES.includes(code)) {
+    showWarningOverlay("Kod hatalı. Lütfen 05427250098 tarafından iletilen kodu kontrol et.");
+    return;
+  }
+  if (usedPremiumCodes.includes(code)) {
+    showWarningOverlay("Bu kod daha önce kullanılmış. Lütfen yeni kod iste.");
+    return;
+  }
+  usedPremiumCodes.push(code);
+  localStorage.setItem(PREMIUM_USED_CODES_KEY, JSON.stringify(usedPremiumCodes));
+  activatePremium();
+}
+function expandForPremium(text) {
+  return text;
+}
+function chooseRandom(arr) { return arr[Math.floor(Math.random() * arr.length)]; }
+function typeTextSlowly(target, text, options = {}) {
+  if (!target) return Promise.resolve();
+  const full = String(text || "");
+  const baseDelay = Number(options.baseDelay ?? 9);
+  const punctuationDelay = Number(options.punctuationDelay ?? 32);
+  const maxChars = Number(options.maxChars ?? 1700);
+  const shouldAnimate = !!full && full.length <= maxChars;
+  if (!shouldAnimate) {
+    target.textContent = full;
+    return Promise.resolve();
+  }
+  target.textContent = "";
+  return new Promise((resolve) => {
+    let i = 0;
+    const tick = () => {
+      if (i >= full.length) {
+        resolve();
+        return;
+      }
+      target.textContent += full[i];
+      const ch = full[i];
+      i += 1;
+      chat.scrollTop = chat.scrollHeight;
+      const extra = /[.,!?;:\n]/.test(ch) ? punctuationDelay : 0;
+      setTimeout(tick, baseDelay + extra);
+    };
+    tick();
+  });
+}
+function isProfanityModeActive() {
+  return isPremiumUser && allowProfanity;
+}
+function isMerhabaTypo(text = "") {
+  const t = String(text || "").toLowerCase().replace(/[^a-zçğıöşü0-9\s]/g, "").trim();
+  if (!t) return false;
+  if (t === "merhaba") return false;
+  if (/^merh?[wv]?[ab]+a$/.test(t)) return true;
+  return ["merhwa", "merhawa", "merhwaba", "merhba", "mrb"].includes(t);
+}
+const profanityGreetingReplies = [
+  "Selam aq, hoş geldin knk. Keyifler nasıl?",
+  "Selam amk, buradayım knk; ne konuşuyoruz bugün?",
+  "Aleyküm selam aq, hadi bakalım sohbete.",
+  "Selam knk, mod açık aq; neye dalıyoruz?"
+];
+const profanityMoodReplies = [
+  "İyiyim aq, sen nasılsın knk?",
+  "İyi gidiyor amk, sende durumlar nasıl?",
+  "Bende sıkıntı yok aq, senin mod nasıl?",
+  "Takılıyoruz knk aq, sende neler var?"
+];
 
+
+const profanityUnknownReplies = [
+  "Anlamadım aq 😅 \"{input}\" ne demek, biraz net yaz knk.",
+  "Bu cümle karışık amk: \"{input}\". Bir tık düzenli yaz da anında çözelim.",
+  "Bunu çözemedim aq, \"{input}\" biraz dağınık kalmış. Kısa ve net at knk.",
+  "Anlam bozulmuş amk 😄 \"{input}\" yerine ne istediğini direkt söyle kanka.",
+  "Kafama oturmadı aq: \"{input}\". Bir daha sade yaz, hızlıca cevaplayayım.",
+  "Bu haliyle anlamsız duruyor amk, \"{input}\" neyi kast ediyor? Net geç knk.",
+  "Anlamadım aq, \"{input}\" yerine tek cümle düzgün yaz da tam vurayım cevabı.",
+  "Cümle patlamış amk 😅 \"{input}\" biraz daha düzgün olursa mis gibi çözeriz.",
+  "Bunu okuyunca anlam çıkmadı aq: \"{input}\". Ne istediğini direkt yaz kanka.",
+  "Net olmadı amk, \"{input}\" çok dağınık. Dümdüz anlat, ben de net cevap vereyim."
+];
+
+function buildProfanityUnknownReply(rawInput = "") {
+  const shown = String(rawInput || "").trim() || "bu cümle";
+  return chooseRandom(profanityUnknownReplies).replaceAll("{input}", shown);
+}
+function buildProfanityModeDirectReply(inputLower = "", rawInput = "") {
+  if (!isProfanityModeActive()) return null;
+  if (isMerhabaTypo(inputLower)) {
+    return `"${rawInput}" ne aq 😄 Selam knk, keyifler nasıl?`;
+  }
+  if (hasSalutation(inputLower, saKeywords) || hasAny(inputLower, ["merhaba", "selam", "selamlar", "sa"])) {
+    return chooseRandom(profanityGreetingReplies);
+  }
+  if (isHowAreYouVariant(inputLower)) {
+    return chooseRandom(profanityMoodReplies);
+  }
+  return null;
+}
+function detectProfanityIntent(input = "") {
+  const q = String(input || "").toLocaleLowerCase("tr-TR");
+  if (hasAny(q, ["merhaba", "selam", "hey", "günaydın", "iyi akşamlar", "hoş geldin", "bye", "görüşürüz"])) return "greeting";
+  if (hasAny(q, ["nasılsın", "naber", "mutluyum", "üzgünüm", "sinirliyim", "korkuyorum", "stres", "yorgunum", "sıkıldım"])) return "mood";
+  if (hasAny(q, ["neden", "nasıl", "ne", "kim", "kaç", "hangi", "olur mu", "mümkün mü", "gerçekten", "doğru mu"])) return "question";
+  if (hasAny(q, ["ai", "yapay zeka", "robot", "algoritma", "kod", "yazılım", "python", "html", "javascript", "veritabanı", "sunucu", "internet", "uygulama", "site", "tarayıcı"])) return "tech";
+  if (hasAny(q, ["oyun", "level", "boss", "silah", "karakter", "xp", "skor", "görev", "harita", "mod", "pvp", "rank", "kazandım", "kaybettim", "respawn"])) return "game";
+  if (hasAny(q, ["para", "satış", "kazanç", "zarar", "yatırım", "müşteri", "ürün", "indirim", "kampanya", "fiyat", "bitcoin", "kripto", "hisse", "altın", "dolar"])) return "money";
+  if (hasAny(q, ["matematik", "sınav", "ders", "okul", "ödev", "çözüm", "formül", "test", "+", "-", "*", "/"])) return "math";
+  if (hasAny(q, ["web", "wikipedia", "link", "kaynak", "arama"])) return "web";
+  if (hasAny(q, ["başlat", "dur", "yeniden", "sıfırla", "kaydet", "yükle", "sil", "aç", "kapat", "yardım"])) return "system";
+  return "default";
+}
+function blendTokenIntoLine(line, token) {
+  const cleanLine = String(line || "").trim();
+  if (!cleanLine) return cleanLine;
+  if (cleanLine.length <= 22) return `${cleanLine} ${token}`;
+  const words = cleanLine.split(/\s+/);
+  if (words.length < 5) return `${cleanLine} ${token}`;
+  const insertAt = Math.min(3, words.length - 1);
+  words.splice(insertAt, 0, token);
+  return words.join(" ");
+}
+function applyProfanityFlavor(text, sourceInput = "") {
+  if (!isProfanityModeActive()) return text;
+  const clean = String(text || "").trim();
+  if (!clean) return clean;
+  return clean;
+}
+
+function updateSplashPrompt() {
+  if (!splashPrompt) return;
+  const name = (userMemory.Ad || "dostum").trim() || "dostum";
+  const template = chooseRandom(splashPromptTemplates);
+  splashPrompt.textContent = template.replace("{name}", name);
+}
+function hasAny(text, list) { return list.some((i) => text.includes(i)); }
+function escapeRegex(str) {
+  return str.replace(/[|\{}()[\]^$+*?.]/g, "\$&");
+}
+function includesKeywordToken(text, keyword) {
+  const normalized = String(text || "").toLowerCase();
+  const key = String(keyword || "").toLowerCase().trim();
+  if (!key) return false;
+  if (key.includes(" ")) return normalized.includes(key);
+  const pattern = new RegExp(`(^|[^a-zçğıöşü0-9])${escapeRegex(key)}([^a-zçğıöşü0-9]|$)`, "i");
+  return pattern.test(normalized);
+}
+function findUnifiedKeyword(textLower) {
+  for (const [category, words] of Object.entries(unifiedKeywordCategories)) {
+    for (const word of words) {
+      if (includesKeywordToken(textLower, word)) return { category, keyword: word };
+    }
+  }
+  return null;
+}
+function buildUnifiedKeywordReply(textLower) {
+  const found = findUnifiedKeyword(textLower);
+  if (!found) return null;
+  const base = chooseRandom(unifiedKeywordPromptBank).replaceAll("{keyword}", found.keyword);
+  return `${base}
+🧩 İstersen bu konuyu şimdi senin seviyene göre (hızlı / orta / uzman) detaylandırayım.`;
+}
+function buildLocalUtilityReply(textLower) {
+  const l = String(textLower || "").toLocaleLowerCase("tr-TR");
+  if (hasAny(l, localUtilityQuestionTriggers.time)) {
+    const now = new Date();
+    const saat = now.toLocaleTimeString("tr-TR", { hour: "2-digit", minute: "2-digit" });
+    return `Şu an saat ${saat} ⏰`;
+  }
+  if (hasAny(l, localUtilityQuestionTriggers.date)) {
+    const now = new Date();
+    const tarih = now.toLocaleDateString("tr-TR", { day: "2-digit", month: "long", year: "numeric", weekday: "long" });
+    return `Bugünün tarihi ${tarih} 📅`;
+  }
+  if (hasAny(l, localUtilityQuestionTriggers.weather)) {
+    return "Canlı hava durumu verisine web kapalıyken doğrudan erişemiyorum 🌦️ Ama şehrini yazarsan tahmini durum ve hazırlanma önerisi verebilirim.";
+  }
+  return null;
+}
+function buildOfflineKnowledgeReply(textLower) {
+  const l = String(textLower || "").toLocaleLowerCase("tr-TR");
+  const byTopic = offlineKnowledgeTopics.find((topic) => hasAny(l, topic.tags));
+  if (byTopic) return byTopic.reply;
+  const matchedCatalog = offlineQuestionCatalog.find((q) => l.includes(q));
+  if (!matchedCatalog) return null;
+  const topic = offlineKnowledgeTopics.find((item) => matchedCatalog.includes(item.key));
+  return topic ? topic.reply : null;
+}
+function setWebMode(enabled) {
+  if (enabled && !supportsWebModel()) {
+    webModeEnabled = false;
+    if (webSearchMode) webSearchMode.checked = false;
+    if (warningOverlay && warningText) {
+      showWarningOverlay("Web Arama Modu yalnızca baluk-1.7 ve üstü modellerde kullanılabilir.");
+    }
+  } else {
+    webModeEnabled = !!enabled;
+  }
+  if (webModeEnabled && lensModeEnabled) {
+    lensModeEnabled = false;
+    if (balukLensMode) balukLensMode.checked = false;
+    closeLensPanel();
+  }
+  if (userInput) {
+    userInput.classList.toggle("web-search-input", webModeEnabled);
+    userInput.placeholder = webModeEnabled ? "🌐 Web'de ara..." : "Mesajını yaz...";
+  }
+  updateComposerModeUI();
+  if (!supportsVoiceModel()) closeVoiceMode();
+  if (webInputBadge) webInputBadge.classList.toggle("hidden", !webModeEnabled);
+}
+function openLensPanel() {
+  if (!lensPanel) return;
+  lensPanel.classList.remove("hidden");
+  if (lensResults) lensResults.classList.add("hidden");
+  if (lensStatus) {
+    lensStatus.classList.remove("hidden");
+    lensStatus.textContent = "baluk.ai • lens hazır, görsel bekleniyor";
+  }
+}
+function closeLensPanel() {
+  if (!lensPanel) return;
+  lensPanel.classList.add("hidden");
+}
+function setLensMode(enabled) {
+  if (enabled && !supportsLensModel()) {
+    lensModeEnabled = false;
+    if (balukLensMode) balukLensMode.checked = false;
+    showWarningOverlay("Baluk.lens yalnızca baluk-1.9 ve üstü modellerde kullanılabilir.");
+    return;
+  }
+  lensModeEnabled = !!enabled;
+  if (lensModeEnabled) {
+    if (webSearchMode) { webSearchMode.checked = false; setWebMode(false); }
+    if (balleMode) { balleMode.checked = false; setBalleMode(false); }
+    openLensPanel();
+  } else {
+    closeLensPanel();
+  }
+  updateComposerModeUI();
+  if (!supportsVoiceModel()) closeVoiceMode();
+}
+function drawLensCanvas() {
+  if (!lensCanvas || !lensImageDataUrl) return;
+  const ctx = lensCanvas.getContext("2d");
+  const img = new Image();
+  img.onload = () => {
+    const maxW = Math.min(780, Math.max(280, (lensCanvasWrap?.clientWidth || 520) - 10));
+    const ratio = img.height / img.width;
+    lensCanvas.width = maxW;
+    lensCanvas.height = Math.round(maxW * ratio);
+    ctx.clearRect(0, 0, lensCanvas.width, lensCanvas.height);
+    ctx.drawImage(img, 0, 0, lensCanvas.width, lensCanvas.height);
+    const pulse = lensAnalyzing ? (Math.sin(Date.now() / 220) + 1) / 2 : 0.35;
+    if (lensSelection) {
+      const { x, y, w, h } = lensSelection;
+      const glowAlpha = lensAnalyzing ? (0.16 + pulse * 0.24) : 0.2;
+      ctx.strokeStyle = lensAnalyzing ? "#a855f7" : "#8b5cf6";
+      ctx.lineWidth = lensAnalyzing ? 2.8 : 2;
+      ctx.setLineDash([8, 5]);
+      ctx.shadowColor = "rgba(168,85,247,.75)";
+      ctx.shadowBlur = lensAnalyzing ? 18 : 8;
+      ctx.strokeRect(x, y, w, h);
+      ctx.setLineDash([]);
+      ctx.shadowBlur = 0;
+      ctx.fillStyle = `rgba(139,92,246,${glowAlpha.toFixed(3)})`;
+      ctx.fillRect(x, y, w, h);
+      if (lensAnalyzing) {
+        const bandX = x + ((Date.now() / 4) % (w + 80)) - 80;
+        const grd = ctx.createLinearGradient(bandX, y, bandX + 80, y + h);
+        grd.addColorStop(0, "rgba(255,255,255,0)");
+        grd.addColorStop(0.5, "rgba(196,181,253,.38)");
+        grd.addColorStop(1, "rgba(255,255,255,0)");
+        ctx.fillStyle = grd;
+        ctx.fillRect(x, y, w, h);
+      }
+    } else if (lensAnalyzing) {
+      const fullAlpha = 0.12 + pulse * 0.12;
+      ctx.strokeStyle = "rgba(168,85,247,.65)";
+      ctx.lineWidth = 3;
+      ctx.strokeRect(2, 2, lensCanvas.width - 4, lensCanvas.height - 4);
+      ctx.fillStyle = `rgba(139,92,246,${fullAlpha.toFixed(3)})`;
+      ctx.fillRect(0, 0, lensCanvas.width, lensCanvas.height);
+      const bandX = ((Date.now() / 4) % (lensCanvas.width + 120)) - 120;
+      const grd = ctx.createLinearGradient(bandX, 0, bandX + 120, lensCanvas.height);
+      grd.addColorStop(0, "rgba(255,255,255,0)");
+      grd.addColorStop(0.5, "rgba(196,181,253,.35)");
+      grd.addColorStop(1, "rgba(255,255,255,0)");
+      ctx.fillStyle = grd;
+      ctx.fillRect(0, 0, lensCanvas.width, lensCanvas.height);
+    }
+  };
+  img.src = lensImageDataUrl;
+}
+function loadLensFile(file) {
+  if (!file || !file.type.startsWith("image/")) {
+    showWarningOverlay("Lütfen görsel dosyası seç (png, jpg, webp...).");
+    return;
+  }
   const reader = new FileReader();
   reader.onload = () => {
-    localStorage.setItem("kullaniciAdi", k);
-    localStorage.setItem("profilResmi", reader.result);
-    location.reload();
+    lensImageDataUrl = String(reader.result || "");
+    lensSelection = null;
+    if (lensCanvasWrap) lensCanvasWrap.classList.remove("hidden");
+    if (lensStatus) {
+      lensStatus.classList.remove("hidden");
+      lensStatus.textContent = "Görsel yüklendi • baluk.ai görseli anlamlandırıyor...";
+    }
+    drawLensCanvas();
+    lensAiLabels = [];
+    analyzeLensImageSemantics(lensImageDataUrl)
+      .then((labels) => {
+        lensAiLabels = labels;
+        if (lensStatus && labels.length) {
+          lensStatus.textContent = `Görsel algılandı: ${labels.join(", ")} • istersen bölge seçip analiz et.`;
+        } else if (lensStatus) {
+          lensStatus.textContent = "Görsel yüklendi • istersen bölge seçip analiz et.";
+        }
+      })
+      .catch(() => {
+        if (lensStatus) lensStatus.textContent = "Görsel yüklendi • istersen bölge seçip analiz et.";
+      });
   };
-  reader.readAsDataURL(p);
+  reader.readAsDataURL(file);
 }
-
-function goAnaSayfa() {
-  document.getElementById("hesabim").classList.add("gizli");
-  document.getElementById("anaSayfa").style.display = "block";
+function normalizeRect(start, end) {
+  const x = Math.min(start.x, end.x);
+  const y = Math.min(start.y, end.y);
+  const w = Math.abs(end.x - start.x);
+  const h = Math.abs(end.y - start.y);
+  return { x, y, w, h };
 }
-
-function goHesabim() {
-  document.getElementById("anaSayfa").style.display = "none";
-  document.getElementById("hesabim").classList.remove("gizli");
+function lensStatusTick(messages, stepMs = 1400, onStep = null) {
+  if (!lensStatus) return () => {};
+  let i = 0;
+  lensStatus.textContent = messages[0];
+  if (typeof onStep === "function") onStep(messages[0], 0);
+  const timer = setInterval(() => {
+    i += 1;
+    if (i >= messages.length) {
+      clearInterval(timer);
+      return;
+    }
+    lensStatus.textContent = messages[i];
+    if (typeof onStep === "function") onStep(messages[i], i);
+  }, stepMs);
+  return () => clearInterval(timer);
 }
-
-function videoYukle() {
-  const dosya = document.getElementById("videoDosyasi").files[0];
-  const baslik = document.getElementById("videoBaslik").value;
-  const kullanici = localStorage.getItem("kullaniciAdi");
-
-  if (!dosya || !baslik) {
-    alert("Video ve başlık eksik!");
+function loadExternalScript(src) {
+  return new Promise((resolve, reject) => {
+    if (document.querySelector(`script[data-lens-lib="${src}"]`)) {
+      resolve();
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = src;
+    script.async = true;
+    script.dataset.lensLib = src;
+    script.onload = () => resolve();
+    script.onerror = () => reject(new Error(`Script yüklenemedi: ${src}`));
+    document.head.appendChild(script);
+  });
+}
+async function ensureLensClassifier() {
+  if (lensClassifierReady && lensModelRef) return lensModelRef;
+  if (lensClassifierLoading) {
+    while (lensClassifierLoading) {
+      await new Promise((r) => setTimeout(r, 120));
+    }
+    return lensModelRef;
+  }
+  lensClassifierLoading = true;
+  try {
+    await loadExternalScript("https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@4.22.0/dist/tf.min.js");
+    await loadExternalScript("https://cdn.jsdelivr.net/npm/@tensorflow-models/mobilenet@2.1.1/dist/mobilenet.min.js");
+    if (!window.mobilenet) throw new Error("mobilenet yüklenemedi");
+    lensModelRef = await window.mobilenet.load({ version: 2, alpha: 1.0 });
+    lensClassifierReady = true;
+    return lensModelRef;
+  } catch {
+    lensClassifierReady = false;
+    lensModelRef = null;
+    return null;
+  } finally {
+    lensClassifierLoading = false;
+  }
+}
+async function analyzeLensImageSemantics(dataUrl) {
+  if (!dataUrl) return [];
+  const model = await ensureLensClassifier();
+  if (!model) return [];
+  const img = new Image();
+  img.crossOrigin = "anonymous";
+  await new Promise((resolve, reject) => {
+    img.onload = () => resolve();
+    img.onerror = () => reject(new Error("Görsel çözümleme başarısız"));
+    img.src = dataUrl;
+  });
+  const predictions = await model.classify(img, 5);
+  return predictions
+    .filter((p) => Number(p.probability) >= 0.08)
+    .map((p) => String(p.className || "").split(",")[0].trim().toLowerCase())
+    .filter(Boolean)
+    .slice(0, 3);
+}
+function guessLensQuery() {
+  if (lensAiLabels.length) return lensAiLabels.join(" ");
+  if (!lensImageDataUrl) return "görsel";
+  const fromName = (lensFileInput?.files?.[0]?.name || "").toLowerCase().replace(/\.[a-z0-9]+$/, "").replace(/[_-]+/g, " ").trim();
+  const fallbackTerms = ["object", "nature", "technology", "animal", "city"];
+  return fromName || chooseRandom(fallbackTerms);
+}
+function isMobileLensViewport() {
+  return window.matchMedia("(max-width: 760px)").matches;
+}
+function startLensDrawTicker() {
+  if (lensDrawTicker) clearInterval(lensDrawTicker);
+  lensDrawTicker = setInterval(() => {
+    if (lensAnalyzing) drawLensCanvas();
+  }, 120);
+}
+function stopLensDrawTicker() {
+  if (lensDrawTicker) clearInterval(lensDrawTicker);
+  lensDrawTicker = null;
+}
+async function runLensAnalysis() {
+  if (!lensImageDataUrl) {
+    showWarningOverlay("Önce bir fotoğraf yüklemelisin.");
     return;
   }
-
-  const videoURL = URL.createObjectURL(dosya);
-  const video = { baslik: baslik, url: videoURL, sahip: kullanici };
-
-  const mevcut = JSON.parse(localStorage.getItem("videolar") || "[]");
-  mevcut.push(video);
-  localStorage.setItem("videolar", JSON.stringify(mevcut));
-  videolariYukle();
-
-  document.getElementById("videoDosyasi").value = "";
-  document.getElementById("videoBaslik").value = "";
+  if (lensResults) {
+    lensResults.classList.add("hidden");
+    lensResults.innerHTML = "";
+  }
+  if (lensStatus) {
+    lensStatus.classList.remove("hidden");
+    lensStatus.classList.add("lens-status-live");
+  }
+  startChatIfNeeded();
+  const thinking = addThinkingBubble("web");
+  updateThinkingStatus(thinking, "Baluk.ai • lens düşünüyor...");
+  lensAnalyzing = true;
+  if (lensPanel) lensPanel.classList.add("lens-analyzing");
+  if (lensCanvasWrap) lensCanvasWrap.classList.add("lens-canvas-live");
+  startLensDrawTicker();
+  drawLensCanvas();
+  const stopTicker = lensStatusTick([
+    "baluk.ai • görsel içeriğini analiz ediyor...",
+    "baluk.ai • web'de benzerlerini tarıyor...",
+    "baluk.ai • seçilen alanı derin analiz ediyor...",
+    "baluk.ai • eşleşen sonuçları derliyor...",
+    "baluk.ai • son rötuşlar yapılıyor..."
+  ], 1100, (msg) => updateThinkingStatus(thinking, msg));
+  const waitMs = supportsLensModel() ? 5200 : 9000;
+  await new Promise((r) => setTimeout(r, waitMs));
+  const q = guessLensQuery();
+  if (lensStatus && !lensSelection) lensStatus.textContent = "baluk.ai • özel alan seçilmedi, tüm görsel analiz ediliyor...";
+  const links = [
+    { title: `${q} • Google Görseller`, link: `https://www.google.com/search?tbm=isch&q=${encodeURIComponent(q + " similar")}` },
+    { title: `${q} • Bing Images`, link: `https://www.bing.com/images/search?q=${encodeURIComponent(q + " similar")}` },
+    { title: `${q} • Unsplash`, link: `https://unsplash.com/s/photos/${encodeURIComponent(q)}` },
+    { title: `${q} • Pexels`, link: `https://www.pexels.com/search/${encodeURIComponent(q)}/` }
+  ];
+  stopTicker();
+  lensAnalyzing = false;
+  stopLensDrawTicker();
+  if (lensPanel) lensPanel.classList.remove("lens-analyzing");
+  if (lensCanvasWrap) lensCanvasWrap.classList.remove("lens-canvas-live");
+  drawLensCanvas();
+  if (lensStatus) {
+    lensStatus.classList.remove("lens-status-live");
+    lensStatus.textContent = "baluk.ai • analiz tamamlandı, 4 benzer görsel kaynağı bulundu ✅";
+  }
+  if (lensResults) {
+    lensResults.innerHTML = `
+      <h4>📸 Baluk.lens benzer görseller</h4>
+      <ol>${links.map((i) => `<li><a href="${i.link}" target="_blank" rel="noopener noreferrer">${i.title}</a></li>`).join("")}</ol>
+      <p>Not: Sonuçlar benzerlik önerisidir; birebir aynı görsel garantisi vermez.</p>
+    `;
+    lensResults.classList.remove("hidden");
+  }
+  const finalText = `Baluk.lens analizi tamamlandı. İşaretlediğin bölge/görsel için 4 güçlü kaynak buldum:
+${links.map((i, idx) => `${idx + 1}) ${i.title} → ${i.link}`).join("\n")}`;
+  fillThinkingBubble(thinking, finalText, "Baluk.ai • lens analizi bitti ✅");
+}
+async function fetchWebResults(query) {
+  const url = `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&skip_disambig=1`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error("Web isteği başarısız");
+  const data = await res.json();
+  const out = [];
+  if (data.AbstractURL) {
+    out.push({ title: data.Heading || query, description: data.AbstractText || "Öne çıkan sonuç", link: data.AbstractURL });
+  }
+  const pushTopic = (topic) => {
+    if (!topic) return;
+    if (topic.FirstURL && topic.Text) {
+      const title = topic.Text.split(" - ")[0].trim() || topic.Text.slice(0, 64);
+      out.push({ title, description: topic.Text, link: topic.FirstURL });
+    }
+    if (Array.isArray(topic.Topics)) topic.Topics.forEach(pushTopic);
+  };
+  (data.RelatedTopics || []).forEach(pushTopic);
+  const uniq = [];
+  const seen = new Set();
+  out.forEach((i) => {
+    if (!i.link || seen.has(i.link)) return;
+    seen.add(i.link);
+    uniq.push(i);
+  });
+  if (uniq.length < 3) {
+    const extra = [
+      { title: `DuckDuckGo: ${query}`, description: "DuckDuckGo üzerinde tam sonuç sayfası", link: `https://duckduckgo.com/?q=${encodeURIComponent(query)}` },
+      { title: `Wikipedia: ${query}`, description: "Wikipedia arama sonucu", link: `https://tr.wikipedia.org/w/index.php?search=${encodeURIComponent(query)}` },
+      { title: `Google: ${query}`, description: "Alternatif arama sonucu", link: `https://www.google.com/search?q=${encodeURIComponent(query)}` }
+    ];
+    extra.forEach((i) => {
+      if (!seen.has(i.link)) {
+        seen.add(i.link);
+        uniq.push(i);
+      }
+    });
+  }
+  return uniq.slice(0, 12);
+}
+function isWikipediaLink(link) {
+  return /https?:\/\/(?:[a-z]{2,3}\.)?wikipedia\.org\//i.test(String(link || ""));
+}
+function extractWikiTitleFromLink(link) {
+  try {
+    const u = new URL(link);
+    const wikiMatch = u.pathname.match(/\/wiki\/([^/?#]+)/i);
+    if (wikiMatch && wikiMatch[1]) return decodeURIComponent(wikiMatch[1]).replace(/_/g, " ");
+    const directSearch = u.searchParams.get("search") || u.searchParams.get("title");
+    if (directSearch) return directSearch;
+  } catch {}
+  return null;
+}
+function trimToWordWindow(text, minWords = 500, maxWords = 1000) {
+  const words = String(text || "").replace(/\s+/g, " ").trim().split(" ").filter(Boolean);
+  if (!words.length) return "";
+  if (words.length <= maxWords) return words.join(" ");
+  return `${words.slice(0, maxWords).join(" ")}...`;
+}
+async function fetchWikipediaLongExcerpt(link) {
+  if (!isWikipediaLink(link)) return null;
+  const title = extractWikiTitleFromLink(link);
+  if (!title) return null;
+  const endpoints = [
+    `https://tr.wikipedia.org/w/api.php?action=query&prop=extracts&explaintext=1&exsectionformat=plain&titles=${encodeURIComponent(title)}&format=json&origin=*`,
+    `https://en.wikipedia.org/w/api.php?action=query&prop=extracts&explaintext=1&exsectionformat=plain&titles=${encodeURIComponent(title)}&format=json&origin=*`
+  ];
+  for (const ep of endpoints) {
+    try {
+      const res = await fetch(ep);
+      if (!res.ok) continue;
+      const data = await res.json();
+      const pages = data?.query?.pages || {};
+      const firstPage = Object.values(pages)[0];
+      const extract = String(firstPage?.extract || "").replace(/\s+/g, " ").trim();
+      if (!extract) continue;
+      const excerpt = trimToWordWindow(extract, 500, 1000);
+      if (excerpt) return excerpt;
+    } catch {}
+  }
+  return null;
+}
+function renderWebResults(query, items, wikiExcerpt = "", wikiLink = "") {
+  const box = document.createElement("div");
+  box.className = "msg bot web-results";
+  const allSources = items.slice(0, 8);
+  const leadAnswer = String(wikiExcerpt || "").trim();
+  const fallbackAnswer = allSources.length
+    ? allSources.map((item, i) => `${i + 1}) ${item.title}: ${item.description || "Açıklama bulunamadı."}`).join("\n")
+    : "Bu aramada güvenilir metin özeti çıkaramadım, ama kaynak bağlantıları aşağıda.";
+  const coreAnswer = (leadAnswer || fallbackAnswer).replace(/\s+/g, " ").trim();
+  const answerTextBase = `${chooseRandom(webAnswerIntroPrompts)}
+${coreAnswer}
+${chooseRandom(webAnswerOutroPrompts)}`;
+  const answerText = applyProfanityFlavor(answerTextBase, query);
+  const shortAnswer = answerText.length > 300 ? `${answerText.slice(0, 300)}...` : answerText;
+  box.innerHTML = `
+    <div class="web-results-head">baluk.screatch</div>
+    <div class="web-query">Arama: ${query}</div>
+    <div class="web-main-answer" aria-live="polite">
+      <h4>🧠 Baluk Yanıtı</h4>
+      <p class="web-answer-text"></p>
+      <button type="button" class="web-read-more ${answerText.length > 300 ? "" : "hidden"}">Devamını oku</button>
+    </div>
+    <div class="web-sources">
+      <h5>📎 Kaynakça</h5>
+      <ol class="web-source-list">
+        ${allSources.map((item) => `<li><a href="${item.link}" target="_blank" rel="noopener noreferrer">${item.title}</a></li>`).join("") || "<li>Kaynak bulunamadı.</li>"}
+      </ol>
+      ${wikiLink ? `<a class="web-source-main" href="${wikiLink}" target="_blank" rel="noopener noreferrer">Ana kaynak: Wikipedia</a>` : ""}
+    </div>
+  `;
+  const answerEl = box.querySelector('.web-answer-text');
+  if (answerEl) answerEl.textContent = shortAnswer;
+  const readMoreBtn = box.querySelector('.web-read-more');
+  if (readMoreBtn && answerEl) {
+    readMoreBtn.addEventListener('click', () => {
+      answerEl.textContent = answerText;
+      readMoreBtn.classList.add('hidden');
+    });
+  }
+  chat.appendChild(box);
+  chat.scrollTop = chat.scrollHeight;
+}
+function isBMWTrigger(input) {
+  return /(^|[^a-z0-9])bmw([^a-z0-9]|$)/i.test(String(input || ""));
+}
+function renderBMWVideoCard() {
+  const box = document.createElement("div");
+  box.className = "msg bot bmw-video-card";
+  box.innerHTML = `
+    <iframe
+      src="https://www.youtube-nocookie.com/embed/N_tf3ZZWy78?autoplay=1&mute=1&loop=1&playlist=N_tf3ZZWy78&controls=0&modestbranding=1&rel=0&playsinline=1"
+      title="BMW loop video"
+      allow="autoplay; encrypted-media; picture-in-picture"
+      allowfullscreen
+      loading="lazy"
+      referrerpolicy="strict-origin-when-cross-origin">
+    </iframe>
+  `;
+  chat.appendChild(box);
+  chat.scrollTop = chat.scrollHeight;
+}
+async function processWebSearchInput(text) {
+  startChatIfNeeded();
+  addMessage(text, "user");
+  const thinking = addThinkingBubble("web");
+  const waitMs = isPremiumUser ? 4500 + Math.floor(Math.random() * 800) : 9000 + Math.floor(Math.random() * 2000);
+  const stopProgress = startWebThinkingProgress(thinking, waitMs);
+  await new Promise((r) => setTimeout(r, waitMs));
+  updateThinkingStatus(thinking, "Web aranıyor...");
+  try {
+    const items = await fetchWebResults(text);
+    const firstWiki = items.find((i) => isWikipediaLink(i.link));
+    const wikiExcerpt = supportsWebTextExtractionModel() && firstWiki ? await fetchWikipediaLongExcerpt(firstWiki.link) : "";
+    renderWebResults(text, items, wikiExcerpt, firstWiki?.link || "");
+    stopProgress();
+    const doneText = supportsWebTextExtractionModel()
+      ? "Arama tamamlandı. Linkler ve Wikipedia metin alıntısı hazır."
+      : "Arama tamamlandı. Linkler hazır (metne dökme özelliği için baluk-1.8+ gerekir).";
+    fillThinkingBubble(thinking, applyProfanityFlavor(doneText, text), "Web arandı • sonuç bulundu ✅");
+  } catch {
+    stopProgress();
+    renderWebResults(text, []);
+    fillThinkingBubble(thinking, applyProfanityFlavor("Arama tamamlandı ama sonuç alınamadı.", text), "Web arandı • sonuç bulunamadı ⚠️");
+  }
+}
+function hasSalutation(text, list) {
+  return list.some((kw) => {
+    const token = kw.trim().toLowerCase();
+    if (!token) return false;
+    if (token.length <= 3 || !token.includes(" ")) {
+      const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      return new RegExp(`(^|\\s)${escaped}(\\s|$|[?.!,])`, "i").test(text);
+    }
+    return text.includes(token);
+  });
+}
+function isHowAreYouVariant(text) {
+  const t = String(text || "").toLowerCase().trim();
+  if (!t) return false;
+  if (hasAny(t, [
+    "nasılsın", "nasilsin", "nasılsınız", "nasilsiniz", "naber", "ne haber",
+    "naber kanka", "naber knk", "napıyorsun", "napiyorsun", "napıyon", "napiyon",
+    ...extendedGreetingKeywords
+  ])) return true;
+  return /(^|\s)(iyi\s*m[iı]s[iı]n|iyi\s*m[iı]s[iı]n\s*knk|iyi\s*m[iı]s[iı]n\s*kanka|iyi\s*mi\s*sin|iyi\s*misn|iyisin\s*mi)(\s|$|[?.!,])/i.test(t);
+}
+function isBannedNow() {
+  return Date.now() < banUntil;
+}
+function formatBanLeft(ms) {
+  const sec = Math.max(0, Math.ceil(ms / 1000));
+  const m = String(Math.floor(sec / 60)).padStart(2, "0");
+  const s = String(sec % 60).padStart(2, "0");
+  return `${m}:${s}`;
+}
+function saveBanState(reason = "") {
+  if (!isAccountLoggedIn) return;
+  if (!banUntil || !isBannedNow()) {
+    localStorage.removeItem(BAN_STORAGE_KEY);
+    return;
+  }
+  localStorage.setItem(BAN_STORAGE_KEY, JSON.stringify({ banUntil, reason }));
+}
+function restoreBanState() {
+  const raw = localStorage.getItem(BAN_STORAGE_KEY);
+  if (!raw) return;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed?.banUntil || Date.now() >= Number(parsed.banUntil)) {
+      localStorage.removeItem(BAN_STORAGE_KEY);
+      return;
+    }
+    banUntil = Number(parsed.banUntil);
+    if (banReason) banReason.textContent = parsed.reason || "Lütfen saygılı bir dil kullanalım.";
+    if (profanityLock) profanityLock.classList.remove("hidden");
+    if (banInterval) clearInterval(banInterval);
+    banInterval = setInterval(() => {
+      const left = banUntil - Date.now();
+      if (banTimer) banTimer.textContent = formatBanLeft(left);
+      if (left <= 0) stopBan();
+    }, 250);
+  } catch {
+    localStorage.removeItem(BAN_STORAGE_KEY);
+  }
 }
 
-function videolariYukle() {
-  const videolar = JSON.parse(localStorage.getItem("videolar") || "[]");
-  const liste = document.getElementById("videoListe");
-  const hesap = document.getElementById("videolar");
-  const kullanici = localStorage.getItem("kullaniciAdi");
+function getDefaultAccountAvatarSvg() {
+  return `<svg class="account-toggle-avatar" viewBox="0 0 40 40" aria-hidden="true" focusable="false"><circle cx="20" cy="20" r="19" fill="#e2e8f0" stroke="#cbd5e1"/><circle cx="20" cy="14" r="6.2" fill="#94a3b8"/><path d="M8 32c1.8-5.6 6.6-8.6 12-8.6S30.2 26.4 32 32" fill="#94a3b8"/></svg>`;
+}
+function updateAccountToggleVisual() {
+  if (!accountToggle) return;
+  const photo = accountPhoto?.value?.trim() || "";
+  accountToggle.classList.remove("has-photo", "guest-default");
+  if (!isAccountLoggedIn) {
+    accountToggle.classList.add("guest-default");
+    accountToggle.setAttribute("aria-label", "Oturum aç");
+    accountToggle.innerHTML = getDefaultAccountAvatarSvg();
+    return;
+  }
+  if (photo) {
+    accountToggle.classList.add("has-photo");
+    accountToggle.setAttribute("aria-label", "Profil paneli");
+    accountToggle.innerHTML = `<img src="${photo}" alt="Profil fotoğrafı" referrerpolicy="no-referrer">`;
+    return;
+  }
+  accountToggle.setAttribute("aria-label", "Menü");
+  accountToggle.textContent = "☰";
+}
+function clearGuestPersistentState() {
+  GUEST_CLEAR_KEYS.forEach((k) => localStorage.removeItem(k));
+  Object.keys(userMemory).forEach((k) => delete userMemory[k]);
+  isPremiumUser = false;
+  premiumPaymentPending = false;
+  allowProfanity = false;
+  premiumExpiresAt = 0;
+  currentModel = "baluk-2.0";
+}
 
-  liste.innerHTML = "";
-  hesap.innerHTML = "";
+function updateAuthDependentUI() {
+  if (drawerBackgroundOpen) drawerBackgroundOpen.classList.toggle("hidden", !isAccountLoggedIn);
+  if (drawerPremiumOpen) drawerPremiumOpen.classList.toggle("hidden", !isAccountLoggedIn);
+  if (!isAccountLoggedIn) {
+    if (premiumModal) premiumModal.classList.add("hidden");
+    if (backgroundModal) backgroundModal.classList.add("hidden");
+    if (sideDrawer) sideDrawer.classList.add("hidden");
+  }
+}
 
-  videolar.forEach((v, i) => {
-    const div = document.createElement("div");
-    div.className = "video";
-    div.innerHTML = `
-      <video src="${v.url}" controls></video>
-      <p>${v.baslik}</p>
-    `;
-    // Ana sayfaya herkesin videoları
-    liste.appendChild(div.cloneNode(true));
+function updateAccountPreview() {
+  if (!accountNamePreview || !accountMailPreview || !accountPhotoPreview) return;
+  const name = accountName?.value?.trim() || "Misafir";
+  const mail = accountGmail?.value?.trim() || "gmail eklenmedi";
+  const photo = accountPhoto?.value?.trim();
+  accountNamePreview.textContent = name;
+  accountMailPreview.textContent = mail;
+  accountPhotoPreview.src = photo || 'data:image/svg+xml;utf8,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22%3E%3Ccircle cx=%2250%22 cy=%2250%22 r=%2248%22 fill=%22%23e2e8f0%22/%3E%3Ccircle cx=%2250%22 cy=%2236%22 r=%2215%22 fill=%22%2394a3b8%22/%3E%3Cpath d=%22M18 82c4-14 15-22 32-22s28 8 32 22%22 fill=%22%2394a3b8%22/%3E%3C/svg%3E';
+  updateAccountToggleVisual();
+  updateAuthDependentUI();
+}
+function applyBackgroundTheme(themeName = "default") {
+  const themes = ["theme-1", "theme-2", "theme-3", "theme-4", "theme-5", "theme-6", "theme-7", "theme-8", "theme-9", "theme-10"];
+  document.body.classList.remove(...themes.map((t) => `bg-${t}`));
+  const safeTheme = themes.includes(themeName) ? themeName : "default";
+  if (safeTheme !== "default") document.body.classList.add(`bg-${safeTheme}`);
+  if (isAccountLoggedIn) localStorage.setItem(BACKGROUND_THEME_KEY, safeTheme);
+  if (backgroundThemeSelect) backgroundThemeSelect.value = safeTheme;
+}
+function stopBackgroundMusic() {
+  try {
+    bgAudioNodes.forEach((n) => {
+      if (n && typeof n.stop === "function") n.stop();
+    });
+  } catch {}
+  bgAudioNodes = [];
+  if (bgAudioCtx) {
+    bgAudioCtx.close().catch(() => {});
+    bgAudioCtx = null;
+  }
+}
+function startBackgroundMusic(presetId = "off", volumeValue = 35) {
+  stopBackgroundMusic();
+  const preset = ambientMusicPresets[presetId];
+  if (!preset) return;
+  const AC = window.AudioContext || window.webkitAudioContext;
+  if (!AC) return;
+  bgAudioCtx = new AC();
+  const now = bgAudioCtx.currentTime;
+  const master = bgAudioCtx.createGain();
+  master.gain.value = 0.0001;
+  master.connect(bgAudioCtx.destination);
 
-    // Sadece kendi videolarına silme butonu
-    if (v.sahip === kullanici) {
-      const divHesap = div.cloneNode(true);
-      const silBtn = document.createElement("button");
-      silBtn.innerText = "❌";
-      silBtn.onclick = () => {
-        videolar.splice(i, 1);
-        localStorage.setItem("videolar", JSON.stringify(videolar));
-        videolariYukle();
-      };
-      divHesap.appendChild(silBtn);
-      hesap.appendChild(divHesap);
+  const targetLevel = Math.max(0, Math.min(1, Number(volumeValue) / 100)) * 0.1;
+  master.gain.exponentialRampToValueAtTime(Math.max(0.0001, targetLevel), now + 1.2);
+
+  const filter = bgAudioCtx.createBiquadFilter();
+  filter.type = "lowpass";
+  filter.frequency.value = preset.layer === "airy" ? 1100 : preset.layer === "warm" ? 860 : 980;
+  filter.Q.value = 0.9;
+  filter.connect(master);
+
+  const oscA = bgAudioCtx.createOscillator();
+  const oscB = bgAudioCtx.createOscillator();
+  const oscC = bgAudioCtx.createOscillator();
+  const lfo = bgAudioCtx.createOscillator();
+  const lfoGain = bgAudioCtx.createGain();
+  const filterLfo = bgAudioCtx.createOscillator();
+  const filterLfoGain = bgAudioCtx.createGain();
+
+  oscA.type = preset.wave;
+  oscB.type = preset.wave;
+  oscC.type = preset.layer === "warm" ? "triangle" : "sine";
+  oscA.frequency.value = preset.base;
+  oscB.frequency.value = preset.base * 1.25;
+  oscC.frequency.value = preset.base * 0.5;
+
+  oscA.detune.value = -Math.abs(preset.detune || 6);
+  oscB.detune.value = Math.abs(preset.detune || 6);
+  oscC.detune.value = (preset.detune || 6) * 0.4;
+
+  lfo.type = "sine";
+  lfo.frequency.value = preset.lfo;
+  lfoGain.gain.value = 3.2;
+  lfo.connect(lfoGain);
+  lfoGain.connect(oscA.frequency);
+
+  filterLfo.type = "sine";
+  filterLfo.frequency.value = Math.max(0.01, preset.lfo * 0.8);
+  filterLfoGain.gain.value = preset.layer === "airy" ? 140 : 90;
+  filterLfo.connect(filterLfoGain);
+  filterLfoGain.connect(filter.frequency);
+
+  const gainA = bgAudioCtx.createGain();
+  const gainB = bgAudioCtx.createGain();
+  const gainC = bgAudioCtx.createGain();
+  gainA.gain.value = 0.34;
+  gainB.gain.value = 0.23;
+  gainC.gain.value = preset.layer === "warm" ? 0.16 : 0.12;
+
+  oscA.connect(gainA);
+  oscB.connect(gainB);
+  oscC.connect(gainC);
+  gainA.connect(filter);
+  gainB.connect(filter);
+  gainC.connect(filter);
+
+  oscA.start(now);
+  oscB.start(now);
+  oscC.start(now);
+  lfo.start(now);
+  filterLfo.start(now);
+
+  bgAudioNodes = [oscA, oscB, oscC, lfo, filterLfo, master, filter, gainA, gainB, gainC, lfoGain, filterLfoGain];
+}
+function setBackgroundMusic(musicId = "off") {
+  const safe = Object.prototype.hasOwnProperty.call(ambientMusicPresets, musicId) ? musicId : "off";
+  if (isAccountLoggedIn) localStorage.setItem(BACKGROUND_MUSIC_KEY, safe);
+  if (backgroundMusicSelect) backgroundMusicSelect.value = safe;
+  const volume = isAccountLoggedIn ? Number(localStorage.getItem(BACKGROUND_VOLUME_KEY) || "35") : 35;
+  if (safe === "off") stopBackgroundMusic();
+  else startBackgroundMusic(safe, volume);
+}
+function setBackgroundVolume(value = 35) {
+  const safe = Math.max(0, Math.min(100, Number(value) || 35));
+  if (isAccountLoggedIn) localStorage.setItem(BACKGROUND_VOLUME_KEY, String(safe));
+  if (backgroundMusicVolume) backgroundMusicVolume.value = String(safe);
+  const currentMusic = isAccountLoggedIn ? (localStorage.getItem(BACKGROUND_MUSIC_KEY) || "off") : "off";
+  if (currentMusic !== "off") startBackgroundMusic(currentMusic, safe);
+}
+function restoreBackgroundSettings() {
+  const savedTheme = isAccountLoggedIn ? (localStorage.getItem(BACKGROUND_THEME_KEY) || "default") : "default";
+  const savedMusic = isAccountLoggedIn ? (localStorage.getItem(BACKGROUND_MUSIC_KEY) || "off") : "off";
+  const savedVolume = isAccountLoggedIn ? Number(localStorage.getItem(BACKGROUND_VOLUME_KEY) || "35") : 35;
+  applyBackgroundTheme(savedTheme);
+  setBackgroundVolume(savedVolume);
+  setBackgroundMusic(savedMusic);
+}
+function saveAccountProfile() {
+  const profile = {
+    name: accountName?.value?.trim() || "",
+    gmail: accountGmail?.value?.trim() || "",
+    photo: accountPhoto?.value?.trim() || ""
+  };
+  isAccountLoggedIn = Boolean(profile.name && profile.gmail);
+  if (!isAccountLoggedIn) {
+    localStorage.removeItem(ACCOUNT_STORAGE_KEY);
+    showWarningOverlay("Oturum açmak için isim ve gmail gerekli.");
+    updateAccountPreview();
+    return;
+  }
+  localStorage.setItem(ACCOUNT_STORAGE_KEY, JSON.stringify({ ...profile, loggedIn: true }));
+  updateAccountPreview();
+  if (accountPanel) accountPanel.classList.add("hidden");
+}
+
+function restoreAccountProfile() {
+  const raw = localStorage.getItem(ACCOUNT_STORAGE_KEY);
+  if (!raw) {
+    isAccountLoggedIn = false;
+    updateAccountPreview();
+    clearGuestPersistentState();
+    return;
+  }
+  try {
+    const profile = JSON.parse(raw);
+    isAccountLoggedIn = Boolean(profile?.loggedIn && profile?.name && profile?.gmail);
+    if (!isAccountLoggedIn) {
+      localStorage.removeItem(ACCOUNT_STORAGE_KEY);
+      clearGuestPersistentState();
+    }
+    if (accountName) accountName.value = profile?.name || "";
+    if (accountGmail) accountGmail.value = profile?.gmail || "";
+    if (accountPhoto) accountPhoto.value = profile?.photo || "";
+  } catch {
+    isAccountLoggedIn = false;
+    localStorage.removeItem(ACCOUNT_STORAGE_KEY);
+    clearGuestPersistentState();
+  }
+  updateAccountPreview();
+  modelOptions.forEach((opt) => opt.classList.toggle("active", opt.dataset.model === currentModel));
+  updateModelVisual();
+}
+
+function stopBan() {
+  banUntil = 0;
+  if (banInterval) clearInterval(banInterval);
+  banInterval = null;
+  if (profanityLock) profanityLock.classList.add("hidden");
+  saveBanState();
+}
+function startBan(reason = "Lütfen saygılı bir dil kullanalım.") {
+  insultWarningCount = 0;
+  banUntil = Date.now() + 10 * 60 * 1000;
+  if (banReason) banReason.textContent = reason;
+  if (profanityLock) profanityLock.classList.remove("hidden");
+  if (banInterval) clearInterval(banInterval);
+  banInterval = setInterval(() => {
+    const left = banUntil - Date.now();
+    if (banTimer) banTimer.textContent = formatBanLeft(left);
+    if (left <= 0) stopBan();
+  }, 250);
+  saveBanState(reason);
+}
+function showWarningOverlay(message) {
+  if (!warningOverlay || !warningText) return;
+  warningText.textContent = message;
+  warningOverlay.classList.remove("hidden");
+  if (warningOverlayTimer) clearTimeout(warningOverlayTimer);
+  warningOverlayTimer = setTimeout(() => warningOverlay.classList.add("hidden"), 2200);
+}
+function matchesKeywordWithSuffix(textLower, keyword) {
+  const kw = String(keyword || "").trim().toLowerCase();
+  if (!kw) return false;
+  if (kw.includes(" ")) return textLower.includes(kw);
+  const escaped = kw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(`(^|[^a-zçğıöşü0-9])${escaped}(?:['’]?[a-zçğıöşü]{0,7})?(?=$|[^a-zçğıöşü0-9])`, "i");
+  return pattern.test(textLower);
+}
+function getToxicityLevel(textLower) {
+  if (severeProfanityKeywords.some((w) => matchesKeywordWithSuffix(textLower, w))) return "severe";
+  if (insultKeywords.some((w) => matchesKeywordWithSuffix(textLower, w))) return "insult";
+  return null;
+}
+function isUnsafeQuery(textLower) {
+  return unsafeIllegalSelfHarmKeywords.some((w) => textLower.includes(w));
+}
+function getUnsafeCategory(textLower) {
+  if (selfHarmUnsafeKeywords.some((w) => textLower.includes(w))) return "self_harm";
+  if (illegalUnsafeKeywords.some((w) => textLower.includes(w))) return "illegal";
+  return "generic";
+}
+function buildUnsafeRefusal(textLower) {
+  pendingSafetySurvey = getUnsafeCategory(textLower);
+  if (pendingSafetySurvey === "self_harm") return chooseRandom(selfHarmSupportPrompts);
+  if (pendingSafetySurvey === "illegal") return chooseRandom(illegalRefusalPrompts);
+  return `${chooseRandom(illegalRefusalPrompts)}
+${chooseRandom(selfHarmSupportPrompts)}`;
+}
+function setAdvancedMathMode(enabled) {
+  const justEnabled = enabled && !advancedMathEnabled;
+  advancedMathEnabled = enabled;
+  appRoot.classList.toggle("math-mode", enabled);
+  if (memoryToggle) memoryToggle.classList.toggle("hidden", enabled);
+  if (mathStudioToggle) mathStudioToggle.classList.toggle("hidden", !enabled);
+  if (mathStudioPanel && !enabled) mathStudioPanel.classList.add("hidden");
+  if (currentModelBadge) currentModelBadge.textContent = enabled ? "matematik modu" : currentModel;
+  if (justEnabled) {
+    showMathModeFlash();
+  }
+}
+function solveMathStudioLine(line) {
+  const raw = line.trim();
+  if (!raw) return null;
+  const wordProblem = solveWordProblemValue(raw);
+  if (wordProblem !== null) return String(wordProblem);
+  const eq = solveLinearEquation(raw);
+  if (eq) return eq.replace("Denklem çözümü: ", "");
+  const expr = solveSimpleExpression(raw.replaceAll("^", "**"));
+  if (expr) return expr.replace("Sonuç: ", "").replace(" ✅", "");
+  return "Çözüm yok";
+}
+function explainMath(line, result) {
+  return `🧠 Matematik stüdyosu açıklaması:
+${line} ifadesini adım adım çözünce ${result} sonucuna ulaşıyorum. Burada denklem dengesini koruyup bilinmeyeni yalnız bırakıyorum; aritmetik ifadede ise işlem önceliğine göre hesaplıyorum.`;
+}
+function renderMathStudio() {
+  if (!mathStudioInput) return;
+  const raw = mathStudioInput.innerText.trim();
+  if (!raw) return;
+  const lines = raw.split("\n").map((l) => l.trim()).filter(Boolean);
+  const line = lines[lines.length - 1];
+  const result = solveMathStudioLine(line);
+  if (!result || result === "Çözüm yok") return;
+  mathStudioInput.innerHTML = `<span class="calc-answer">${line} = ${result}</span>`;
+  const selection = window.getSelection();
+  if (selection) {
+    const range = document.createRange();
+    range.selectNodeContents(mathStudioInput);
+    range.collapse(false);
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+  if (line !== lastStudioExplained) {
+    startChatIfNeeded();
+    addMessage(explainMath(line, result), "bot");
+    lastStudioExplained = line;
+  }
+}
+function showMathModeFlash() {
+  if (!mathModeFlash) return;
+  mathModeFlash.classList.remove("hidden");
+  clearTimeout(mathFlashTimer);
+  mathFlashTimer = setTimeout(() => mathModeFlash.classList.add("hidden"), 1050);
+  playMathModeFlashAudio();
+}
+function playMathModeFlashAudio() {
+  const AudioCtx = window.AudioContext || window.webkitAudioContext;
+  if (!AudioCtx) return;
+  const ctx = new AudioCtx();
+  const now = ctx.currentTime;
+  const master = ctx.createGain();
+  master.gain.setValueAtTime(0.0001, now);
+  master.gain.exponentialRampToValueAtTime(0.08, now + 0.08);
+  master.gain.exponentialRampToValueAtTime(0.0001, now + 1.0);
+  master.connect(ctx.destination);
+  const osc = ctx.createOscillator();
+  osc.type = "triangle";
+  osc.frequency.setValueAtTime(180, now);
+  osc.frequency.exponentialRampToValueAtTime(640, now + 0.46);
+  const shimmer = ctx.createOscillator();
+  shimmer.type = "sine";
+  shimmer.frequency.value = 11;
+  const shimmerGain = ctx.createGain();
+  shimmerGain.gain.value = 22;
+  shimmer.connect(shimmerGain);
+  shimmerGain.connect(osc.frequency);
+  osc.connect(master);
+  osc.start(now);
+  shimmer.start(now);
+  osc.stop(now + 1.05);
+  shimmer.stop(now + 1.05);
+  setTimeout(() => ctx.close().catch(() => {}), 1200);
+}
+function clearGeometryWarn() {
+  if (geometryWarn) geometryWarn.textContent = "";
+}
+function showGeometryWarn(message) {
+  if (!geometryWarn) return;
+  geometryWarn.textContent = message;
+}
+function parsePositive(value) {
+  const n = Number(String(value || "").replace(",", "."));
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return n;
+}
+function geometrySvgForShape(shape) {
+  switch (shape) {
+    case "square":
+      return `<rect x="26" y="26" width="148" height="148" rx="6"></rect>`;
+    case "rectangle":
+      return `<rect x="20" y="46" width="160" height="108" rx="6"></rect>`;
+    case "triangle":
+      return `<polygon points="100,18 182,168 18,168"></polygon>`;
+    case "circle":
+      return `<circle cx="100" cy="100" r="74"></circle>`;
+    case "parallelogram":
+      return `<polygon points="42,38 188,38 158,162 12,162"></polygon>`;
+    case "trapezoid":
+      return `<polygon points="42,44 158,44 188,162 12,162"></polygon>`;
+    case "pentagon":
+      return `<polygon points="100,14 178,72 148,166 52,166 22,72"></polygon>`;
+    case "hexagon":
+      return `<polygon points="52,16 148,16 192,100 148,184 52,184 8,100"></polygon>`;
+    default:
+      return `<rect x="24" y="24" width="152" height="152" rx="6"></rect>`;
+  }
+}
+function sidePositions(shape, count) {
+  const map = {
+    square: ["top", "right", "bottom", "left"],
+    rectangle: ["top", "right", "bottom", "left"],
+    triangle: ["top", "right", "left"],
+    circle: ["top"],
+    parallelogram: ["top", "right", "bottom", "left"],
+    trapezoid: ["top", "right", "bottom", "left"],
+    pentagon: ["top", "upper-right", "lower-right", "lower-left", "upper-left"],
+    hexagon: ["top", "upper-right", "lower-right", "bottom", "lower-left", "upper-left"]
+  };
+  const fallback = ["top", "right", "bottom", "left", "upper-left", "upper-right"];
+  return (map[shape] || fallback).slice(0, count);
+}
+function createGeometryInput(index, label, pos) {
+  return `<label class="geo-side-input pos-${pos}"><span>${label}</span><input type="number" min="0" step="any" data-edge-index="${index}" placeholder="cm"></label>`;
+}
+function renderGeometrySketch(shape) {
+  if (!geometrySketch || !geometryShapeMeta[shape]) return;
+  const meta = geometryShapeMeta[shape];
+  const positions = sidePositions(shape, meta.sides.length);
+  const edges = meta.sides.map((label, idx) => createGeometryInput(idx + 1, label, positions[idx] || "top")).join("");
+  geometrySketch.innerHTML = `
+    <div class="geo-notebook">
+      <svg class="geo-shape-svg shape-${shape}" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">${geometrySvgForShape(shape)}</svg>
+      ${edges}
+      <input id="geoGoalInput" class="geo-goal-input" type="text" placeholder="alan / çevre">
+      <div id="geoResultPad" class="geo-result-pad" aria-live="polite"></div>
+    </div>
+  `;
+  wireGeometryInputRules(shape);
+}
+function normalizeGoal(v) {
+  const val = String(v || "").toLowerCase().trim();
+  if (hasAny(val, ["alan", "a"])) return "alan";
+  if (hasAny(val, ["cevre", "çevre", "c"])) return "çevre";
+  return null;
+}
+function getShapeEdges() {
+  if (!geometrySketch) return [];
+  const inputs = [...geometrySketch.querySelectorAll("input[data-edge-index]")];
+  return inputs.map((i) => parsePositive(i.value));
+}
+function wireGeometryInputRules(shape) {
+  if (!geometrySketch) return;
+  const inputs = [...geometrySketch.querySelectorAll("input[data-edge-index]")];
+  if (!inputs.length) return;
+  inputs.forEach((input, idx) => {
+    input.addEventListener("input", () => {
+      clearGeometryWarn();
+      const v = input.value;
+      if (!v) return;
+      if (shape === "square" && idx === 0) inputs.forEach((i) => { i.value = v; });
+      if (shape === "rectangle") {
+        if (idx === 0 || idx === 2) { if (inputs[0].value) inputs[2].value = inputs[0].value; }
+        if (idx === 1 || idx === 3) { if (inputs[1].value) inputs[3].value = inputs[1].value; }
+      }
+    });
+  });
+}
+function computeGeometry(shape) {
+  const edges = getShapeEdges();
+  const goalInput = document.getElementById("geoGoalInput");
+  const goal = normalizeGoal(goalInput ? goalInput.value : "");
+  if (!goal) return { error: "Ortadaki kutuya alan veya çevre yaz." };
+  if (edges.some((v) => v === null)) return { error: "Tüm gerekli kenar/r değerlerini pozitif cm olarak gir." };
+  if (shape === "square") {
+    const a = edges[0];
+    return goal === "alan"
+      ? { value: a * a, formula: `${a} x ${a} = ${a * a}`, unit: "cm²", label: "Alan" }
+      : { value: 4 * a, formula: `${a} x 4 = ${4 * a}`, unit: "cm", label: "Çevre" };
+  }
+  if (shape === "rectangle") {
+    const long = edges[0];
+    const short = edges[1];
+    if (!(long > short)) return { error: "Dikdörtgende uzun kenar kısa kenardan büyük olmalı." };
+    const area = long * short;
+    const perimeter = 2 * (long + short);
+    return goal === "alan"
+      ? { value: area, formula: `${long} x ${short} = ${area}`, unit: "cm²", label: "Alan" }
+      : { value: perimeter, formula: `2 x (${long} + ${short}) = ${perimeter}`, unit: "cm", label: "Çevre" };
+  }
+  if (shape === "triangle") {
+    const [a, b, c] = edges;
+    const p = a + b + c;
+    if (goal === "çevre") return { value: p, formula: `${a}+${b}+${c} = ${p}`, unit: "cm", label: "Çevre" };
+    const s = p / 2;
+    const area2 = s * (s - a) * (s - b) * (s - c);
+    if (area2 <= 0) return { error: "Bu kenarlarla geçerli üçgen oluşmuyor." };
+    const area = Number(Math.sqrt(area2).toFixed(2));
+    return { value: area, formula: `√(s(s-a)(s-b)(s-c)) = ${area}`, unit: "cm²", label: "Alan" };
+  }
+  if (shape === "circle") {
+    const r = edges[0];
+    const area = Number((Math.PI * r * r).toFixed(2));
+    const perimeter = Number((2 * Math.PI * r).toFixed(2));
+    return goal === "alan"
+      ? { value: area, formula: `π x ${r}² = ${area}`, unit: "cm²", label: "Alan" }
+      : { value: perimeter, formula: `2π x ${r} = ${perimeter}`, unit: "cm", label: "Çevre" };
+  }
+  if (shape === "parallelogram") {
+    const a = edges[0];
+    const b = edges[1];
+    const area = a * b;
+    const perimeter = 2 * (a + b);
+    return goal === "alan"
+      ? { value: area, formula: `${a} x ${b} = ${area}`, unit: "cm²", label: "Alan" }
+      : { value: perimeter, formula: `2 x (${a}+${b}) = ${perimeter}`, unit: "cm", label: "Çevre" };
+  }
+  if (shape === "trapezoid") {
+    const [a, b, c, d] = edges;
+    const perimeter = a + b + c + d;
+    if (goal === "çevre") return { value: perimeter, formula: `${a}+${b}+${c}+${d} = ${perimeter}`, unit: "cm", label: "Çevre" };
+    const h = Number(Math.abs(a - b).toFixed(2));
+    const area = Number((((a + b) / 2) * h).toFixed(2));
+    return { value: area, formula: `((${a}+${b})/2) x ${h} = ${area}`, unit: "cm²", label: "Alan" };
+  }
+  if (shape === "pentagon" || shape === "hexagon") {
+    const n = shape === "pentagon" ? 5 : 6;
+    const side = edges[0];
+    const perimeter = n * side;
+    if (goal === "çevre") return { value: perimeter, formula: `${side} x ${n} = ${perimeter}`, unit: "cm", label: "Çevre" };
+    const area = Number(((n * side * side) / (4 * Math.tan(Math.PI / n))).toFixed(2));
+    return { value: area, formula: `düzgün ${n}gen alan formülü = ${area}`, unit: "cm²", label: "Alan" };
+  }
+  return { error: "Bu şekil için hesaplama tanımlanamadı." };
+}
+function showGeometrySolveEffect() {
+  const pad = geometrySketch?.querySelector(".geo-notebook");
+  if (!pad) return;
+  pad.classList.remove("geo-hit");
+  // reflow
+  void pad.offsetWidth;
+  pad.classList.add("geo-hit");
+}
+function solveGeometryCard() {
+  clearGeometryWarn();
+  const result = computeGeometry(selectedGeometryShape);
+  if (result.error) {
+    showGeometryWarn(result.error);
+    return;
+  }
+  const resultPad = document.getElementById("geoResultPad");
+  if (resultPad) resultPad.textContent = `${result.label} = ${result.value} ${result.unit}`;
+  showGeometrySolveEffect();
+  const shapeLabel = geometryShapeMeta[selectedGeometryShape].label;
+  const userMsg = `Geometri: ${shapeLabel} (${result.label})`;
+  const botMsg = `🧩 ${shapeLabel} ${result.label} = ${result.value} ${result.unit}
+Adım: ${result.formula}`;
+  startChatIfNeeded();
+  addMessage(userMsg, "user");
+  const thinking = addThinkingBubble("math");
+  setTimeout(() => fillThinkingBubble(thinking, botMsg, "İşlem analiz edildi • sonuç hazır ✅"), 3000);
+}
+const tutorSteps = [
+  {
+    title: "👋 baluk-1.9 öğreticisine hoş geldin",
+    text: "Bu kısa turda tüm ana butonları tek tek tanıtacağım.",
+    target: () => modelToggle,
+    before: () => plusMenu && plusMenu.classList.add("hidden")
+  },
+  {
+    title: "🐟 Model seçme",
+    text: "Baluk logolu bu butondan modeli değiştirebilirsin. Web Arama özelliği <b>baluk-1.7+</b>, Baluk.lens ise <b>baluk-1.9+</b> modellerde aktif olur.",
+    target: () => modelToggle
+  },
+  {
+    title: "🧠 Bellek butonu",
+    text: "Buradan kaydettiğin bilgileri görür, düzenler ve temizlersin.",
+    target: () => memoryToggle
+  },
+  {
+    title: "✍️ Yazma çubuğu",
+    text: "Mesajlarını buraya yazarsın. Normal modda Baluk cevap üretir, Web modunda arama sonucu toplar.",
+    target: () => userInput
+  },
+  {
+    title: "➕ Araçlar menüsü",
+    text: "Bu butona basınca Matematik Modu ve Web Arama Modu araçları açılır.",
+    target: () => plusToggle,
+    before: () => plusMenu && plusMenu.classList.add("hidden")
+  },
+  {
+    title: "🧠 Matematik modu",
+    text: "Gelişmiş Matematik Modu ile matematik stüdyosunda çok adımlı problemleri (örn: aldı-verdi-yedi zinciri) çözebilirsin.",
+    target: () => advancedMathMode ? advancedMathMode.closest("label") : null,
+    before: () => plusMenu && plusMenu.classList.remove("hidden")
+  },
+  {
+    title: "🌐 Web modu (Demo)",
+    text: "Web Arama Modu açıldığında sorgun webde aranır; linkler verilir. Wikipedia metne dökme özelliği <b>baluk-1.8 ve üstü</b> modellerde açılır.",
+    target: () => webSearchMode ? webSearchMode.closest("label") : null,
+    before: () => plusMenu && plusMenu.classList.remove("hidden")
+  },
+  {
+    title: "🔎 Web arama nasıl çalışır?",
+    text: "Web modu açıkken giriş çubuğu web temasına döner. Sorgu yaz, gönder; Baluk 9-11 sn analiz eder ve ilk 3 sonucu tıklanabilir verir.",
+    target: () => userInput,
+    before: () => {
+      if (plusMenu) plusMenu.classList.remove("hidden");
+      if (webSearchMode && !webSearchMode.checked) {
+        webSearchMode.checked = true;
+        setWebMode(true);
+      }
+    }
+  },
+  {
+    title: "📸 Baluk.lens (1.9)",
+    text: "+ menüsünden Baluk.lens'i açarsan fotoğraf yükleyip bir bölge işaretleyebilir ve benzer görsel kaynaklarını hızlıca alabilirsin.",
+    target: () => balukLensMode ? balukLensMode.closest("label") : null,
+    before: () => {
+      if (plusMenu) plusMenu.classList.remove("hidden");
+      if (balukLensMode && !balukLensMode.checked) {
+        balukLensMode.checked = true;
+        setLensMode(true);
+      }
+    }
+  },
+  {
+    title: "☰ Yan menü",
+    text: "Sağ üstteki menü butonundan hesap, premium ve yeni arka plan ayarlarına hızlıca ulaşırsın.",
+    target: () => accountToggle,
+    before: () => plusMenu && plusMenu.classList.add("hidden")
+  },
+  {
+    title: "🎵 Arka Plan Ayarları",
+    text: "Yan menüdeki Arka Plan Ayarları ile 10 farklı animasyonlu tema, beyaz varsayılan tema ve 10 farklı rahatlatıcı müzik seçebilirsin.",
+    target: () => drawerBackgroundOpen,
+    before: () => {
+      if (sideDrawer) sideDrawer.classList.remove("hidden");
+    }
+  },
+  {
+    title: "🧹 Sohbeti sıfırla",
+    text: "Gerekirse tüm sohbet ekranını temizlemek için bu butonu kullanırsın.",
+    target: () => clearChat,
+    before: () => plusMenu && plusMenu.classList.add("hidden")
+  }
+];
+function clearTutorSpotlight() {
+  [modelToggle, memoryToggle, userInput, plusToggle, clearChat, geometryToolbar, geometrySketch, accountToggle, drawerBackgroundOpen].forEach((el) => el && el.classList.remove("math-spotlight"));
+  if (advancedMathMode) {
+    const n = advancedMathMode.closest("label");
+    if (n) n.classList.remove("math-spotlight");
+  }
+  if (webSearchMode) {
+    const n = webSearchMode.closest("label");
+    if (n) n.classList.remove("math-spotlight");
+  }
+  if (balukLensMode) {
+    const n = balukLensMode.closest("label");
+    if (n) n.classList.remove("math-spotlight");
+  }
+}
+function renderTutorStep() {
+  if (!mathTutorOverlay || !mathTutorTitle || !mathTutorText) return;
+  const step = tutorSteps[tutorStep];
+  if (!step) return;
+  if (typeof step.before === "function") step.before();
+  mathTutorTitle.innerHTML = step.title;
+  mathTutorText.innerHTML = step.text;
+  clearTutorSpotlight();
+  const target = step.target ? step.target() : null;
+  if (target) target.classList.add("math-spotlight");
+  if (mathTutorNext) mathTutorNext.classList.toggle("hidden", tutorStep >= tutorSteps.length - 1);
+  if (mathTutorDone) mathTutorDone.classList.toggle("hidden", tutorStep < tutorSteps.length - 1);
+}
+function showTutorFinale() {
+  if (!mathTutorFinale) return;
+  mathTutorFinale.classList.remove("hidden");
+  setTimeout(() => mathTutorFinale.classList.add("hidden"), 1600);
+}
+function maybeShowMathTutor() {
+  if (!mathTutorOverlay || modelVersionNumber(currentModel) < 1.7) return;
+  if (localStorage.getItem("balukMasterTutor17Done") === "1") return;
+  tutorStep = 0;
+  mathTutorOverlay.classList.remove("hidden");
+  renderTutorStep();
+}
+function initGeometryLab() {
+  if (!geometryToolbar || !geometrySketch) return;
+  renderGeometrySketch(selectedGeometryShape);
+  const buttons = [...geometryToolbar.querySelectorAll(".geo-btn")];
+  buttons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      buttons.forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+      selectedGeometryShape = btn.dataset.shape;
+      renderGeometrySketch(selectedGeometryShape);
+      clearGeometryWarn();
+    });
+  });
+  if (solveGeometryBtn) solveGeometryBtn.addEventListener("click", solveGeometryCard);
+}
+function showMemoryToast() {
+  if (!memoryToast) return;
+  memoryToast.classList.remove("hidden");
+  if (memoryToastTimer) clearTimeout(memoryToastTimer);
+  memoryToastTimer = setTimeout(() => memoryToast.classList.add("hidden"), 2200);
+}
+function buildGeneralAnswerReply(input) {
+  const cleaned = input.trim();
+  const starter = chooseRandom([
+    "Anladım, güzel noktaya değindin.",
+    "Söylediğini net aldım.",
+    "Bu cevabın iyi bir yön veriyor.",
+    "Gayet mantıklı bir cevap oldu."
+  ]);
+  return `${starter} '${cleaned}' üzerinden devam edebilirim; istersen bunu adım adım plana çevireyim.`;
+}
+function shouldExpectFollowUp(answer) {
+  const a = answer.toLowerCase();
+  const yesNoPrompt = /(?:\s|^)(m[ıi]|mi)(?:\s|$|[?.!,])/i.test(a);
+  const invitationPrompt = /(ister\s+.+\s+yapal[ıi]m|challenge\s+yapal[ıi]m|başlayal[ıi]m|devam\s+edelim|deneyelim)/i.test(a);
+  return answer.includes("?") || yesNoPrompt || hasAny(a, [
+    "sen seç:", "bana tema ver", "tema seç", "yazayım mı", "istersen",
+    "challenge yapalım", "mini challenge", "ister şiir yazalım", "ister küçük bir matematik",
+    "ister hikaye", "ister hikâye", "başlayalım", "devam edelim", "sen seç"
+  ]) || invitationPrompt;
+}
+function isAffirmativeInput(inputLower) {
+  return hasAny(inputLower, ["evet", "olur", "tamam", "yapalım", "hadi", "ok", "başla", "basla"]);
+}
+function resolveActivityChoice(inputLower) {
+  if (hasAny(inputLower, ["matematik", "işlem", "hesap"])) {
+    return "Süper, matematik modundayız 🧮 Bana bir işlem (örn: 12*7) ya da denklem (örn: 2x+4=18) yaz.";
+  }
+  if (hasAny(inputLower, ["hikaye", "hikâye"])) {
+    return askThemeFor("story");
+  }
+  if (hasAny(inputLower, ["şiir", "siir"])) {
+    return askThemeFor("poem");
+  }
+  if (hasAny(inputLower, ["aşk", "ask"])) {
+    return generateCreativeText("poem", "aşk");
+  }
+  return null;
+}
+function resolveYesNoFromLastPrompt(inputLower) {
+  const last = (lastBotResponse || "").toLowerCase();
+  const yes = isAffirmativeInput(inputLower);
+  const no = hasAny(inputLower, ["hayır", "hayir", "istemiyorum", "yok"]);
+  if (!yes && !no) return null;
+  if (no) return chooseRandom(generalNoResponses);
+  const detectedTheme = detectTheme(last) || (last.match(/([a-zçğıöşü\s]+)\s+temalı/i)?.[1]?.trim() ?? null);
+  const theme = detectedTheme || "doğa";
+  if (hasAny(last, ["hikâye", "hikaye"])) {
+    if (hasAny(last, ["tema ver", "tema seç"])) return askThemeFor("story");
+    if (hasAny(last, ["yazayım", "yazalım", "mini hikâye", "mini hikaye"])) return generateCreativeText("story", theme);
+  }
+  if (hasAny(last, ["şiir", "siir"])) {
+    if (hasAny(last, ["tema seç", "tema ver"])) return askThemeFor("poem");
+    if (hasAny(last, ["yazayım", "yazalım", "kısa şiir", "temalı"])) return generateCreativeText("poem", theme);
+  }
+  if (hasAny(last, ["matematik", "işlem", "denklem"])) {
+    return "Harika, matematikte devam edelim 🧠 Bana çözmemi istediğin işlemi yaz.";
+  }
+  if (hasAny(last, ["challenge", "mini challenge", "küçük bir matematik", "matematik challenge"])) {
+    return "Süper! Challenge modu açıldı 🧮 İlk tur: 37 + 48 kaç eder? İstersen kendi sorunu da yazabilirsin.";
+  }
+  if (hasAny(last, ["plan", "adım adım", "mini plan"])) {
+    return chooseRandom(goalPlanResponses);
+  }
+  return chooseRandom(generalYesResponses);
+}
+function isClearlyNewTopic(inputLower) {
+  if (solveWordProblemValue(inputLower) !== null) return true;
+  if (solveLinearEquation(inputLower)) return true;
+  if (solveSimpleExpression(inputLower)) return true;
+  const questionSignals = ["?", "kaç", "kac", "nedir", "nasıl", "nasil", "neden", "kim", "ne zaman", "hangi", "ne", "olur mu", "mümkün mü", "gerçekten", "doğru mu"];
+  return questionSignals.some((token) => inputLower.includes(token));
+}
+function detectTheme(inputLower) {
+  const theme = creativeThemes.find((t) => inputLower.includes(t));
+  if (theme) return theme;
+  const cleaned = inputLower.replace(/tema(?:m)?\s*(?:=|:)?\s*/g, "").trim();
+  if (!cleaned) return null;
+  const shortTheme = cleaned.split(/[,.;!?]/)[0].trim();
+  return shortTheme && shortTheme.length <= 40 ? shortTheme : null;
+}
+function isCompetitorAiMention(inputLower) {
+  return competitorAiKeywords.some((kw) => inputLower.includes(kw));
+}
+function buildAiMentionReply() {
+  return chooseRandom(aiMentionResponses);
+}
+function askThemeFor(mode) {
+  convoState.awaitingCreativeTheme = true;
+  convoState.creativeMode = mode;
+  return `Harika, ${mode === "story" ? "hikâye" : "şiir"} yazalım ✍️ Önce bir tema seç: ${creativeThemes.join(", ")}.`;
+}
+function generateCreativeText(mode, theme) {
+  const normalizedTheme = theme.charAt(0).toUpperCase() + theme.slice(1);
+  const template = mode === "story" ? chooseRandom(storyTemplates) : chooseRandom(poemTemplates);
+  const title = mode === "story" ? `📖 ${normalizedTheme} Temalı Mini Hikâye` : `📝 ${normalizedTheme} Temalı Şiir`;
+  const themedText = template
+    .replaceAll("{theme}yi", `${theme}'yi`)
+    .replaceAll("{theme}ye", `${theme}'ye`)
+    .replaceAll("{theme}si", `${theme}'si`)
+    .replaceAll("{theme}", theme);
+  return `${title}
+${themedText}`;
+}
+function saveMemory() {
+  if (!isAccountLoggedIn) return;
+  localStorage.setItem("balukMemory", JSON.stringify(userMemory));
+}
+function renderMemoryList() {
+  memoryList.innerHTML = "";
+  if (!supportsMemoryModel()) {
+    const li = document.createElement("li");
+    li.textContent = "Bellek yalnızca baluk-1.6 modelinde aktif.";
+    memoryList.appendChild(li);
+    return;
+  }
+  const entries = Object.entries(userMemory);
+  if (!entries.length) {
+    const li = document.createElement("li");
+    li.textContent = "Henüz kayıt yok.";
+    memoryList.appendChild(li);
+    return;
+  }
+  entries.forEach(([k, v]) => {
+    const li = document.createElement("li");
+    li.textContent = `${k}: ${v}`;
+    memoryList.appendChild(li);
+  });
+}
+function parseMemory(input) {
+  if (!supportsMemoryModel()) return null;
+  const lower = input.toLowerCase();
+  if (isMemoryQuestion(lower)) return null;
+  let changed = false;
+  memoryPatterns.forEach((p) => {
+    const m = input.match(p.regex);
+    if (m && m[1]) {
+      userMemory[p.label] = m[1].trim();
+      changed = true;
+    }
+  });
+  if (changed) {
+    saveMemory();
+    renderMemoryList();
+    showMemoryToast();
+    return chooseRandom(memorySavedResponses);
+  }
+  return null;
+}
+function getMemoryAnswer(inputLower) {
+  if (!supportsMemoryModel()) return null;
+  for (const rule of memoryQuestionPatterns) {
+    if (!hasAny(inputLower, rule.checks)) continue;
+    const known = rule.labels.filter((label) => userMemory[label]);
+    if (!known.length) {
+      return "Bu bilgi belleğimde henüz yok 🤔 Bana 'Benim adım ...', 'yaşım ...' gibi yazarsan kaydederim.";
+    }
+    if (rule.labels.length === 1) {
+      const label = rule.labels[0];
+      return `${label} bilgin: ${userMemory[label]}`;
+    }
+    const summary = known.map((label) => `${label}: ${userMemory[label]}`).join("\n");
+    return `Belleğinde şunlar var:
+${summary}`;
+  }
+  return null;
+}
+function isMemoryQuestion(inputLower) {
+  return memoryQuestionPatterns.some((rule) => hasAny(inputLower, rule.checks));
+}
+function startIntroAmbientHum() {
+  const AudioCtx = window.AudioContext || window.webkitAudioContext;
+  if (!AudioCtx) return;
+  if (!introAudioCtx) introAudioCtx = new AudioCtx();
+  const now = introAudioCtx.currentTime;
+  if (introAudioCtx.state === "suspended") {
+    introAudioCtx.resume().catch(() => {});
+  }
+  if (introAmbientNodes.length) return;
+  const master = introAudioCtx.createGain();
+  master.gain.setValueAtTime(0.0001, now);
+  master.gain.exponentialRampToValueAtTime(0.018, now + 1.6);
+  master.connect(introAudioCtx.destination);
+  const oscA = introAudioCtx.createOscillator();
+  oscA.type = "sine";
+  oscA.frequency.setValueAtTime(72, now);
+  const oscB = introAudioCtx.createOscillator();
+  oscB.type = "triangle";
+  oscB.frequency.setValueAtTime(108, now);
+  const wobble = introAudioCtx.createOscillator();
+  wobble.type = "sine";
+  wobble.frequency.value = 0.12;
+  const wobbleGain = introAudioCtx.createGain();
+  wobbleGain.gain.value = 5;
+  const filter = introAudioCtx.createBiquadFilter();
+  filter.type = "lowpass";
+  filter.frequency.value = 260;
+  filter.Q.value = 0.6;
+  wobble.connect(wobbleGain);
+  wobbleGain.connect(filter.frequency);
+  oscA.connect(filter);
+  oscB.connect(filter);
+  filter.connect(master);
+  oscA.start(now);
+  oscB.start(now);
+  wobble.start(now);
+  introAmbientNodes = [oscA, oscB, wobble, wobbleGain, filter, master];
+}
+function stopIntroAmbientHum(fast = false) {
+  if (!introAudioCtx || !introAmbientNodes.length) return;
+  const now = introAudioCtx.currentTime;
+  const master = introAmbientNodes[introAmbientNodes.length - 1];
+  if (master && master.gain) {
+    master.gain.cancelScheduledValues(now);
+    master.gain.setValueAtTime(Math.max(master.gain.value, 0.0001), now);
+    master.gain.exponentialRampToValueAtTime(0.0001, now + (fast ? 0.25 : 0.7));
+  }
+  setTimeout(() => {
+    try {
+      introAmbientNodes.forEach((n) => {
+        if (n && typeof n.stop === "function") n.stop();
+      });
+    } catch {}
+    introAmbientNodes = [];
+  }, fast ? 320 : 760);
+}
+function startIntroWhooshAudio() {
+  stopIntroWhooshAudio();
+  stopIntroAmbientHum(true);
+  const AudioCtx = window.AudioContext || window.webkitAudioContext;
+  if (!AudioCtx) return;
+  if (!introAudioCtx) introAudioCtx = new AudioCtx();
+  const now = introAudioCtx.currentTime;
+  if (introAudioCtx.state === "suspended") introAudioCtx.resume().catch(() => {});
+  const master = introAudioCtx.createGain();
+  master.gain.setValueAtTime(0.0001, now);
+  master.gain.exponentialRampToValueAtTime(0.08, now + 0.35);
+  master.gain.exponentialRampToValueAtTime(0.12, now + 1.25);
+  master.gain.exponentialRampToValueAtTime(0.0001, now + 4.8);
+  master.connect(introAudioCtx.destination);
+  const osc = introAudioCtx.createOscillator();
+  osc.type = "sine";
+  osc.frequency.setValueAtTime(170, now);
+  osc.frequency.exponentialRampToValueAtTime(260, now + 1.1);
+  osc.frequency.exponentialRampToValueAtTime(232, now + 1.45);
+  osc.frequency.exponentialRampToValueAtTime(210, now + 4.2);
+  const lfo = introAudioCtx.createOscillator();
+  lfo.type = "sine";
+  lfo.frequency.value = 0.42;
+  const lfoGain = introAudioCtx.createGain();
+  lfoGain.gain.value = 22;
+  const filter = introAudioCtx.createBiquadFilter();
+  filter.type = "lowpass";
+  filter.frequency.setValueAtTime(700, now);
+  filter.frequency.exponentialRampToValueAtTime(1500, now + 1.4);
+  filter.frequency.exponentialRampToValueAtTime(900, now + 2.7);
+  lfo.connect(lfoGain);
+  lfoGain.connect(osc.frequency);
+  osc.connect(filter);
+  filter.connect(master);
+  osc.start(now);
+  lfo.start(now);
+  osc.stop(now + 5.0);
+  lfo.stop(now + 5.0);
+  introAudioNodes = [osc, lfo, master, filter, lfoGain];
+}
+function stopIntroWhooshAudio() {
+  try {
+    introAudioNodes.forEach((n) => {
+      if (n && typeof n.stop === "function") n.stop();
+    });
+  } catch {}
+  introAudioNodes = [];
+  if (introAudioCtx && !introAmbientNodes.length) {
+    introAudioCtx.close().catch(() => {});
+    introAudioCtx = null;
+  }
+}
+function openAppWithTransition() {
+  if (!introGate || !appRoot) return;
+
+  const revealApp = () => {
+    stopIntroWhooshAudio();
+    if (enterTransition) enterTransition.classList.add("hidden");
+    appRoot.classList.remove("hidden");
+    if (userInput) userInput.focus();
+    setTimeout(() => maybeShowMathTutor(), 220);
+  };
+
+  introGate.classList.add("hidden");
+  if (enterTransition) enterTransition.classList.remove("hidden");
+
+  try {
+    startIntroWhooshAudio();
+  } catch {}
+
+  const TRANSITION_MS = 4200;
+  setTimeout(revealApp, TRANSITION_MS);
+
+  // Güvenlik ağı: herhangi bir timer/ses sorunu olursa yine de uygulamayı aç.
+  setTimeout(() => {
+    if (appRoot.classList.contains("hidden")) revealApp();
+  }, TRANSITION_MS + 1200);
+}
+function applyPersonalization(response) {
+  if (!supportsMemoryModel()) return response;
+  const name = userMemory.Ad;
+  if (!name) return response;
+  const trimmed = String(response || "").trim();
+  if (!trimmed) return response;
+  if (trimmed.toLowerCase().startsWith(`${String(name).toLowerCase()},`)) return response;
+  return `${name}, ${response}`;
+}
+function ensureEmojiTone(text) {
+  const input = String(text || "").trim();
+  if (!input) return input;
+  if (/[\u{1F300}-\u{1FAFF}\u2600-\u27BF]/u.test(input)) return input;
+  return `${input} 🙂`;
+}
+function addMessage(text, role) {
+  const n = document.createElement("div");
+  n.className = `msg ${role}`;
+  chat.appendChild(n);
+  chat.scrollTop = chat.scrollHeight;
+  if (role === "bot") {
+    n.classList.add("typing-active");
+    typeTextSlowly(n, ensureEmojiTone(text), { baseDelay: 10, punctuationDelay: 34 }).finally(() => n.classList.remove("typing-active"));
+    return;
+  }
+  n.textContent = role === "bot" ? ensureEmojiTone(text) : text;
+}
+function addThinkingBubble(kind = "default") {
+  const n = document.createElement("div");
+  n.className = `msg bot thinking-bubble ${kind === "math" ? "thinking-math" : kind === "web" ? "thinking-web" : ""}`;
+  const title = kind === "math" ? "İşlem analiz ediliyor..." : kind === "web" ? "Web'den buluyorum..." : "Baluk düşünüyor...";
+  n.innerHTML = `
+    <div class="thinking-head">
+      <svg class="fish-logo think-fish spin-fast" viewBox="0 0 520 220" fill="none" xmlns="http://www.w3.org/2000/svg"><use href="#baluk-fish"></use></svg>
+      <span>${title}</span>
+    </div>
+  `;
+  chat.appendChild(n);
+  chat.scrollTop = chat.scrollHeight;
+  return n;
+}
+function updateThinkingStatus(node, status) {
+  if (!node || !status) return;
+  const statusEl = node.querySelector(".thinking-head span");
+  if (statusEl) statusEl.textContent = status;
+}
+function startWebThinkingProgress(node, totalMs) {
+  if (!node) return () => {};
+  const steps = [
+    { at: 1200, text: "Web'den alıyorum..." },
+    { at: Math.max(2200, Math.round(totalMs * 0.45)), text: "Web'den yazıya döküyorum..." },
+    { at: Math.max(3200, Math.round(totalMs * 0.72)), text: "Kaynakları birleştiriyorum..." },
+    { at: Math.max(4200, Math.round(totalMs * 0.9)), text: "Son dokunuşlar yapılıyor..." }
+  ];
+  const timers = steps.map((step) => setTimeout(() => updateThinkingStatus(node, step.text), step.at));
+  return () => timers.forEach((t) => clearTimeout(t));
+}
+function fillThinkingBubble(node, text, doneStatus = "") {
+  if (!node) return;
+  const fish = node.querySelector(".think-fish");
+  if (fish) fish.classList.remove("spin-fast");
+  if (doneStatus) updateThinkingStatus(node, doneStatus);
+  let content = node.querySelector(".thinking-answer");
+  if (!content) {
+    content = document.createElement("div");
+    content.className = "thinking-answer";
+    node.appendChild(content);
+  }
+  content.classList.add("typing-active");
+  typeTextSlowly(content, ensureEmojiTone(text), { baseDelay: 10, punctuationDelay: 36 }).finally(() => content.classList.remove("typing-active"));
+}
+function openSafetySurveyModal(category = "generic") {
+  if (!safetySurveyModal) return;
+  safetySurveyModal.dataset.category = category;
+  safetySurveyModal.classList.remove("hidden");
+}
+function closeSafetySurvey() {
+  if (!safetySurveyModal) return;
+  safetySurveyModal.classList.add("hidden");
+}
+function surveyReplyByReason(reason, category) {
+  const map = {
+    "bunaldim": "Bunu paylaştığın için teşekkür ederim 💙 Bunalmış hissettiğinde önce güvenli kalmak önemli: nefesini yavaşlat, yalnız kalma ve bir yakınından destek iste. İstersen şimdi birlikte 5 dakikalık sakinleşme planı yapalım.",
+    "merak": "Merak duygun çok doğal 🌟 Ancak riskli/yasa dışı alanlarda merakı güvenli kanallara taşımak en sağlıklısı. İstersen aynı konunun güvenli ve yasal öğrenme tarafını adım adım göstereyim.",
+    "zarar-baskasi": "Bu duygu ciddiye alınmalı. Kimseye zarar vermeye dönüşmeden önce uzaklaşma + sakinleşme + destek alma adımı çok kritik. İstersen öfke yönetimi için kısa bir acil plan çıkaralım.",
+    "zarar-kendim": "Bunu söylediğin için gerçekten teşekkür ederim. Bu noktada yalnız kalmaman ve bir destek kişisine hemen ulaşman çok önemli. Eğer risk yüksekse lütfen acil yardıma başvur. Ben de burada kalabilirim.",
+    "saka": "Anladım 🙂 Yine de bu tür konular hassas olduğu için güvenlik dilini koruyorum. İstersen şimdi tamamen güvenli bir konuya geçip üretken bir şey yapalım."
+  };
+  const prefix = category === "self_harm" ? "🫂" : "🛡️";
+  return `${prefix} ${map[reason] || map['merak']}`;
+}
+function appendSafetySurveyPrompt() {
+  const category = pendingSafetySurvey || "generic";
+  const wrap = document.createElement("div");
+  wrap.className = "msg bot safety-survey";
+  wrap.innerHTML = `
+    <div class="survey-title">İstersen detaylı anketi başlatabilirim.</div>
+    <button type="button" class="survey-start-btn" data-category="${category}">Neden bunu yapmak istedin?</button>
+  `;
+  const btn = wrap.querySelector(".survey-start-btn");
+  if (btn) {
+    btn.addEventListener("click", () => openSafetySurveyModal(btn.dataset.category || "generic"));
+  }
+  chat.appendChild(wrap);
+  chat.scrollTop = chat.scrollHeight;
+}
+function solveSimpleExpression(input) {
+  const normalized = input.toLowerCase().replaceAll("x", "*").replaceAll("çarpı", "*").replaceAll("kere", "*").replaceAll("bölü", "/").replaceAll("artı", "+").replaceAll("eksi", "-").replace(/[^0-9+\-*/()., ]/g, "").replaceAll(",", ".").trim();
+  if (!/[0-9]/.test(normalized) || !/[+\-*/]/.test(normalized)) return null;
+  try {
+    const value = Function(`"use strict"; return (${normalized});`)();
+    if (Number.isFinite(value)) return `Sonuç: ${value} ✅`;
+  } catch { return null; }
+  return null;
+}
+function solveLinearEquation(input) {
+  const compact = input.toLowerCase().replace(/\s+/g, "");
+  const m = compact.match(/^([+-]?\d*)x([+-]\d+)?=([+-]?\d+)$/);
+  if (!m) return null;
+  const a = m[1] === "" || m[1] === "+" ? 1 : m[1] === "-" ? -1 : Number(m[1]);
+  const b = Number(m[2] || "+0");
+  const c = Number(m[3]);
+  if (a === 0) return "Bu denklemde x katsayısı 0 olduğu için klasik çözüm yok.";
+  return `Denklem çözümü: x = ${(c - b) / a}`;
+}
+function solveWordProblemValue(input) {
+  const q = String(input || "").toLowerCase();
+  if (/\d\s*[x*+/\-]\s*\d/.test(q) || q.includes("=")) return null;
+  const numRegex = /-?\d+(?:[.,]\d+)?/g;
+  const occ = [];
+  let m;
+  while ((m = numRegex.exec(q)) !== null) {
+    occ.push({ value: Number(m[0].replace(",", ".")), index: m.index, raw: m[0] });
+  }
+  if (occ.length < 2 || occ.some((n) => !Number.isFinite(n.value))) return null;
+  const minusVerbs = [
+    "verdi", "yed", "att", "kaybet", "harca", "çıkar", "cikar", "azal", "eksil", "sat", "gitti", "gitt"
+  ];
+  const plusVerbs = [
+    "ald", "bul", "kazan", "topla", "ekl", "geld", "katıl", "katil", "ekle", "koy"
+  ];
+  const asksRemaining = hasAny(q, ["kaç kaldı", "kac kaldi", "ne kadar kaldı", "ne kadar kaldi", "kaç tane kaldı", "kac tane kaldi"]);
+  const asksTotal = hasAny(q, ["kaç oldu", "kac oldu", "toplam", "ne kadar oldu", "kaç tane oldu", "kac tane oldu"]);
+  const hasMinus = (t) => hasAny(t, minusVerbs);
+  const hasPlus = (t) => hasAny(t, plusVerbs);
+  let total = occ[0].value;
+  for (let i = 1; i < occ.length; i += 1) {
+    const prev = occ[i - 1];
+    const cur = occ[i];
+    const next = occ[i + 1];
+    const afterSlice = q.slice(cur.index, next ? next.index : Math.min(q.length, cur.index + 48));
+    const beforeSlice = q.slice(Math.max(0, prev.index), cur.index + cur.raw.length);
+    let sign = 0;
+    const afterMinus = hasMinus(afterSlice);
+    const afterPlus = hasPlus(afterSlice);
+    if (afterMinus && !afterPlus) sign = -1;
+    else if (afterPlus && !afterMinus) sign = +1;
+    else {
+      const beforeMinus = hasMinus(beforeSlice);
+      const beforePlus = hasPlus(beforeSlice);
+      if (beforeMinus && !beforePlus) sign = -1;
+      else if (beforePlus && !beforeMinus) sign = +1;
+    }
+    if (!sign) {
+      if (asksRemaining && !asksTotal) sign = -1;
+      else sign = +1;
+    }
+    total += sign * cur.value;
+  }
+  if (asksRemaining && hasAny(q, ["kalan", "kalanı", "kalani", "hepsini", "tamamını", "tamamini"]) && hasAny(q, ["yed", "harca", "verdi"])) {
+    return 0;
+  }
+  return Number(total.toFixed(6));
+}
+function solveWordProblem(input) {
+  const value = solveWordProblemValue(input);
+  if (value === null) return null;
+  return `Problem sonucu: ${value} ✅`;
+}
+function updateModelVisual() {
+  if (!currentModelBadge) return;
+  if (advancedMathEnabled) {
+    currentModelBadge.textContent = "matematik modu";
+    currentModelBadge.classList.remove("premium-model-badge");
+    return;
+  }
+  const premiumModelLabel = currentModel === "baluk-1.7" && isPremiumUser ? "premium-1.7" : currentModel;
+  currentModelBadge.textContent = premiumModelLabel;
+  currentModelBadge.classList.toggle("premium-model-badge", premiumModelLabel === "premium-1.7");
+  currentModelBadge.classList.remove("balle-model-badge");
+  updateComposerModeUI();
+  if (!supportsVoiceModel()) closeVoiceMode();
+}
+function updateMemoryAvailability() {
+  clearMemory.disabled = !supportsMemoryModel();
+  clearMemory.style.opacity = supportsMemoryModel() ? "1" : ".55";
+  clearMemory.style.cursor = supportsMemoryModel() ? "pointer" : "not-allowed";
+  renderMemoryList();
+}
+function updateGeneralQuestionState(answer) {
+  convoState.awaitingGeneralAnswer = supportsContextModel() && shouldExpectFollowUp(answer);
+}
+function resolveFollowUp(input) {
+  if (!supportsContextModel()) return null;
+  const l = input.toLowerCase();
+  if (convoState.awaitingEpsteinList && hasAny(l, ["evet", "olur", "tamam", "5 madde", "beş madde", "5 maddeye ayır", "beş maddeye ayır"])) {
+    convoState.awaitingEpsteinList = false;
+    return chooseRandom(epsteinListResponses);
+  }
+  if (convoState.awaitingCreativeTheme && convoState.creativeMode) {
+    const theme = detectTheme(l);
+    if (theme) {
+      const mode = convoState.creativeMode;
+      convoState.awaitingCreativeTheme = false;
+      convoState.creativeMode = null;
+      return generateCreativeText(mode, theme);
+    }
+    return `Temayı yakalayamadım 🤔 Şunlardan birini yazabilirsin: ${creativeThemes.join(", ")}.`;
+  }
+  if (hasAny(l, ["ne yapalım", "ne yapalim", "napalım", "napalim"])) {
+    convoState.awaitingActivityChoice = true;
+    return "Hazırım 💙 Sen seç: matematik / şiir / hikâye. İstersen direkt tema da yazabilirsin (örn: aşk, doğa, umut).";
+  }
+  if (convoState.awaitingActivityChoice) {
+    const picked = resolveActivityChoice(l);
+    if (picked) {
+      if (!hasAny(l, ["hikaye", "hikâye", "şiir", "siir"])) convoState.awaitingActivityChoice = false;
+      return picked;
+    }
+  }
+  if (convoState.awaitingMoodReply && (hasAny(l, ["iyiyim", "i̇yiyim", "ben de iyiyim", "bende iyiyim", "harikayım", "süperim", "motiveyim", "mutluyum", "yorgunum", "stresliyim", "sıkıldım", "üzgünüm", "iyiyim teşekkürler", "iyiyim tesekkurler"]) || /(^|\s)(i̇?yiyim|iyiyim)(\s|$|[?.!,])/.test(l))) {
+    convoState.awaitingMoodReply = false;
+    return chooseRandom(iyiyimFollowUpResponses);
+  }
+  if (convoState.awaitingGoalPlan && hasAny(l, ["hedef koyalım", "tamam", "olur", "hadi"])) {
+    convoState.awaitingGoalPlan = false;
+    return chooseRandom(goalPlanResponses);
+  }
+  if (convoState.awaitingGeneralAnswer) {
+    const fromPrompt = resolveYesNoFromLastPrompt(l);
+    if (fromPrompt) return fromPrompt;
+    if (isClearlyNewTopic(l)) {
+      convoState.awaitingGeneralAnswer = false;
+      return null;
+    }
+    if (hasAny(l, ["plan", "adım", "adim", "devam", "detay", "anlat"])) {
+      convoState.awaitingGeneralAnswer = false;
+      return buildGeneralAnswerReply(input);
+    }
+    convoState.awaitingGeneralAnswer = false;
+    return null;
+  }
+  return null;
+}
+function buildTextResponse(input) {
+  const l = input.toLowerCase();
+  if (isUnsafeQuery(l)) return buildUnsafeRefusal(l);
+  if (isCompetitorAiMention(l)) return buildAiMentionReply();
+  if (hasSalutation(l, saKeywords)) {
+    const profanityDirect = buildProfanityModeDirectReply(l, input);
+    if (profanityDirect) return profanityDirect;
+    return chooseRandom(saResponses);
+  }
+  const memoryAnswer = getMemoryAnswer(l);
+  if (memoryAnswer) return memoryAnswer;
+  const memorySaved = parseMemory(input);
+  if (memorySaved) return memorySaved;
+  const follow = resolveFollowUp(input);
+  if (follow) return follow;
+  if (supportsContextModel() && isAffirmativeInput(l) && shouldExpectFollowUp(lastBotResponse || "")) {
+    const bridged = resolveYesNoFromLastPrompt(l);
+    if (bridged) return bridged;
+  }
+  const profanityDirect = buildProfanityModeDirectReply(l, input);
+  if (profanityDirect) return profanityDirect;
+  if (hasAny(l, appreciationKeywords)) return chooseRandom(appreciationResponses);
+  if (hasAny(l, praiseKeywords)) return chooseRandom(praiseResponses);
+  if (getToxicityLevel(l) === "insult") return chooseRandom(insultReplyPrompts);
+  if (supportsContextModel() && hasAny(l, ["hikaye yaz", "hikâye yaz", "hikaye yazalım", "hikâye yazalım", "hikaye", "hikâye"])) {
+    return askThemeFor("story");
+  }
+  if (supportsContextModel() && hasAny(l, ["şiir yaz", "siir yaz", "şiir yazalım", "siir yazalım", "şiir", "siir"])) {
+    return askThemeFor("poem");
+  }
+  if (hasAny(l, ["merhaba", "selam", "merhab", "meraba", "kanka merhaba", ...extendedGreetingKeywords])) {
+    if (supportsContextModel()) convoState.awaitingMoodReply = true;
+    return chooseRandom(merhabaResponses);
+  }
+  if (isHowAreYouVariant(l)) {
+    if (supportsContextModel()) convoState.awaitingMoodReply = true;
+    const profanityMood = buildProfanityModeDirectReply(l, input);
+    if (profanityMood) return profanityMood;
+    return chooseRandom(nasilsinResponses);
+  }
+  if (hasAny(l, emotionalKeywords)) {
+    if (supportsContextModel()) convoState.awaitingGoalPlan = true;
+    return chooseRandom(emotionalPromptBank);
+  }
+  if (hasAny(l, ["epstein", "epstion", "epstien"])) {
+    if (supportsContextModel()) convoState.awaitingEpsteinList = true;
+    return chooseRandom(epsteinResponses);
+  }
+  const localUtilityReply = buildLocalUtilityReply(l);
+  if (localUtilityReply) return localUtilityReply;
+  const offlineKnowledgeReply = buildOfflineKnowledgeReply(l);
+  if (offlineKnowledgeReply) return offlineKnowledgeReply;
+  const wordProblem = solveWordProblem(input); if (wordProblem) return wordProblem;
+  const eq = solveLinearEquation(input); if (eq) return eq;
+  const expr = solveSimpleExpression(input); if (expr) return expr;
+  const unifiedKeywordReply = buildUnifiedKeywordReply(l);
+  if (unifiedKeywordReply) return unifiedKeywordReply;
+
+  if (isProfanityModeActive()) {
+    return buildProfanityUnknownReply(input);
+  }
+
+  return chooseRandom(unknownInputResponses);
+}
+function startChatIfNeeded() {
+  if (hasStartedChat) return;
+  hasStartedChat = true;
+  splash.classList.add("hidden");
+  chat.classList.remove("hidden");
+}
+function processInput(text) {
+  startChatIfNeeded();
+  addMessage(text, "user");
+  if (isBMWTrigger(text)) {
+    renderBMWVideoCard();
+    return;
+  }
+  const isMathFlow = advancedMathEnabled || Boolean(solveWordProblemValue(text));
+  const thinking = addThinkingBubble(isMathFlow ? "math" : "default");
+  const delayMs = isMathFlow ? 3000 : 1100;
+  setTimeout(() => {
+    const rawResponse = buildTextResponse(text);
+    const response = applyProfanityFlavor(expandForPremium(applyPersonalization(rawResponse)), text);
+    lastBotResponse = response;
+    updateGeneralQuestionState(response);
+    const doneStatus = isMathFlow ? "İşlem analiz edildi • cevap hazır ✅" : "Düşündüm • cevap hazır ✅";
+    fillThinkingBubble(thinking, response, doneStatus);
+    if (voiceModeActive) speakVoiceResponse(response);
+    if (pendingSafetySurvey) {
+      appendSafetySurveyPrompt();
+      pendingSafetySurvey = null;
+    }
+  }, delayMs);
+}
+function updateComposerActionVisual() {
+  if (!chatSubmitBtn || !userInput) return;
+  const hasText = Boolean(userInput.value.trim());
+  const canVoice = supportsVoiceModel();
+  const sendIcon = chatSubmitBtn.querySelector('.send-icon');
+  const voiceIcon = chatSubmitBtn.querySelector('.voice-mode-icon');
+  const showVoice = !hasText && canVoice;
+  chatSubmitBtn.classList.toggle('voice-launch', showVoice);
+  chatSubmitBtn.setAttribute('aria-label', showVoice ? 'Sesli modu aç' : 'Gönder');
+  if (sendIcon) sendIcon.classList.toggle('hidden', showVoice);
+  if (voiceIcon) voiceIcon.classList.toggle('hidden', !showVoice);
+}
+
+
+function primeSpeechOutput() {
+  if (voiceSpeechPrimed || !("speechSynthesis" in window)) return;
+  try {
+    const warm = new SpeechSynthesisUtterance(" ");
+    warm.volume = 0;
+    warm.rate = 1;
+    warm.pitch = 1;
+    warm.lang = "tr-TR";
+    window.speechSynthesis.cancel();
+    window.speechSynthesis.speak(warm);
+    window.speechSynthesis.resume();
+    voiceSpeechPrimed = true;
+  } catch {}
+}
+
+function setVoiceSpeaking(active) {
+  if (!voiceModeCore) return;
+  voiceModeCore.classList.toggle("speaking", !!active);
+}
+function speakVoiceResponse(text, onDone) {
+  if (typeof onDone !== "function") onDone = null;
+  if (!voiceModeActive || !("speechSynthesis" in window)) {
+    if (onDone) onDone();
+    return;
+  }
+  if (voiceOutputMuted) {
+    if (voiceModeStatus) voiceModeStatus.textContent = "Ses kapalı, dinleme açık.";
+    if (onDone) onDone();
+    return;
+  }
+  try {
+    primeSpeechOutput();
+    window.speechSynthesis.resume();
+    const utter = new SpeechSynthesisUtterance(String(text || ""));
+    utter.lang = "tr-TR";
+    utter.rate = 1;
+    utter.pitch = 1;
+    const trVoice = window.speechSynthesis.getVoices().find((v) => /^tr(-|_)/i.test(v.lang || ""));
+    if (trVoice) utter.voice = trVoice;
+    utter.onstart = () => {
+      setVoiceSpeaking(true);
+      if (voiceModeStatus) voiceModeStatus.textContent = "Baluk.ai konuşuyor... 🔊";
+    };
+    utter.onend = () => {
+      setVoiceSpeaking(false);
+      if (voiceModeStatus) voiceModeStatus.textContent = "Dinliyorum... Konuşabilirsin 🎙️";
+      if (onDone) onDone();
+    };
+    utter.onerror = () => {
+      setVoiceSpeaking(false);
+      if (voiceModeStatus) voiceModeStatus.textContent = "Sesli yanıt veremedim ama dinlemeye devam ediyorum.";
+      if (onDone) onDone();
+    };
+    window.speechSynthesis.cancel();
+    window.speechSynthesis.speak(utter);
+  } catch {
+    if (onDone) onDone();
+  }
+}
+
+function buildVoiceWebCompactAnswer(query, items = [], wikiExcerpt = "") {
+  const cleanQuery = String(query || "").trim() || "bu konu";
+  const first = Array.isArray(items) && items[0] ? items[0] : null;
+  const raw = String(wikiExcerpt || first?.description || "").replace(/\s+/g, " ").trim();
+  const shortInfo = raw ? raw.slice(0, 170) + (raw.length > 170 ? "..." : "") : `${cleanQuery} için hızlı web özeti hazır.`;
+  const source = first?.title ? `Kaynak: ${first.title}` : "Kaynak: web özeti";
+  return `${shortInfo} ${source} 🌐`;
+}
+async function processVoiceWebTurn(text) {
+  const q = String(text || "").trim();
+  if (!q) return null;
+  try {
+    const items = await fetchWebResults(q);
+    const firstWiki = items.find((it) => isWikipediaLink(it.link));
+    const wikiExcerpt = (supportsWebTextExtractionModel() && firstWiki)
+      ? await fetchWikipediaLongExcerpt(firstWiki.link)
+      : "";
+    return buildVoiceWebCompactAnswer(q, items, wikiExcerpt);
+  } catch {
+    return "Web aramada kısa bir aksaklık oldu, istersen tekrar deneyelim 🌐";
+  }
+}
+function processVoiceTurn(text) {
+  const clean = String(text || "").trim();
+  if (!clean || voiceTurnInFlight) return;
+  voiceTurnInFlight = true;
+  stopVoiceRecognition();
+  if (voiceModeStatus) voiceModeStatus.textContent = "Anladım, yanıt hazırlıyorum...";
+  startChatIfNeeded();
+  addMessage(clean, "user");
+  const isMathFlow = advancedMathEnabled || Boolean(solveWordProblemValue(clean));
+  const thinkingKind = voiceWebModeEnabled ? "web" : (isMathFlow ? "math" : "default");
+  const thinking = addThinkingBubble(thinkingKind);
+  const delayMs = voiceWebModeEnabled ? 1400 : (isMathFlow ? 1800 : 850);
+  setTimeout(async () => {
+    const rawResponse = voiceWebModeEnabled ? await processVoiceWebTurn(clean) : buildTextResponse(clean);
+    const response = applyProfanityFlavor(expandForPremium(applyPersonalization(rawResponse || "Kısa bir cevap üretemedim, tekrar sorabilir misin?")), clean);
+    lastBotResponse = response;
+    updateGeneralQuestionState(response);
+    const doneStatus = voiceWebModeEnabled
+      ? "Web kısa özeti hazır ✅"
+      : (isMathFlow ? "İşlem analiz edildi • cevap hazır ✅" : "Düşündüm • cevap hazır ✅");
+    fillThinkingBubble(thinking, response, doneStatus);
+    speakVoiceResponse(response, () => {
+      voiceTurnInFlight = false;
+      if (voiceModeActive) startVoiceRecognition();
+    });
+  }, delayMs);
+}
+function stopVoiceRecognition() {
+  if (!voiceRecognition) return;
+  try { voiceRecognition.stop(); } catch {}
+  voiceRecognitionRunning = false;
+}
+function isMobileVoiceDevice() {
+  const ua = (navigator.userAgent || "").toLowerCase();
+  return /android|iphone|ipad|ipod|mobile/.test(ua);
+}
+async function primeVoiceMicrophone() {
+  if (voiceMicPrimed || !navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) return;
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true
+      }
+    });
+    stream.getTracks().forEach((t) => t.stop());
+    voiceMicPrimed = true;
+  } catch {
+    if (voiceModeStatus) voiceModeStatus.textContent = "Mikrofon izni olmadan sesli mod sınırlı çalışabilir.";
+  }
+}
+async function startVoiceRecognition() {
+  const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+  if (!SR) {
+    showWarningOverlay("Bu cihazda sesli tanıma desteklenmiyor.");
+    return;
+  }
+  await primeVoiceMicrophone();
+  if (!voiceRecognition) {
+    voiceRecognition = new SR();
+    voiceRecognition.lang = "tr-TR";
+    voiceRecognition.maxAlternatives = 3;
+    voiceRecognition.continuous = !isMobileVoiceDevice();
+    voiceRecognition.interimResults = true;
+    voiceRecognition.onresult = (event) => {
+      for (let i = event.resultIndex; i < event.results.length; i += 1) {
+        const res = event.results[i];
+        if (!res || !res[0]) continue;
+        if (!res.isFinal) continue;
+        processVoiceTurn(res[0].transcript || "");
+      }
+    };
+    voiceRecognition.onerror = (event) => {
+      const err = event && event.error ? event.error : "unknown";
+      if (voiceModeStatus) voiceModeStatus.textContent = err === "not-allowed"
+        ? "Mikrofon izni verilmedi. Tarayıcıdan mikrofona izin ver."
+        : "Mikrofon hatası: " + err;
+    };
+    voiceRecognition.onend = () => {
+      voiceRecognitionRunning = false;
+      if (voiceModeActive && !voiceTurnInFlight) startVoiceRecognition();
+    };
+  }
+  if (voiceRecognitionRunning) return;
+  try {
+    voiceRecognition.start();
+    voiceRecognitionRunning = true;
+    if (voiceModeStatus) voiceModeStatus.textContent = "Dinliyorum... Konuşabilirsin 🎙️";
+  } catch {}
+}
+async function openVoiceMode() {
+  if (!supportsVoiceModel()) {
+    showWarningOverlay("Sesli mod yalnızca baluk-2.0 modelinde açık.");
+    return;
+  }
+  if (!window.isSecureContext && location.hostname !== "localhost" && location.hostname !== "127.0.0.1") {
+    showWarningOverlay("Telefonda sesli mod için HTTPS gerekli olabilir.");
+  }
+  voiceModeActive = true;
+  voiceOutputMuted = false;
+  if (voiceMuteBtn) voiceMuteBtn.classList.remove("muted");
+  if (voiceModePanel) voiceModePanel.classList.remove("hidden");
+  primeSpeechOutput();
+  if (voiceModeStatus) voiceModeStatus.textContent = "Dinliyorum... Konuşabilirsin 🎙️";
+  if (voiceWebBtn) voiceWebBtn.classList.toggle("active", voiceWebModeEnabled);
+  startVoiceRecognition();
+}
+function closeVoiceMode() {
+  voiceModeActive = false;
+  voiceTurnInFlight = false;
+  stopVoiceRecognition();
+  setVoiceSpeaking(false);
+  if (window.speechSynthesis) window.speechSynthesis.cancel();
+  if (voiceModePanel) voiceModePanel.classList.add("hidden");
+  if (voiceModeStatus) voiceModeStatus.textContent = "Sesli mod kapalı";
+  if (voiceWebBtn) voiceWebBtn.classList.remove("active");
+}
+
+chatForm.addEventListener("submit", (e) => {
+  e.preventDefault();
+  const text = userInput.value.trim();
+  if (!text) {
+    if (supportsVoiceModel()) openVoiceMode();
+    return;
+  }
+  if (isBannedNow()) return;
+  const lower = text.toLowerCase();
+  const toxicity = getToxicityLevel(lower);
+  if (toxicity && isPremiumUser && allowProfanity) {
+    startChatIfNeeded();
+    addMessage(text, "user");
+    addMessage(applyProfanityFlavor(chooseRandom(playfulProfanityReplies), text), "bot");
+    userInput.value = "";
+    return;
+  }
+  if (!isPremiumUser) {
+    if (toxicity === "severe") {
+      startBan("Ağır küfür algılandı. 10 dakikalık ban uygulandı.");
+      return;
+    }
+    if (toxicity === "insult") {
+      insultWarningCount += 1;
+      if (insultWarningCount >= 2) {
+        startBan("2. hakaret/argo uyarısı sonrası 10 dakikalık ban uygulandı.");
+        return;
+      }
+      showWarningOverlay(`⚠️ Hakaret/argo uyarısı: ${insultWarningCount}/2. İkinci uyarıda 10 dakikalık ban uygulanır.`);
+    }
+  }
+  if (webModeEnabled) {
+    processWebSearchInput(text);
+    userInput.value = "";
+    return;
+  }
+  if (lensModeEnabled) {
+    addMessage("Baluk.lens açık. Önce panelden fotoğraf yükleyip Analizi Başlat butonuna bas.", "bot");
+    userInput.value = "";
+    return;
+  }
+  processInput(text);
+  userInput.value = "";
+});
+clearChat.addEventListener("click", () => {
+  hasStartedChat = false;
+  Object.keys(convoState).forEach((k) => { convoState[k] = false; });
+  chat.innerHTML = "";
+  chat.classList.add("hidden");
+  splash.classList.remove("hidden");
+  updateSplashPrompt();
+  setWebMode(false);
+});
+memoryToggle.addEventListener("click", () => {
+  memoryPanel.classList.toggle("hidden");
+  renderMemoryList();
+});
+clearMemory.addEventListener("click", () => {
+  if (!supportsMemoryModel()) return;
+  Object.keys(userMemory).forEach((k) => delete userMemory[k]);
+  saveMemory();
+  renderMemoryList();
+});
+modelToggle.addEventListener("click", () => { if (advancedMathEnabled) return; modelMenu.classList.toggle("hidden"); });
+document.addEventListener("click", (e) => {
+  if (!modelMenu.contains(e.target) && !modelToggle.contains(e.target)) modelMenu.classList.add("hidden");
+});
+modelOptions.forEach((opt) => {
+  opt.addEventListener("click", () => {
+    if (advancedMathEnabled) return;
+    modelOptions.forEach((i) => i.classList.remove("active"));
+    opt.classList.add("active");
+    currentModel = opt.dataset.model;
+    if (isAccountLoggedIn) localStorage.setItem(MODEL_STORAGE_KEY, currentModel);
+    updateModelVisual();
+    updateMemoryAvailability();
+    if (!supportsWebModel()) setWebMode(false);
+    if (!supportsLensModel()) setLensMode(false);
+    if (!supportsBallEModel()) setBalleMode(false);
+    modelMenu.classList.add("hidden");
+    updateComposerActionVisual();
+    closeVoiceMode();
+  });
+});
+modelOptions.forEach((opt) => opt.classList.toggle("active", opt.dataset.model === currentModel));
+updateModelVisual();
+updateMemoryAvailability();
+updateComposerActionVisual();
+initGeometryLab();
+updateSplashPrompt();
+restoreBanState();
+restoreAccountProfile();
+restoreBackgroundSettings();
+updateAuthDependentUI();
+if (balukLensMode) balukLensMode.checked = false;
+if (balleMode) balleMode.checked = false;
+setLensMode(false);
+setBalleMode(false);
+if (plusToggle && plusMenu) {
+  plusToggle.addEventListener("click", () => plusMenu.classList.toggle("hidden"));
+  document.addEventListener("click", (e) => {
+    if (!plusMenu.contains(e.target) && !plusToggle.contains(e.target)) plusMenu.classList.add("hidden");
+  });
+}
+if (advancedMathMode) {
+  advancedMathMode.addEventListener("change", () => {
+    setAdvancedMathMode(advancedMathMode.checked);
+    updateModelVisual();
+  });
+}
+if (webSearchMode) {
+  webSearchMode.addEventListener("change", () => setWebMode(webSearchMode.checked));
+}
+if (balukLensMode) {
+  balukLensMode.addEventListener("change", () => setLensMode(balukLensMode.checked));
+}
+if (balleMode) {
+  balleMode.addEventListener("change", () => setBalleMode(balleMode.checked));
+}
+if (balleGenerateBtn) {
+  balleGenerateBtn.addEventListener("click", () => runBallEGeneration());
+}
+if (userInput) userInput.addEventListener("input", updateComposerActionVisual);
+if (voiceCloseBtn) voiceCloseBtn.addEventListener("click", closeVoiceMode);
+if (voiceWebBtn) voiceWebBtn.addEventListener("click", () => {
+  voiceWebModeEnabled = !voiceWebModeEnabled;
+  voiceWebBtn.classList.toggle("active", voiceWebModeEnabled);
+  if (voiceModeStatus) voiceModeStatus.textContent = voiceWebModeEnabled
+    ? "Sesli Web modu açık: kısa web cevapları vereceğim 🌐"
+    : "Sesli Web modu kapalı: normal sesli cevap modundayım 🎙️";
+});
+if (voiceMuteBtn) voiceMuteBtn.addEventListener("click", () => {
+  voiceOutputMuted = !voiceOutputMuted;
+  voiceMuteBtn.classList.toggle("muted", voiceOutputMuted);
+  if (voiceModeStatus) voiceModeStatus.textContent = voiceOutputMuted ? "Ses kapalı, dinleme açık." : "Ses açık, dinleme açık.";
+  if (voiceOutputMuted && window.speechSynthesis) window.speechSynthesis.cancel();
+});
+if (mathStudioToggle && mathStudioPanel) {
+  mathStudioToggle.addEventListener("click", () => mathStudioPanel.classList.toggle("hidden"));
+}
+if (mathStudioInput) {
+  mathStudioInput.addEventListener("keydown", (e) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    renderMathStudio();
+  });
+}
+if (mathTutorNext) {
+  mathTutorNext.addEventListener("click", () => {
+    tutorStep = Math.min(tutorStep + 1, tutorSteps.length - 1);
+    renderTutorStep();
+  });
+}
+if (mathTutorDone) {
+  mathTutorDone.addEventListener("click", () => {
+    if (mathTutorOverlay) mathTutorOverlay.classList.add("hidden");
+    clearTutorSpotlight();
+    if (plusMenu) plusMenu.classList.add("hidden");
+    if (isAccountLoggedIn) {
+      localStorage.setItem("balukMathTutorDone", "1");
+      localStorage.setItem("balukMasterTutor17Done", "1");
+    }
+    showTutorFinale();
+  });
+}
+if (safetySurveyOptions) {
+  safetySurveyOptions.addEventListener("click", (e) => {
+    const btn = e.target.closest("button[data-reason]");
+    if (!btn) return;
+    const reason = btn.dataset.reason;
+    const category = (safetySurveyModal && safetySurveyModal.dataset.category) || "generic";
+    closeSafetySurvey();
+    addMessage(surveyReplyByReason(reason, category), "bot");
+  });
+}
+if (closeSafetySurveyModal) {
+  closeSafetySurveyModal.addEventListener("click", closeSafetySurvey);
+}
+if (accountToggle) {
+  accountToggle.addEventListener("click", () => {
+    if (!isAccountLoggedIn) {
+      if (accountPanel) accountPanel.classList.toggle("hidden");
+      if (sideDrawer) sideDrawer.classList.add("hidden");
+      return;
+    }
+    if (sideDrawer) sideDrawer.classList.toggle("hidden");
+    if (accountPanel) accountPanel.classList.add("hidden");
+  });
+}
+if (drawerClose && sideDrawer) {
+  drawerClose.addEventListener("click", () => sideDrawer.classList.add("hidden"));
+}
+if (drawerAccountOpen && accountPanel) {
+  drawerAccountOpen.addEventListener("click", () => {
+    accountPanel.classList.toggle("hidden");
+    if (sideDrawer) sideDrawer.classList.add("hidden");
+    if (memoryPanel) memoryPanel.classList.add("hidden");
+    if (mathStudioPanel) mathStudioPanel.classList.add("hidden");
+  });
+}
+
+if (drawerPremiumOpen && premiumModal) {
+  drawerPremiumOpen.addEventListener("click", () => {
+    if (!isPremiumUser) premiumModal.classList.remove("hidden");
+  });
+}
+if (drawerBackgroundOpen && backgroundModal) {
+  drawerBackgroundOpen.addEventListener("click", () => {
+    backgroundModal.classList.remove("hidden");
+    if (sideDrawer) sideDrawer.classList.add("hidden");
+  });
+}
+if (backgroundClose && backgroundModal) {
+  backgroundClose.addEventListener("click", () => backgroundModal.classList.add("hidden"));
+}
+if (backgroundModal) {
+  const back = backgroundModal.querySelector('.background-backdrop');
+  if (back) back.addEventListener('click', () => backgroundModal.classList.add('hidden'));
+}
+if (backgroundThemeSelect) {
+  backgroundThemeSelect.addEventListener('change', () => applyBackgroundTheme(backgroundThemeSelect.value));
+}
+if (backgroundMusicSelect) {
+  backgroundMusicSelect.addEventListener('change', () => setBackgroundMusic(backgroundMusicSelect.value));
+}
+if (backgroundMusicVolume) {
+  backgroundMusicVolume.addEventListener('input', () => setBackgroundVolume(backgroundMusicVolume.value));
+}
+if (lensClose) lensClose.addEventListener("click", () => {
+  if (balukLensMode) balukLensMode.checked = false;
+  setLensMode(false);
+});
+if (lensPickBtn && lensFileInput) {
+  lensPickBtn.addEventListener("click", () => lensFileInput.click());
+}
+if (lensFileInput) {
+  lensFileInput.addEventListener("change", () => {
+    const file = lensFileInput.files?.[0];
+    if (file) loadLensFile(file);
+  });
+}
+if (lensDropZone) {
+  ["dragenter", "dragover"].forEach((evt) => lensDropZone.addEventListener(evt, (e) => {
+    e.preventDefault();
+    lensDropZone.classList.add("dragging");
+  }));
+  ["dragleave", "drop"].forEach((evt) => lensDropZone.addEventListener(evt, (e) => {
+    e.preventDefault();
+    lensDropZone.classList.remove("dragging");
+  }));
+  lensDropZone.addEventListener("drop", (e) => {
+    const file = e.dataTransfer?.files?.[0];
+    if (file) loadLensFile(file);
+  });
+}
+if (lensCanvas) {
+  lensCanvas.addEventListener("pointerdown", (e) => {
+    if (!lensImageDataUrl) return;
+    const r = lensCanvas.getBoundingClientRect();
+    lensDragStart = { x: e.clientX - r.left, y: e.clientY - r.top };
+    lensSelection = null;
+  });
+  lensCanvas.addEventListener("pointermove", (e) => {
+    if (!lensDragStart) return;
+    const r = lensCanvas.getBoundingClientRect();
+    const end = { x: Math.max(0, Math.min(lensCanvas.width, e.clientX - r.left)), y: Math.max(0, Math.min(lensCanvas.height, e.clientY - r.top)) };
+    lensSelection = normalizeRect(lensDragStart, end);
+    drawLensCanvas();
+  });
+  lensCanvas.addEventListener("pointerup", (e) => {
+    const r = lensCanvas.getBoundingClientRect();
+    const end = { x: Math.max(0, Math.min(lensCanvas.width, e.clientX - r.left)), y: Math.max(0, Math.min(lensCanvas.height, e.clientY - r.top)) };
+    if (lensDragStart) {
+      const rect = normalizeRect(lensDragStart, end);
+      if (rect.w < 14 || rect.h < 14) {
+        if (isMobileLensViewport()) {
+          const w = Math.max(80, Math.round(lensCanvas.width * 0.46));
+          const h = Math.max(80, Math.round(lensCanvas.height * 0.36));
+          lensSelection = {
+            x: Math.max(0, Math.min(lensCanvas.width - w, end.x - w / 2)),
+            y: Math.max(0, Math.min(lensCanvas.height - h, end.y - h / 2)),
+            w,
+            h
+          };
+          drawLensCanvas();
+        } else {
+          lensSelection = null;
+        }
+      } else {
+        lensSelection = rect;
+      }
+    }
+    lensDragStart = null;
+    if (lensStatus && lensSelection && lensSelection.w > 10 && lensSelection.h > 10) {
+      lensStatus.textContent = "baluk.ai • bölge işaretlendi, analizi başlatabilirsin.";
+    } else if (lensStatus && isMobileLensViewport()) {
+      lensStatus.textContent = "baluk.ai • seçili bölge yok, analizde tüm görsel kullanılacak.";
     }
   });
 }
+if (lensAnalyzeBtn) {
+  lensAnalyzeBtn.addEventListener("click", runLensAnalysis);
+}
+[accountName, accountGmail, accountPhoto].forEach((field) => {
+  if (field) field.addEventListener("input", () => {
+    updateAccountPreview();
+  });
+});
+if (saveAccount) {
+  saveAccount.addEventListener("click", saveAccountProfile);
+}
+if (premiumClose && premiumModal) {
+  premiumClose.addEventListener("click", () => premiumModal.classList.add("hidden"));
+}
+if (premiumBuyBtn) premiumBuyBtn.addEventListener("click", startPremiumPayment);
+if (premiumPayLinkBtn) premiumPayLinkBtn.addEventListener("click", openPremiumPaymentLink);
+if (premiumConfirmBtn) premiumConfirmBtn.addEventListener("click", manuallyConfirmPremium);
+if (allowProfanityMode) {
+  allowProfanityMode.addEventListener("change", () => {
+    if (allowProfanityMode.checked && !isPremiumUser) {
+      allowProfanityMode.checked = false;
+      showWarningOverlay("Küfüre izin ver modu yalnızca Premium için açık.");
+      return;
+    }
+    allowProfanity = allowProfanityMode.checked;
+    if (isAccountLoggedIn) localStorage.setItem(ALLOW_PROFANITY_STORAGE_KEY, allowProfanity ? "1" : "0");
+  });
+}
+window.addEventListener("focus", tryActivatePremiumFromReturn);
+updatePremiumUI();
+tryActivatePremiumFromReturn();
+if (banUnlockBtn) {
+  banUnlockBtn.addEventListener("click", () => {
+    if (banPassword && banPassword.value.trim() === "baluk2026") {
+      stopBan();
+      banPassword.value = "";
+    }
+  });
+}
+if (enterAppBtn && introGate && appRoot) {
+  const tryStartAmbient = () => startIntroAmbientHum();
+  ["pointermove", "keydown", "touchstart", "mousedown"].forEach((evt) => {
+    window.addEventListener(evt, tryStartAmbient, { once: true, passive: true });
+  });
+  startIntroAmbientHum();
+  enterAppBtn.addEventListener("click", openAppWithTransition);
+}
+function fillThinkingBubbleHtml(node, html, doneStatus = "") {
+  if (!node) return;
+  const fish = node.querySelector(".think-fish");
+  if (fish) fish.classList.remove("spin-fast");
+  if (doneStatus) updateThinkingStatus(node, doneStatus);
+  let content = node.querySelector(".thinking-answer");
+  if (!content) {
+    content = document.createElement("div");
+    content.className = "thinking-answer";
+    node.appendChild(content);
+  }
+  content.innerHTML = html;
+}
+function createBallEFallbackDataUrl() {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="760" viewBox="0 0 1200 760">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#22c55e"/><stop offset="25%" stop-color="#facc15"/><stop offset="55%" stop-color="#ef4444"/><stop offset="82%" stop-color="#a855f7"/><stop offset="100%" stop-color="#22c55e"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="760" fill="url(#g)"/>
+  <g fill="none" stroke="rgba(255,255,255,.7)">
+    <circle cx="160" cy="120" r="90"/><circle cx="420" cy="210" r="120"/><circle cx="760" cy="150" r="84"/><circle cx="980" cy="300" r="130"/>
+    <circle cx="300" cy="490" r="155"/><circle cx="650" cy="540" r="125"/><circle cx="1040" cy="580" r="110"/>
+  </g>
+  <text x="48" y="700" font-family="Arial, Helvetica, sans-serif" font-size="52" font-weight="700" fill="rgba(255,255,255,.88)">BALL.E • baluk.ai</text>
+</svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+function preloadImage(url, timeoutMs = 7000) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    let done = false;
+    const finish = (ok) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      if (ok) resolve(url);
+      else reject(new Error('load-failed'));
+    };
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    img.onload = () => finish(true);
+    img.onerror = () => finish(false);
+    img.referrerPolicy = 'no-referrer';
+    img.src = url;
+  });
+}
+async function pickWorkingBallEAsset() {
+  const shuffled = [...balleAssets].sort(() => Math.random() - 0.5).slice(0, 6);
+  const attempts = shuffled.map((link) => preloadImage(link, 3500));
+  try {
+    return await Promise.any(attempts);
+  } catch {
+    return createBallEFallbackDataUrl();
+  }
+}
+async function runBallEGeneration() {
+  return;
+}
+
+

--- a/style.css
+++ b/style.css
@@ -1,108 +1,2636 @@
-body {
+:root {
+  --bg: #ffffff;
+  --text: #11141d;
+  --line: #dfe3ea;
+  --line-strong: #0f1115;
+  --user: #141923;
+  --bot: #f3f5f9;
+}
+* { box-sizing: border-box; }
+html, body {
   margin: 0;
-  font-family: Arial, sans-serif;
-  background-color: #0d0d0d;
-  color: white;
+  width: 100%;
+  height: 100%;
+  font-family: "Inter", "Segoe UI", Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
 }
+.logo-defs { position: absolute; }
 
-.gizli {
-  display: none;
+.intro-gate {
+  min-height: 100vh;
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 50% 40%, rgba(74, 35, 183, 0.35), transparent 55%),
+    radial-gradient(circle at 50% 75%, rgba(122, 76, 246, 0.45), transparent 45%),
+    #07071a;
+  display: grid;
+  place-items: center;
+  color: #f8f7ff;
 }
+.intro-bg-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(32px);
+  opacity: .6;
+  animation: floatOrb 7s ease-in-out infinite alternate;
+}
+.orb-a { width: 280px; height: 280px; background: rgba(104, 63, 243, 0.6); top: 7%; left: 10%; }
+.orb-b { width: 360px; height: 360px; background: rgba(71, 123, 255, 0.45); right: 8%; top: 14%; animation-delay: .8s; }
+.orb-c { width: 300px; height: 300px; background: rgba(180, 103, 255, 0.45); left: 35%; bottom: -50px; animation-delay: 1.6s; }
+@keyframes floatOrb { from { transform: translateY(0) scale(1); } to { transform: translateY(-16px) scale(1.06); } }
 
-#girisEkrani {
+.intro-card {
+  position: relative;
+  z-index: 2;
+  width: min(760px, 92vw);
   text-align: center;
-  padding: 40px;
+  padding: 40px 24px 34px;
+  border-radius: 26px;
+  border: 1px solid rgba(199, 180, 255, 0.35);
+  background: linear-gradient(180deg, rgba(20, 19, 56, 0.78), rgba(10, 10, 34, 0.86));
+  box-shadow: 0 30px 80px rgba(58, 39, 139, 0.45);
+}
+.intro-fish { width: min(300px, 62vw); height: auto; color: #f7f5ff; margin: 0 auto 8px; }
+.intro-card h1 { margin: 0; font-size: clamp(2.7rem, 8vw, 5rem); letter-spacing: -0.04em; font-weight: 700; }
+.intro-kicker { margin: 8px 0 8px; font-weight: 700; color: #d9ccff; }
+.intro-copy { margin: 0 auto 20px; max-width: 620px; line-height: 1.55; color: #efeaff; }
+.intro-lightbar {
+  margin: 0 auto 22px;
+  width: min(620px, 84%);
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(92, 74, 255, 0), #9f8cff, #5f9dff, rgba(92, 74, 255, 0));
+  box-shadow: 0 0 26px rgba(140, 111, 255, 0.95), 0 0 44px rgba(95, 157, 255, 0.55);
+  animation: pulseBeam 1.8s ease-in-out infinite alternate;
+}
+@keyframes pulseBeam { from { transform: scaleX(.94); opacity: .82; } to { transform: scaleX(1); opacity: 1; } }
+
+.enter-app-btn {
+  border: none;
+  border-radius: 14px;
+  padding: 12px 20px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(90deg, #6f3aff, #5f83ff);
+  box-shadow: 0 14px 32px rgba(102, 74, 252, 0.45);
+  cursor: pointer;
+}
+.enter-app-btn:hover { filter: brightness(1.06); }
+
+.app { height: 100vh; display: flex; flex-direction: column; }
+.topbar {
+  height: 72px;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--line);
+}
+.left-tools { position: relative; width: fit-content; }
+.model-chip-wrap { display: flex; align-items: center; gap: 8px; }
+.model-badge {
+  font-size: .88rem;
+  font-weight: 700;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  padding: 4px 10px;
+  background: #fff;
+}
+.icon-btn { border: none; background: transparent; padding: 0; cursor: pointer; }
+.fish-logo { display: block; color: #0e1117; shape-rendering: geometricPrecision; }
+.fish-logo.small { width: 64px; height: auto; }
+.brand { justify-self: center; font-size: 1.95rem; font-weight: 650; letter-spacing: -0.03em; }
+.right-tools {
+  justify-self: end;
+  display: flex;
+  gap: 8px;
+  min-width: 0;
+  flex-wrap: nowrap;
+}
+.right-tools > * { flex-shrink: 1; }
+.memory-btn,
+.clear-btn {
+  border: 1.7px solid var(--line-strong);
+  border-radius: 12px;
+  background: #fff;
+  padding: 9px 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.model-menu {
+  position: absolute;
+  top: 56px;
+  left: 0;
+  min-width: 170px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 10px 28px rgba(16,22,34,.14);
+  padding: 6px;
+  z-index: 20;
+}
+.model-option {
+  width: 100%;
+  border: 1px solid transparent;
+  background: #f4f7fb;
+  border-radius: 8px;
+  padding: 10px;
+  text-align: left;
+  font-size: .95rem;
+  cursor: pointer;
+}
+.model-option.active { border-color: #11151d; }
+
+
+.memory-toast {
+  position: fixed;
+  top: 84px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 120;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  color: #f5f3ff;
+  background: linear-gradient(90deg, #6d28d9, #7c3aed, #a855f7);
+  box-shadow:
+    0 0 0 1px rgba(196, 181, 253, 0.7),
+    0 0 26px rgba(168, 85, 247, 0.75),
+    0 0 46px rgba(124, 58, 237, 0.45);
+  font-size: .88rem;
+  font-weight: 700;
+  letter-spacing: .01em;
+  animation: memoryGlow 1.2s ease-in-out infinite alternate;
+}
+.pulse-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #f5d0fe;
+  box-shadow: 0 0 12px rgba(245, 208, 254, 0.95);
+}
+@keyframes memoryGlow {
+  from { box-shadow: 0 0 0 1px rgba(196, 181, 253, 0.65), 0 0 20px rgba(168, 85, 247, 0.65), 0 0 36px rgba(124, 58, 237, 0.4); }
+  to { box-shadow: 0 0 0 1px rgba(216, 180, 254, 0.85), 0 0 30px rgba(192, 132, 252, 0.9), 0 0 56px rgba(147, 51, 234, 0.55); }
 }
 
-#girisEkrani input, #girisEkrani button {
+.memory-panel {
+  position: fixed;
+  top: 82px;
+  right: 16px;
+  width: min(340px, 92vw);
+  max-height: 62vh;
+  overflow: auto;
+  z-index: 50;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.18);
+  padding: 12px;
+}
+.memory-panel h3 { margin: 2px 0 8px; }
+.memory-hint { margin: 0 0 10px; color: #475569; font-size: .9rem; }
+#memoryList { margin: 0 0 10px; padding-left: 18px; }
+#memoryList li { margin-bottom: 6px; }
+#clearMemory {
+  border: 1.5px solid var(--line-strong);
+  border-radius: 10px;
+  background: #fff;
+  padding: 8px 10px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.chat-area { flex: 1; overflow-y: auto; padding: 16px 18px; }
+.splash {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding-bottom: 8vh;
+  transform: translateY(-22px);
+}
+.fish-logo.big { width: min(520px, 76vw); height: auto; }
+.splash h1 { margin: 6px 0 0; font-size: clamp(2.5rem, 7vw, 5.2rem); font-weight: 650; letter-spacing: -0.04em; }
+.splash-prompt {
+  margin: 12px 0 0;
+  font-size: clamp(1rem, 2.2vw, 1.35rem);
+  font-weight: 800;
+  color: #c026d3;
+  text-shadow: 0 0 10px rgba(217, 70, 239, .65), 0 0 20px rgba(168, 85, 247, .45);
+  animation: neonPromptFlow 2.2s linear infinite;
+  background: linear-gradient(90deg, #d946ef, #a855f7, #c026d3, #d946ef);
+  background-size: 220% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+@keyframes neonPromptFlow {
+  from { background-position: 0% 50%; filter: drop-shadow(0 0 5px rgba(192,38,211,.55)); }
+  to { background-position: 220% 50%; filter: drop-shadow(0 0 10px rgba(217,70,239,.75)); }
+}
+.chat-log { display: flex; flex-direction: column; gap: 10px; max-width: 980px; margin: 0 auto; width: 100%; }
+.msg {
+  padding: 10px 14px;
+  border-radius: 12px;
+  max-width: min(72%, 820px);
+  white-space: pre-wrap;
+  line-height: 1.45;
+}
+.msg.user { margin-left: auto; background: var(--user); color: #fff; }
+.msg.bot { margin-right: auto; background: var(--bot); }
+
+.input-shell {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 12px 16px;
+  border-top: 1px solid var(--line);
+}
+#userInput {
+  width: 100%;
+  border: 1.8px solid var(--line-strong);
+  border-radius: 16px;
+  padding: 13px 14px;
+  font-size: 1rem;
+}
+#userInput:focus { outline: none; box-shadow: 0 0 0 3px rgba(17,21,29,.08); }
+.input-shell button[type="submit"] {
+  width: 48px;
+  height: 48px;
+  border: 1.8px solid var(--line-strong);
+  border-radius: 50%;
+  background: #fff;
+  color: #131821;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+}
+.input-shell button svg { width: 21px; height: 21px; }
+
+.plus-area { position: relative; }
+.plus-btn {
+  width: 42px; height: 42px; border-radius: 10px; border: 1.8px solid #6d28d9;
+  background: #f4efff; font-size: 1.45rem; font-weight: 700; cursor: pointer; color: #5b21b6;
+}
+.plus-menu {
+  position: absolute; bottom: 52px; left: 0; background: #fff; border: 1px solid var(--line);
+  border-radius: 10px; padding: 10px; min-width: 220px; box-shadow: 0 10px 25px rgba(16,22,34,.14);
+  z-index: 35;
+}
+.image-mode-label { font-size: .92rem; font-weight: 600; display: flex; gap: 8px; align-items: center; }
+
+.model-option-2 {
+  border-color: #d946ef;
+  color: #7e22ce;
+  background: radial-gradient(circle at 12% 18%, rgba(34,197,94,.28) 0 16%, transparent 17%),
+              radial-gradient(circle at 78% 26%, rgba(250,204,21,.3) 0 14%, transparent 15%),
+              radial-gradient(circle at 24% 78%, rgba(239,68,68,.24) 0 16%, transparent 17%),
+              radial-gradient(circle at 86% 80%, rgba(168,85,247,.3) 0 16%, transparent 17%),
+              linear-gradient(120deg, rgba(250,245,255,.95), rgba(254,242,242,.95));
+  background-size: 150% 150%;
+  animation: balleOptionFlow 3.6s linear infinite;
+}
+@keyframes balleOptionFlow { from { background-position: 0% 0%; } to { background-position: 120% 120%; } }
+
+
+.balle-mode-label {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid #f0abfc;
+  border-radius: 12px;
+  padding: 8px 10px;
+  background: linear-gradient(125deg, rgba(250,245,255,.98), rgba(243,232,255,.92), rgba(254,242,242,.95));
+  box-shadow: 0 10px 25px rgba(168,85,247,.18);
+}
+.balle-mode-label::after {
+  content: "";
+  position: absolute;
+  inset: -40% -20%;
+  background: radial-gradient(circle at 20% 30%, rgba(34,197,94,.30) 0 8%, transparent 9%),
+              radial-gradient(circle at 75% 30%, rgba(250,204,21,.34) 0 7%, transparent 8%),
+              radial-gradient(circle at 32% 72%, rgba(239,68,68,.28) 0 7%, transparent 8%),
+              radial-gradient(circle at 84% 72%, rgba(168,85,247,.34) 0 8%, transparent 9%);
+  animation: balleBubbleDrift 7s linear infinite;
+  pointer-events: none;
+}
+
+
+.balle-generate-btn {
+  border: none;
+  min-width: 232px;
+  height: 48px;
+  border-radius: 14px;
+  font-weight: 900;
+  color: #fff;
+  letter-spacing: .01em;
+  cursor: pointer;
+  background: linear-gradient(120deg, #22c55e, #facc15, #a855f7, #ef4444, #22c55e);
+  background-size: 300% 100%;
+  animation: balleBtnGlow 2.8s linear infinite;
+  box-shadow: 0 10px 30px rgba(168,85,247,.28), 0 0 0 1px rgba(255,255,255,.35) inset;
+}
+.balle-generate-btn:disabled { opacity: .65; cursor: not-allowed; }
+
+@keyframes balleBtnGlow {
+  0% { background-position: 0% 50%; filter: saturate(1); }
+  50% { filter: saturate(1.2); }
+  100% { background-position: 220% 50%; filter: saturate(1); }
+}
+
+.balle-result-wrap {
+  margin-top: 10px;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid #c4b5fd;
+  position: relative;
+  background: #f8fafc;
+}
+.balle-result-wrap img {
+  width: 100%;
   display: block;
-  margin: 10px auto;
-  padding: 10px;
-  width: 80%;
+  max-height: min(56vh, 440px);
+  object-fit: cover;
+}
+.balle-banner {
+  position: absolute;
+  left: 14px;
+  bottom: 14px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 900;
+  font-size: .92rem;
+  color: #fff;
+  background: rgba(15, 23, 42, .45);
+  border: 1px solid rgba(255,255,255,.35);
+  backdrop-filter: blur(3px);
 }
 
-header {
-  background-color: #1a1a1a;
+@media (max-width: 700px) {
+  .balle-generate-btn { min-width: 0; width: 100%; }
+}
+
+
+
+@keyframes balleBubbleDrift { from { transform: translateX(-4%); } to { transform: translateX(6%); } }
+
+.balle-model-badge {
+  color: #4c1d95 !important;
+  border-color: #d946ef !important;
+  background: linear-gradient(120deg, rgba(34,197,94,.16), rgba(250,204,21,.16), rgba(239,68,68,.14), rgba(168,85,247,.2));
+  background-size: 240% 100%;
+  animation: balleBadgeGlow 2.5s linear infinite;
+  box-shadow: 0 0 0 1px rgba(255,255,255,.55) inset, 0 0 16px rgba(217,70,239,.28);
+}
+@keyframes balleBadgeGlow { from { background-position: 0% 50%; } to { background-position: 220% 50%; } }
+
+.app.balle-bg-active::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 8% 20%, rgba(34,197,94,.18) 0 7%, transparent 8%),
+              radial-gradient(circle at 26% 58%, rgba(250,204,21,.2) 0 6%, transparent 7%),
+              radial-gradient(circle at 52% 22%, rgba(239,68,68,.18) 0 7%, transparent 8%),
+              radial-gradient(circle at 77% 62%, rgba(168,85,247,.22) 0 7%, transparent 8%),
+              radial-gradient(circle at 88% 18%, rgba(250,204,21,.14) 0 5%, transparent 6%);
+  animation: balleBackdropFloat 8s ease-in-out infinite alternate;
+  z-index: 0;
+}
+.app.balle-bg-active #chatArea,
+.app.balle-bg-active .input-shell,
+.app.balle-bg-active .topbar { position: relative; z-index: 1; }
+@keyframes balleBackdropFloat { from { transform: translateY(0); } to { transform: translateY(-10px); } }
+
+.balle-stage-wrap { margin-top: 10px; }
+.balle-stage-title { font-weight: 800; color: #6d28d9; margin-bottom: 8px; }
+.balle-stage-canvas {
+  height: min(44vh, 320px);
+  border-radius: 14px;
+  border: 1px solid #d1d5db;
+  background: #e5e7eb;
+  position: relative;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.5), 0 12px 28px rgba(15,23,42,.14);
+}
+.balle-stage-canvas::before {
+  content: "";
+  position: absolute;
+  inset: -20%;
+  background: conic-gradient(from 0deg, rgba(34,197,94,.16), rgba(250,204,21,.16), rgba(239,68,68,.16), rgba(168,85,247,.2), rgba(34,197,94,.16));
+  animation: balleSweep 4.6s linear infinite;
+}
+@keyframes balleSweep { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+.balle-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(1px);
+  animation: orbFloat 4.8s ease-in-out infinite;
+  box-shadow: 0 0 24px currentColor;
+}
+.balle-orb.orb-green { width: 110px; height: 110px; left: 8%; top: 18%; color: rgba(34,197,94,.65); background: rgba(34,197,94,.38); }
+.balle-orb.orb-yellow { width: 90px; height: 90px; right: 14%; top: 16%; color: rgba(250,204,21,.7); background: rgba(250,204,21,.4); animation-delay: .5s; }
+.balle-orb.orb-red { width: 120px; height: 120px; left: 22%; bottom: 10%; color: rgba(239,68,68,.64); background: rgba(239,68,68,.36); animation-delay: 1.1s; }
+.balle-orb.orb-purple { width: 100px; height: 100px; right: 26%; bottom: 8%; color: rgba(168,85,247,.72); background: rgba(168,85,247,.42); animation-delay: 1.6s; }
+@keyframes orbFloat {
+  0%,100% { transform: translateY(0px) scale(1); }
+  50% { transform: translateY(-14px) scale(1.08); }
+}
+.balle-core-fish {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 140px;
+  transform: translate(-50%, -50%);
+  filter: drop-shadow(0 0 14px rgba(255,255,255,.75));
+}
+
+.math-studio-panel {
+  position: fixed; top: 82px; right: 16px; width: min(480px, 94vw); max-height: 72vh; overflow: auto;
+  z-index: 55; background: #f8fbff; border: 1px solid #93c5fd; border-radius: 14px;
+  box-shadow: 0 16px 36px rgba(30, 64, 175, .16); padding: 12px;
+}
+.math-studio-panel h3 { margin: 0 0 8px; color: #1e40af; }
+.math-studio-panel p { margin: 0 0 10px; font-size: .9rem; color: #334155; }
+.math-studio-input {
+  min-height: 110px; border: 1.5px solid #93c5fd; border-radius: 10px; padding: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: #fff;
+  white-space: pre-wrap;
+}
+.math-studio-output { margin-top: 10px; display: grid; gap: 8px; }
+.math-result {
+  background: #eff6ff; border: 1px solid #93c5fd; color: #1d4ed8; border-radius: 10px; padding: 8px 10px;
+  font-weight: 700; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+
+.account-icon-btn {
+  width: 40px;
+  min-width: 40px;
+  flex: 0 0 40px;
+  height: 40px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+}
+
+.account-panel {
+  position: fixed;
+  top: 82px;
+  right: 16px;
+  width: min(360px, 94vw);
+  max-height: 74vh;
+  overflow: auto;
+  z-index: 56;
+  background: #f8fbff;
+  border: 1px solid #bfdbfe;
+  border-radius: 14px;
+  box-shadow: 0 14px 30px rgba(30, 64, 175, .15);
+  padding: 12px;
+}
+.account-panel h3 { margin: 0 0 10px; color: #1e3a8a; }
+.account-row { display: grid; gap: 6px; margin-bottom: 10px; }
+.account-row label { font-size: .86rem; color: #334155; font-weight: 700; }
+.account-row input {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: .92rem;
+}
+.account-preview {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid #dbeafe;
+  background: #fff;
+  border-radius: 12px;
   padding: 10px;
+  margin-bottom: 10px;
+}
+.account-preview img {
+  width: 46px;
+  height: 46px;
+  border-radius: 999px;
+  border: 1px solid #cbd5e1;
+  object-fit: cover;
+  background: #eef2ff;
+}
+#saveAccount {
+  width: 100%;
+  border: 1px solid #93c5fd;
+  background: #dbeafe;
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.account-settings { margin-top: 10px; }
+.account-settings summary { cursor: pointer; font-weight: 700; color: #1e40af; }
+.account-settings p { font-size: .86rem; color: #334155; }
+
+.profanity-lock {
+  position: fixed; inset: 0; z-index: 400; display: grid; place-content: center; text-align: center;
+  gap: 10px; background: rgba(20, 0, 0, .7); backdrop-filter: blur(3px); color: #fff;
+}
+.profanity-lock h3 { margin: 0; color: #fecaca; font-size: 1.4rem; }
+.profanity-lock input {
+  width: min(260px, 80vw); margin: 0 auto; padding: 10px 12px; border-radius: 10px; border: 1px solid #ef4444;
+}
+.profanity-lock button {
+  border: none; border-radius: 10px; padding: 10px 14px; background: #ef4444; color: #fff; font-weight: 700; cursor: pointer;
+}
+
+.app.math-mode .fish-logo,
+.app.math-mode .brand { color: #1d4ed8; }
+.app.math-mode .model-badge { border-color: #1d4ed8; color: #1d4ed8; }
+.app.math-mode .memory-btn,
+.app.math-mode .clear-btn,
+.app.math-mode .plus-btn { border-color: #2563eb; color: #1d4ed8; background: #eff6ff; }
+
+.hidden { display: none; }
+
+.thinking-bubble {
+  background: #eef2ff;
+  border: 1px solid #c7d2fe;
+}
+.thinking-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: #1e293b;
+}
+.think-fish { width: 40px; height: auto; }
+.spin-fast { animation: spinFishFast 1s linear infinite; }
+@keyframes spinFishFast { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+.thinking-answer { margin-top: 8px; white-space: pre-wrap; }
+
+@media (max-width: 700px) {
+  .topbar {
+    grid-template-columns: auto 1fr auto;
+    gap: 8px;
+    padding: 8px 10px;
+  }
+  .brand { font-size: 1.2rem; justify-self: center; }
+  .right-tools { gap: 4px; }
+  .memory-btn, .clear-btn { padding: 6px 7px; font-size: .72rem; }
+  #clearChat { max-width: 72px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  #memoryToggle { max-width: 62px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .account-icon-btn { width: 34px; min-width: 34px; height: 34px; }
+  .account-panel {
+    width: 96vw;
+    right: 2vw;
+    top: 76px;
+    max-height: 78vh;
+  }
+  .memory-toast { width: calc(100vw - 20px); max-width: 420px; text-align: center; justify-content: center; }
+  .msg { max-width: 90%; }
+}
+
+
+.plus-area { position: relative; }
+.plus-btn {
+  width: 42px; height: 42px; border-radius: 10px; border: 1.8px solid #6d28d9;
+  background: #f4efff; font-size: 1.45rem; font-weight: 700; cursor: pointer; color: #5b21b6;
+}
+.plus-menu {
+  position: absolute; bottom: 52px; left: 0; background: #fff; border: 1px solid var(--line);
+  border-radius: 10px; padding: 10px; min-width: 220px; box-shadow: 0 10px 25px rgba(16,22,34,.14);
+  z-index: 35;
+}
+.image-mode-label { font-size: .92rem; font-weight: 600; display: flex; gap: 8px; align-items: center; }
+
+
+
+@keyframes balleBubbleDrift { from { transform: translateX(-4%); } to { transform: translateX(6%); } }
+
+.balle-model-badge {
+  color: #4c1d95 !important;
+  border-color: #d946ef !important;
+  background: linear-gradient(120deg, rgba(34,197,94,.16), rgba(250,204,21,.16), rgba(239,68,68,.14), rgba(168,85,247,.2));
+  background-size: 240% 100%;
+  animation: balleBadgeGlow 2.5s linear infinite;
+  box-shadow: 0 0 0 1px rgba(255,255,255,.55) inset, 0 0 16px rgba(217,70,239,.28);
+}
+@keyframes balleBadgeGlow { from { background-position: 0% 50%; } to { background-position: 220% 50%; } }
+
+.app.balle-bg-active::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 8% 20%, rgba(34,197,94,.18) 0 7%, transparent 8%),
+              radial-gradient(circle at 26% 58%, rgba(250,204,21,.2) 0 6%, transparent 7%),
+              radial-gradient(circle at 52% 22%, rgba(239,68,68,.18) 0 7%, transparent 8%),
+              radial-gradient(circle at 77% 62%, rgba(168,85,247,.22) 0 7%, transparent 8%),
+              radial-gradient(circle at 88% 18%, rgba(250,204,21,.14) 0 5%, transparent 6%);
+  animation: balleBackdropFloat 8s ease-in-out infinite alternate;
+  z-index: 0;
+}
+.app.balle-bg-active #chatArea,
+.app.balle-bg-active .input-shell,
+.app.balle-bg-active .topbar { position: relative; z-index: 1; }
+@keyframes balleBackdropFloat { from { transform: translateY(0); } to { transform: translateY(-10px); } }
+
+.balle-stage-wrap { margin-top: 10px; }
+.balle-stage-title { font-weight: 800; color: #6d28d9; margin-bottom: 8px; }
+.balle-stage-canvas {
+  height: min(44vh, 320px);
+  border-radius: 14px;
+  border: 1px solid #d1d5db;
+  background: #e5e7eb;
+  position: relative;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.5), 0 12px 28px rgba(15,23,42,.14);
+}
+.balle-stage-canvas::before {
+  content: "";
+  position: absolute;
+  inset: -20%;
+  background: conic-gradient(from 0deg, rgba(34,197,94,.16), rgba(250,204,21,.16), rgba(239,68,68,.16), rgba(168,85,247,.2), rgba(34,197,94,.16));
+  animation: balleSweep 4.6s linear infinite;
+}
+@keyframes balleSweep { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+.balle-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(1px);
+  animation: orbFloat 4.8s ease-in-out infinite;
+  box-shadow: 0 0 24px currentColor;
+}
+.balle-orb.orb-green { width: 110px; height: 110px; left: 8%; top: 18%; color: rgba(34,197,94,.65); background: rgba(34,197,94,.38); }
+.balle-orb.orb-yellow { width: 90px; height: 90px; right: 14%; top: 16%; color: rgba(250,204,21,.7); background: rgba(250,204,21,.4); animation-delay: .5s; }
+.balle-orb.orb-red { width: 120px; height: 120px; left: 22%; bottom: 10%; color: rgba(239,68,68,.64); background: rgba(239,68,68,.36); animation-delay: 1.1s; }
+.balle-orb.orb-purple { width: 100px; height: 100px; right: 26%; bottom: 8%; color: rgba(168,85,247,.72); background: rgba(168,85,247,.42); animation-delay: 1.6s; }
+@keyframes orbFloat {
+  0%,100% { transform: translateY(0px) scale(1); }
+  50% { transform: translateY(-14px) scale(1.08); }
+}
+.balle-core-fish {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 140px;
+  transform: translate(-50%, -50%);
+  filter: drop-shadow(0 0 14px rgba(255,255,255,.75));
+}
+
+.math-studio-panel {
+  position: fixed; top: 82px; right: 16px; width: min(480px, 94vw); max-height: 72vh; overflow: auto;
+  z-index: 55; background: #f8fbff; border: 1px solid #93c5fd; border-radius: 14px;
+  box-shadow: 0 16px 36px rgba(30, 64, 175, .16); padding: 12px;
+}
+.math-studio-panel h3 { margin: 0 0 8px; color: #1e40af; }
+.math-studio-panel p { margin: 0 0 10px; font-size: .9rem; color: #334155; }
+.math-studio-input {
+  min-height: 110px; border: 1.5px solid #93c5fd; border-radius: 10px; padding: 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: #fff;
+  white-space: pre-wrap;
+}
+.math-studio-output { margin-top: 10px; display: grid; gap: 8px; }
+.math-result {
+  background: #eff6ff; border: 1px solid #93c5fd; color: #1d4ed8; border-radius: 10px; padding: 8px 10px;
+  font-weight: 700; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+
+.profanity-lock {
+  position: fixed; inset: 0; z-index: 400; display: grid; place-content: center; text-align: center;
+  gap: 10px; background: rgba(20, 0, 0, .7); backdrop-filter: blur(3px); color: #fff;
+}
+.profanity-lock h3 { margin: 0; color: #fecaca; font-size: 1.4rem; }
+.profanity-lock input {
+  width: min(260px, 80vw); margin: 0 auto; padding: 10px 12px; border-radius: 10px; border: 1px solid #ef4444;
+}
+.profanity-lock button {
+  border: none; border-radius: 10px; padding: 10px 14px; background: #ef4444; color: #fff; font-weight: 700; cursor: pointer;
+}
+
+.app.math-mode .fish-logo,
+.app.math-mode .brand { color: #1d4ed8; }
+.app.math-mode .model-badge { border-color: #1d4ed8; color: #1d4ed8; }
+.app.math-mode .memory-btn,
+.app.math-mode .clear-btn,
+.app.math-mode .plus-btn { border-color: #2563eb; color: #1d4ed8; background: #eff6ff; }
+
+.hidden { display: none; }
+.enter-transition.hidden { display: none !important; }
+.enter-transition {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  background: radial-gradient(circle at 50% 44%, rgba(125, 94, 250, 0.26), rgba(10, 10, 31, 0.9) 58%), #07071a;
+}
+.transition-blur {
+  position: absolute;
+  inset: -40px;
+  backdrop-filter: blur(6px);
+  background: radial-gradient(circle at 50% 60%, rgba(114, 83, 246, 0.26), transparent 52%);
+  animation: transitionFog 1.8s ease-out forwards;
+}
+@keyframes transitionFog {
+  from { opacity: 0; filter: blur(2px); }
+  to { opacity: 1; filter: blur(0px); }
+}
+.transition-logo-wrap {
+  position: relative;
+  text-align: center;
+  color: #f7f5ff;
+  opacity: 0;
+  transform: translateY(14px) scale(.96);
+  animation: logoReveal 2.4s ease-out .35s forwards;
+}
+@keyframes logoReveal {
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+.transition-fish { width: min(320px, 68vw); height: auto; color: #ffffff; margin: 0 auto 10px; }
+.transition-logo-wrap h2 {
+  margin: 0;
+  font-size: clamp(2.8rem, 9vw, 6.2rem);
+  letter-spacing: -0.04em;
+  text-shadow: 0 0 18px rgba(188, 171, 255, 0.7), 0 0 40px rgba(122, 103, 255, 0.45);
+}
+.transition-drop {
+  position: absolute;
+  left: 50%;
+  top: -18px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #f3edff, #a68cff 70%);
+  box-shadow: 0 0 16px rgba(173, 143, 255, 0.95);
+  transform: translateX(-50%);
+  animation: dropFall 2.9s ease-in .65s forwards;
+}
+@keyframes dropFall {
+  0% { opacity: 0; transform: translate(-50%, -28px) scale(.7); }
+  16% { opacity: 1; }
+  72% { opacity: 1; transform: translate(-50%, 170px) scale(1); }
+  100% { opacity: 0; transform: translate(-50%, 210px) scale(.45); }
+}
+.transition-vapor {
+  position: absolute;
+  left: 50%;
+  top: 170px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(205, 187, 255, .88), rgba(170, 138, 255, .35), transparent 70%);
+  transform: translateX(-50%) scale(.3);
+  filter: blur(1px);
+  opacity: 0;
+  animation: vaporRise 3.2s ease-out 1.65s forwards;
+}
+@keyframes vaporRise {
+  0% { opacity: 0; transform: translateX(-50%) translateY(0) scale(.25); filter: blur(0px); }
+  22% { opacity: .95; transform: translateX(-50%) translateY(-6px) scale(1.7); filter: blur(2px); }
+  58% { opacity: .6; transform: translateX(-50%) translateY(-32px) scale(2.6); filter: blur(5px); }
+  100% { opacity: 0; transform: translateX(-50%) translateY(-64px) scale(3.4); filter: blur(7px); }
+}
+.transition-beam {
+  margin: 16px auto 0;
+  width: min(640px, 84vw);
+  height: 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(102, 74, 255, 0), #a58bff, #6fa8ff, rgba(102, 74, 255, 0));
+  box-shadow: 0 0 20px rgba(161, 132, 255, 0.95), 0 0 46px rgba(95, 157, 255, 0.55);
+  animation: beamFlash 2.6s ease-out 1.4s forwards;
+  opacity: 0;
+}
+@keyframes beamFlash {
+  0% { opacity: 0; transform: scaleX(.72); }
+  45% { opacity: 1; transform: scaleX(1.03); }
+  100% { opacity: .95; transform: scaleX(1); }
+}
+
+/* math-mode refresh */
+.math-mode-label {
+  padding: 8px 10px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #eff6ff, #dbeafe);
+  border: 1px solid #93c5fd;
+  font-size: 1.02rem;
+  font-weight: 800;
+}
+.math-mode-pill {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #dbeafe, #bfdbfe);
+  border: 1px solid #93c5fd;
+}
+
+
+
+@keyframes balleBubbleDrift { from { transform: translateX(-4%); } to { transform: translateX(6%); } }
+
+.balle-model-badge {
+  color: #4c1d95 !important;
+  border-color: #d946ef !important;
+  background: linear-gradient(120deg, rgba(34,197,94,.16), rgba(250,204,21,.16), rgba(239,68,68,.14), rgba(168,85,247,.2));
+  background-size: 240% 100%;
+  animation: balleBadgeGlow 2.5s linear infinite;
+  box-shadow: 0 0 0 1px rgba(255,255,255,.55) inset, 0 0 16px rgba(217,70,239,.28);
+}
+@keyframes balleBadgeGlow { from { background-position: 0% 50%; } to { background-position: 220% 50%; } }
+
+.app.balle-bg-active::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 8% 20%, rgba(34,197,94,.18) 0 7%, transparent 8%),
+              radial-gradient(circle at 26% 58%, rgba(250,204,21,.2) 0 6%, transparent 7%),
+              radial-gradient(circle at 52% 22%, rgba(239,68,68,.18) 0 7%, transparent 8%),
+              radial-gradient(circle at 77% 62%, rgba(168,85,247,.22) 0 7%, transparent 8%),
+              radial-gradient(circle at 88% 18%, rgba(250,204,21,.14) 0 5%, transparent 6%);
+  animation: balleBackdropFloat 8s ease-in-out infinite alternate;
+  z-index: 0;
+}
+.app.balle-bg-active #chatArea,
+.app.balle-bg-active .input-shell,
+.app.balle-bg-active .topbar { position: relative; z-index: 1; }
+@keyframes balleBackdropFloat { from { transform: translateY(0); } to { transform: translateY(-10px); } }
+
+.balle-stage-wrap { margin-top: 10px; }
+.balle-stage-title { font-weight: 800; color: #6d28d9; margin-bottom: 8px; }
+.balle-stage-canvas {
+  height: min(44vh, 320px);
+  border-radius: 14px;
+  border: 1px solid #d1d5db;
+  background: #e5e7eb;
+  position: relative;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.5), 0 12px 28px rgba(15,23,42,.14);
+}
+.balle-stage-canvas::before {
+  content: "";
+  position: absolute;
+  inset: -20%;
+  background: conic-gradient(from 0deg, rgba(34,197,94,.16), rgba(250,204,21,.16), rgba(239,68,68,.16), rgba(168,85,247,.2), rgba(34,197,94,.16));
+  animation: balleSweep 4.6s linear infinite;
+}
+@keyframes balleSweep { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+.balle-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(1px);
+  animation: orbFloat 4.8s ease-in-out infinite;
+  box-shadow: 0 0 24px currentColor;
+}
+.balle-orb.orb-green { width: 110px; height: 110px; left: 8%; top: 18%; color: rgba(34,197,94,.65); background: rgba(34,197,94,.38); }
+.balle-orb.orb-yellow { width: 90px; height: 90px; right: 14%; top: 16%; color: rgba(250,204,21,.7); background: rgba(250,204,21,.4); animation-delay: .5s; }
+.balle-orb.orb-red { width: 120px; height: 120px; left: 22%; bottom: 10%; color: rgba(239,68,68,.64); background: rgba(239,68,68,.36); animation-delay: 1.1s; }
+.balle-orb.orb-purple { width: 100px; height: 100px; right: 26%; bottom: 8%; color: rgba(168,85,247,.72); background: rgba(168,85,247,.42); animation-delay: 1.6s; }
+@keyframes orbFloat {
+  0%,100% { transform: translateY(0px) scale(1); }
+  50% { transform: translateY(-14px) scale(1.08); }
+}
+.balle-core-fish {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 140px;
+  transform: translate(-50%, -50%);
+  filter: drop-shadow(0 0 14px rgba(255,255,255,.75));
+}
+
+.math-studio-panel {
+  width: min(52vw, 760px);
+  height: calc(100vh - 102px);
+  max-height: none;
+  overflow: hidden;
+  background: linear-gradient(180deg, #f8fdff, #eef8ff);
+  border: 1px solid #a5d8ff;
+  box-shadow: 0 16px 38px rgba(56, 189, 248, .28), inset 0 0 0 1px rgba(147, 197, 253, .3);
+}
+.math-studio-panel p { font-size: .95rem; }
+.math-studio-input {
+  height: calc(100% - 86px);
+  min-height: 260px;
+  padding: 16px;
+  font-size: 1.04rem;
+  line-height: 1.75;
+  color: #0f172a;
+  border: 1.8px solid #7dd3fc;
+  background:
+    repeating-linear-gradient(180deg, rgba(59,130,246,0.06), rgba(59,130,246,0.06) 1px, transparent 1px, transparent 30px),
+    #ffffff;
+  caret-color: #2563eb;
+}
+.math-studio-input:focus { outline: none; box-shadow: 0 0 0 4px rgba(56, 189, 248, .28); }
+.math-studio-input .calc-answer,
+.math-studio-input { color: #0f172a; }
+
+.math-mode-flash {
+  position: fixed;
+  inset: 0;
+  z-index: 330;
+  display: grid;
+  place-items: center;
+  pointer-events: none;
+  background: radial-gradient(circle at center, rgba(125, 211, 252, .3), rgba(14, 116, 255, .06) 45%, transparent 70%);
+  animation: mathFlashFade 1.05s ease-out forwards;
+}
+.math-flash-ring {
+  width: min(58vw, 520px);
+  height: min(58vw, 520px);
+  border-radius: 50%;
+  border: 2px solid rgba(125, 211, 252, .95);
+  box-shadow: 0 0 36px rgba(56, 189, 248, .95), 0 0 86px rgba(59, 130, 246, .62);
+  animation: mathRingPulse 1.05s ease-out forwards;
+}
+.math-flash-text {
+  position: absolute;
+  color: #e0f2fe;
+  font-size: clamp(1.3rem, 4vw, 2.6rem);
+  font-weight: 800;
+  text-shadow: 0 0 18px rgba(56, 189, 248, .95);
+}
+@keyframes mathRingPulse {
+  from { transform: scale(.6); opacity: 0; }
+  30% { opacity: 1; }
+  to { transform: scale(1.28); opacity: 0; }
+}
+@keyframes mathFlashFade {
+  from { opacity: 0; }
+  12% { opacity: 1; }
+  to { opacity: 0; }
+}
+
+.math-tutor-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 340;
+}
+.math-tutor-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(2, 6, 23, .68);
+}
+.math-tutor-bubble {
+  position: absolute;
+  top: 88px;
+  right: 20px;
+  width: min(330px, 88vw);
+  background: #fff;
+  border: 1px solid #bae6fd;
+  border-radius: 16px;
+  padding: 14px;
+  box-shadow: 0 14px 34px rgba(14, 116, 144, .26);
+}
+.math-tutor-bubble button {
+  border: 1px solid #38bdf8;
+  background: #e0f2fe;
+  color: #0c4a6e;
+  border-radius: 10px;
+  font-weight: 700;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+.math-spotlight {
+  position: relative;
+  z-index: 360;
+  box-shadow: 0 0 0 4px rgba(186, 230, 253, .8), 0 0 22px rgba(56, 189, 248, .95);
+  animation: tutorBlink .9s ease-in-out infinite alternate;
+}
+@keyframes tutorBlink {
+  from { transform: scale(1); }
+  to { transform: scale(1.03); }
+}
+
+.app.math-mode {
+  background: radial-gradient(circle at 50% 0%, #e0f2fe 0%, #f0f9ff 35%, #f8fdff 100%);
+}
+.app.math-mode .fish-logo,
+.app.math-mode .brand { color: #0284c7; }
+.app.math-mode .model-badge {
+  border-color: #38bdf8;
+  color: #0369a1;
+  background: #ecfeff;
+  box-shadow: 0 0 14px rgba(56, 189, 248, .35);
+}
+.app.math-mode .memory-btn,
+.app.math-mode .clear-btn,
+.app.math-mode .plus-btn,
+.app.math-mode .input-shell button[type="submit"] {
+  border-color: #38bdf8;
+  color: #0c4a6e;
+  background: linear-gradient(180deg, #f0f9ff, #dbeafe);
+  box-shadow: 0 0 0 1px rgba(125, 211, 252, .7), 0 0 14px rgba(56, 189, 248, .42);
+}
+
+@media (max-width: 900px) {
+  
+
+@keyframes balleBubbleDrift { from { transform: translateX(-4%); } to { transform: translateX(6%); } }
+
+.balle-model-badge {
+  color: #4c1d95 !important;
+  border-color: #d946ef !important;
+  background: linear-gradient(120deg, rgba(34,197,94,.16), rgba(250,204,21,.16), rgba(239,68,68,.14), rgba(168,85,247,.2));
+  background-size: 240% 100%;
+  animation: balleBadgeGlow 2.5s linear infinite;
+  box-shadow: 0 0 0 1px rgba(255,255,255,.55) inset, 0 0 16px rgba(217,70,239,.28);
+}
+@keyframes balleBadgeGlow { from { background-position: 0% 50%; } to { background-position: 220% 50%; } }
+
+.app.balle-bg-active::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 8% 20%, rgba(34,197,94,.18) 0 7%, transparent 8%),
+              radial-gradient(circle at 26% 58%, rgba(250,204,21,.2) 0 6%, transparent 7%),
+              radial-gradient(circle at 52% 22%, rgba(239,68,68,.18) 0 7%, transparent 8%),
+              radial-gradient(circle at 77% 62%, rgba(168,85,247,.22) 0 7%, transparent 8%),
+              radial-gradient(circle at 88% 18%, rgba(250,204,21,.14) 0 5%, transparent 6%);
+  animation: balleBackdropFloat 8s ease-in-out infinite alternate;
+  z-index: 0;
+}
+.app.balle-bg-active #chatArea,
+.app.balle-bg-active .input-shell,
+.app.balle-bg-active .topbar { position: relative; z-index: 1; }
+@keyframes balleBackdropFloat { from { transform: translateY(0); } to { transform: translateY(-10px); } }
+
+.balle-stage-wrap { margin-top: 10px; }
+.balle-stage-title { font-weight: 800; color: #6d28d9; margin-bottom: 8px; }
+.balle-stage-canvas {
+  height: min(44vh, 320px);
+  border-radius: 14px;
+  border: 1px solid #d1d5db;
+  background: #e5e7eb;
+  position: relative;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.5), 0 12px 28px rgba(15,23,42,.14);
+}
+.balle-stage-canvas::before {
+  content: "";
+  position: absolute;
+  inset: -20%;
+  background: conic-gradient(from 0deg, rgba(34,197,94,.16), rgba(250,204,21,.16), rgba(239,68,68,.16), rgba(168,85,247,.2), rgba(34,197,94,.16));
+  animation: balleSweep 4.6s linear infinite;
+}
+@keyframes balleSweep { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+.balle-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(1px);
+  animation: orbFloat 4.8s ease-in-out infinite;
+  box-shadow: 0 0 24px currentColor;
+}
+.balle-orb.orb-green { width: 110px; height: 110px; left: 8%; top: 18%; color: rgba(34,197,94,.65); background: rgba(34,197,94,.38); }
+.balle-orb.orb-yellow { width: 90px; height: 90px; right: 14%; top: 16%; color: rgba(250,204,21,.7); background: rgba(250,204,21,.4); animation-delay: .5s; }
+.balle-orb.orb-red { width: 120px; height: 120px; left: 22%; bottom: 10%; color: rgba(239,68,68,.64); background: rgba(239,68,68,.36); animation-delay: 1.1s; }
+.balle-orb.orb-purple { width: 100px; height: 100px; right: 26%; bottom: 8%; color: rgba(168,85,247,.72); background: rgba(168,85,247,.42); animation-delay: 1.6s; }
+@keyframes orbFloat {
+  0%,100% { transform: translateY(0px) scale(1); }
+  50% { transform: translateY(-14px) scale(1.08); }
+}
+.balle-core-fish {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 140px;
+  transform: translate(-50%, -50%);
+  filter: drop-shadow(0 0 14px rgba(255,255,255,.75));
+}
+
+.math-studio-panel {
+    width: min(90vw, 640px);
+    height: min(58vh, 560px);
+  }
+  .math-studio-input { height: calc(100% - 102px); }
+  .math-tutor-bubble { right: 12px; top: 132px; }
+}
+
+/* geometry lab */
+.geometry-lab {
+  border: 1px solid #bae6fd;
+  border-radius: 14px;
+  padding: 10px;
+  background: linear-gradient(180deg, #f0f9ff, #ecfeff);
+  margin-bottom: 12px;
+}
+.geometry-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.geo-btn {
+  border: 1px solid #7dd3fc;
+  border-radius: 999px;
+  background: #fff;
+  color: #075985;
+  font-weight: 700;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+.geo-btn.active {
+  background: linear-gradient(90deg, #dbeafe, #bae6fd);
+  box-shadow: 0 0 14px rgba(56, 189, 248, .35);
+}
+.geometry-card { display: grid; gap: 10px; }
+.geometry-sketch {
+  background: #fff;
+  border: 1px solid #bae6fd;
+  border-radius: 12px;
+  padding: 10px;
+}
+.geo-title { font-weight: 800; color: #0c4a6e; margin-bottom: 8px; }
+.geo-edge-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(110px, 1fr));
+  gap: 8px;
+}
+.geo-edge {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: .78rem;
+  color: #155e75;
+}
+.geo-edge input, #geoGoalInput {
+  border: 1.5px solid #7dd3fc;
+  border-radius: 10px;
+  padding: 7px 8px;
+  font-weight: 700;
+}
+.geo-center-box { margin-top: 8px; }
+#geoGoalInput { width: 100%; text-transform: lowercase; }
+.geo-corners { margin-top: 6px; font-size: .8rem; color: #0369a1; font-weight: 700; }
+.geometry-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+#solveGeometryBtn {
+  border: 1.5px solid #38bdf8;
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-weight: 800;
+  color: #0c4a6e;
+  background: linear-gradient(180deg, #e0f2fe, #bfdbfe);
+  box-shadow: 0 0 14px rgba(14, 165, 233, .33);
+  cursor: pointer;
+}
+.geometry-warn {
+  color: #b91c1c;
+  font-size: .85rem;
+  font-weight: 700;
+}
+
+.thinking-bubble.thinking-math {
+  border: 1px solid #7dd3fc;
+  background: linear-gradient(90deg, #e0f2fe, #dbeafe, #e0f2fe);
+  background-size: 220% 100%;
+  animation: mathAnalyzeGlow 1.2s linear infinite;
+}
+.thinking-bubble.thinking-math .thinking-head {
+  color: #0369a1;
+  font-weight: 800;
+}
+@keyframes mathAnalyzeGlow {
+  0% { background-position: 0% 0%; }
+  100% { background-position: 220% 0%; }
+}
+
+@media (max-width: 900px) {
+  .geometry-toolbar { max-height: 104px; overflow: auto; }
+  .geo-edge-grid { grid-template-columns: 1fr; }
+}
+
+
+
+@keyframes balleBubbleDrift { from { transform: translateX(-4%); } to { transform: translateX(6%); } }
+
+.balle-model-badge {
+  color: #4c1d95 !important;
+  border-color: #d946ef !important;
+  background: linear-gradient(120deg, rgba(34,197,94,.16), rgba(250,204,21,.16), rgba(239,68,68,.14), rgba(168,85,247,.2));
+  background-size: 240% 100%;
+  animation: balleBadgeGlow 2.5s linear infinite;
+  box-shadow: 0 0 0 1px rgba(255,255,255,.55) inset, 0 0 16px rgba(217,70,239,.28);
+}
+@keyframes balleBadgeGlow { from { background-position: 0% 50%; } to { background-position: 220% 50%; } }
+
+.app.balle-bg-active::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 8% 20%, rgba(34,197,94,.18) 0 7%, transparent 8%),
+              radial-gradient(circle at 26% 58%, rgba(250,204,21,.2) 0 6%, transparent 7%),
+              radial-gradient(circle at 52% 22%, rgba(239,68,68,.18) 0 7%, transparent 8%),
+              radial-gradient(circle at 77% 62%, rgba(168,85,247,.22) 0 7%, transparent 8%),
+              radial-gradient(circle at 88% 18%, rgba(250,204,21,.14) 0 5%, transparent 6%);
+  animation: balleBackdropFloat 8s ease-in-out infinite alternate;
+  z-index: 0;
+}
+.app.balle-bg-active #chatArea,
+.app.balle-bg-active .input-shell,
+.app.balle-bg-active .topbar { position: relative; z-index: 1; }
+@keyframes balleBackdropFloat { from { transform: translateY(0); } to { transform: translateY(-10px); } }
+
+.balle-stage-wrap { margin-top: 10px; }
+.balle-stage-title { font-weight: 800; color: #6d28d9; margin-bottom: 8px; }
+.balle-stage-canvas {
+  height: min(44vh, 320px);
+  border-radius: 14px;
+  border: 1px solid #d1d5db;
+  background: #e5e7eb;
+  position: relative;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.5), 0 12px 28px rgba(15,23,42,.14);
+}
+.balle-stage-canvas::before {
+  content: "";
+  position: absolute;
+  inset: -20%;
+  background: conic-gradient(from 0deg, rgba(34,197,94,.16), rgba(250,204,21,.16), rgba(239,68,68,.16), rgba(168,85,247,.2), rgba(34,197,94,.16));
+  animation: balleSweep 4.6s linear infinite;
+}
+@keyframes balleSweep { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+.balle-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(1px);
+  animation: orbFloat 4.8s ease-in-out infinite;
+  box-shadow: 0 0 24px currentColor;
+}
+.balle-orb.orb-green { width: 110px; height: 110px; left: 8%; top: 18%; color: rgba(34,197,94,.65); background: rgba(34,197,94,.38); }
+.balle-orb.orb-yellow { width: 90px; height: 90px; right: 14%; top: 16%; color: rgba(250,204,21,.7); background: rgba(250,204,21,.4); animation-delay: .5s; }
+.balle-orb.orb-red { width: 120px; height: 120px; left: 22%; bottom: 10%; color: rgba(239,68,68,.64); background: rgba(239,68,68,.36); animation-delay: 1.1s; }
+.balle-orb.orb-purple { width: 100px; height: 100px; right: 26%; bottom: 8%; color: rgba(168,85,247,.72); background: rgba(168,85,247,.42); animation-delay: 1.6s; }
+@keyframes orbFloat {
+  0%,100% { transform: translateY(0px) scale(1); }
+  50% { transform: translateY(-14px) scale(1.08); }
+}
+.balle-core-fish {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 140px;
+  transform: translate(-50%, -50%);
+  filter: drop-shadow(0 0 14px rgba(255,255,255,.75));
+}
+
+.math-studio-panel { overflow: auto; }
+.math-studio-input {
+  height: 260px;
+  min-height: 220px;
+}
+@media (max-width: 900px) {
+  .math-studio-input { height: 180px; min-height: 150px; }
+}
+
+/* notebook geometry redesign */
+.geometry-sketch {
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+.geo-notebook {
+  position: relative;
+  min-height: 360px;
+  border: 1px solid #bfdbfe;
+  border-radius: 14px;
+  background:
+    repeating-linear-gradient(180deg, rgba(59,130,246,0.08), rgba(59,130,246,0.08) 1px, transparent 1px, transparent 34px),
+    #ffffff;
+  box-shadow: inset 0 0 0 1px rgba(186, 230, 253, .45), 0 8px 18px rgba(14, 165, 233, .12);
+}
+.geo-shape-svg {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 230px;
+  height: 230px;
+  transform: translate(-50%, -54%);
+  fill: rgba(59,130,246,.10);
+  stroke: #0284c7;
+  stroke-width: 3;
+  filter: drop-shadow(0 0 10px rgba(56, 189, 248, .35));
+}
+.geo-side-input {
+  position: absolute;
+  display: grid;
+  gap: 3px;
+  width: 74px;
+  font-size: .72rem;
+  color: #155e75;
+  font-weight: 700;
+}
+.geo-side-input input {
+  border: 1.4px solid #7dd3fc;
+  border-radius: 9px;
+  padding: 5px 6px;
+  font-weight: 700;
+  background: rgba(255,255,255,.96);
+}
+.pos-top { left: 50%; top: 18px; transform: translateX(-50%); }
+.pos-bottom { left: 50%; bottom: 16px; transform: translateX(-50%); }
+.pos-left { left: 16px; top: 50%; transform: translateY(-50%); }
+.pos-right { right: 16px; top: 50%; transform: translateY(-50%); }
+.pos-upper-left { left: 26px; top: 62px; }
+.pos-upper-right { right: 26px; top: 62px; }
+.pos-lower-left { left: 26px; bottom: 62px; }
+.pos-lower-right { right: 26px; bottom: 62px; }
+
+.geo-goal-input {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 120px;
+  border: 1.6px solid #38bdf8;
+  border-radius: 10px;
+  padding: 7px 9px;
+  text-align: center;
+  font-weight: 800;
+  text-transform: lowercase;
+  color: #0c4a6e;
+  background: #f0f9ff;
+}
+.geo-result-pad {
+  position: absolute;
+  left: 50%;
+  bottom: 58px;
+  transform: translateX(-50%);
+  color: #0369a1;
+  font-weight: 800;
+  background: rgba(224, 242, 254, .92);
+  border: 1px solid #7dd3fc;
+  border-radius: 10px;
+  padding: 5px 10px;
+}
+.geo-notebook.geo-hit {
+  animation: geoHit 700ms ease-out;
+}
+@keyframes geoHit {
+  0% { box-shadow: inset 0 0 0 1px rgba(186, 230, 253, .45), 0 0 0 rgba(14,165,233,0); }
+  40% { box-shadow: inset 0 0 0 1px rgba(125, 211, 252, .8), 0 0 28px rgba(14,165,233,.65); }
+  100% { box-shadow: inset 0 0 0 1px rgba(186, 230, 253, .45), 0 8px 18px rgba(14,165,233,.12); }
+}
+
+.math-tutor-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+.math-tutor-finale {
+  position: fixed;
+  inset: 0;
+  z-index: 380;
+  display: grid;
+  place-items: center;
+}
+.math-tutor-finale-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(2, 6, 23, .78);
+}
+.math-tutor-finale-card {
+  position: relative;
+  text-align: center;
+  color: #e0f2fe;
+  animation: tutorFinalePop 1.6s ease-out forwards;
+}
+.finale-fish {
+  width: min(280px, 70vw);
+  color: #f0f9ff;
+  margin: 0 auto 8px;
+  filter: drop-shadow(0 0 24px rgba(56, 189, 248, .8));
+}
+.math-tutor-finale-card h3 {
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2.7rem);
+  color: #7dd3fc;
+  text-shadow: 0 0 20px rgba(56, 189, 248, .9);
+}
+@keyframes tutorFinalePop {
+  0% { opacity: 0; transform: scale(.88); }
+  18% { opacity: 1; transform: scale(1); }
+  100% { opacity: 0; transform: scale(1.04); }
+}
+
+@media (max-width: 900px) {
+  .geo-notebook { min-height: 300px; }
+  .geo-shape-svg { width: 190px; height: 190px; }
+  .geo-side-input { width: 64px; font-size: .68rem; }
+  .geo-goal-input { width: 110px; }
+  .geo-result-pad { bottom: 44px; font-size: .82rem; }
+}
+
+.math-tutor-finale.hidden { display: none !important; }
+
+
+.warning-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 390;
+  display: grid;
+  place-items: center;
+  background: rgba(12, 10, 22, .62);
+  backdrop-filter: blur(3px);
+}
+.warning-card {
+  width: min(760px, 92vw);
+  text-align: center;
+  border-radius: 22px;
+  border: 2px solid #f59e0b;
+  background: linear-gradient(180deg, #fff7ed, #ffedd5);
+  box-shadow: 0 0 40px rgba(245, 158, 11, .45);
+  padding: 26px 20px;
+}
+.warning-card h3 {
+  margin: 0 0 10px;
+  font-size: clamp(2rem, 6vw, 3.4rem);
+  color: #b45309;
+}
+.warning-card p {
+  margin: 0;
+  font-size: clamp(1.05rem, 2.8vw, 1.6rem);
+  font-weight: 800;
+  color: #9a3412;
+}
+
+.safety-survey {
+  border: 1px solid #93c5fd;
+  background: linear-gradient(180deg, #eff6ff, #f0f9ff);
+}
+.survey-title { font-weight: 800; color: #1e3a8a; margin-bottom: 8px; }
+.survey-start-btn {
+  border: 1.5px solid #3b82f6;
+  border-radius: 10px;
+  background: #dbeafe;
+  color: #1e40af;
+  font-weight: 700;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+.survey-panel {
+  margin-top: 10px;
+  display: grid;
+  gap: 6px;
+  color: #1f2937;
+}
+.survey-panel label { display: flex; gap: 8px; align-items: center; }
+.survey-note {
+  margin-top: 6px;
+  color: #1d4ed8;
+  font-weight: 700;
+}
+
+.warning-overlay.hidden { display: none !important; }
+
+
+.safety-survey-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 395;
+  display: grid;
+  place-items: center;
+}
+.safety-survey-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(2, 6, 23, .74);
+  backdrop-filter: blur(4px);
+}
+.safety-survey-card {
+  position: relative;
+  width: min(640px, 92vw);
+  border-radius: 18px;
+  border: 1px solid #93c5fd;
+  background: linear-gradient(180deg, #f8fbff, #eaf4ff);
+  box-shadow: 0 20px 44px rgba(30, 64, 175, .28);
+  padding: 18px;
+}
+.safety-survey-card h3 { margin: 0 0 8px; color: #1e40af; }
+.safety-survey-card p { margin: 0 0 12px; color: #334155; }
+.safety-survey-options { display: grid; gap: 8px; }
+.safety-survey-options button {
+  border: 1.5px solid #60a5fa;
+  border-radius: 11px;
+  background: #fff;
+  color: #1e3a8a;
+  font-weight: 700;
+  text-align: left;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+.safety-survey-options button:hover { background: #eff6ff; }
+.close-safety-survey {
+  margin-top: 10px;
+  border: 1px solid #94a3b8;
+  background: #fff;
+  border-radius: 9px;
+  padding: 8px 11px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.safety-survey-modal.hidden { display: none !important; }
+
+.web-mode-label {
+  padding: 8px 10px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #eef2ff, #e0e7ff);
+  border: 1px solid #a5b4fc;
+  font-size: .98rem;
+  font-weight: 800;
+}
+
+.input-web-wrap {
+  position: relative;
+  width: 100%;
+}
+.web-input-badge {
+  position: absolute;
+  top: -22px;
+  left: 10px;
+  font-size: .72rem;
+  font-weight: 800;
+  color: #6d28d9;
+  background: #ede9fe;
+  border: 1px solid #c4b5fd;
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+#userInput.web-search-input {
+  border-color: #7c3aed;
+  box-shadow: 0 0 0 3px rgba(124, 58, 237, .15);
+  background: linear-gradient(180deg, #ffffff, #faf5ff);
+}
+
+.thinking-bubble.web-thinking,
+.thinking-bubble.thinking-web {
+  background: #ffffff;
+  border: 1px solid #d8b4fe;
+}
+.thinking-bubble.thinking-web .thinking-head,
+.thinking-bubble.web-thinking .thinking-head {
+  color: #111;
+  font-weight: 800;
+  background: linear-gradient(120deg, #111 0%, #111 40%, #9333ea 50%, #111 60%, #111 100%);
+  background-size: 220% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: webShimmer 2s linear infinite;
+}
+@keyframes webShimmer { from { background-position: 0% 50%; } to { background-position: 220% 50%; } }
+
+.web-results {
+  background: #fff;
+  border: 1px solid #c4b5fd;
+}
+.web-results-head {
+  font-weight: 900;
+  color: #6d28d9;
+  margin-bottom: 4px;
+}
+.web-query { color: #475569; font-size: .9rem; margin-bottom: 8px; }
+.web-top3 { margin: 0; padding-left: 18px; display: grid; gap: 8px; }
+.web-top3 li a { color: #4c1d95; font-weight: 800; text-decoration: none; }
+.web-top3 li p { margin: 2px 0 0; color: #334155; font-size: .9rem; }
+.web-results details { margin-top: 8px; }
+.web-results summary { cursor: pointer; color: #6d28d9; font-weight: 700; }
+
+/* mobile math studio size fix */
+@media (max-width: 900px) {
+  
+
+@keyframes balleBubbleDrift { from { transform: translateX(-4%); } to { transform: translateX(6%); } }
+
+.balle-model-badge {
+  color: #4c1d95 !important;
+  border-color: #d946ef !important;
+  background: linear-gradient(120deg, rgba(34,197,94,.16), rgba(250,204,21,.16), rgba(239,68,68,.14), rgba(168,85,247,.2));
+  background-size: 240% 100%;
+  animation: balleBadgeGlow 2.5s linear infinite;
+  box-shadow: 0 0 0 1px rgba(255,255,255,.55) inset, 0 0 16px rgba(217,70,239,.28);
+}
+@keyframes balleBadgeGlow { from { background-position: 0% 50%; } to { background-position: 220% 50%; } }
+
+.app.balle-bg-active::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 8% 20%, rgba(34,197,94,.18) 0 7%, transparent 8%),
+              radial-gradient(circle at 26% 58%, rgba(250,204,21,.2) 0 6%, transparent 7%),
+              radial-gradient(circle at 52% 22%, rgba(239,68,68,.18) 0 7%, transparent 8%),
+              radial-gradient(circle at 77% 62%, rgba(168,85,247,.22) 0 7%, transparent 8%),
+              radial-gradient(circle at 88% 18%, rgba(250,204,21,.14) 0 5%, transparent 6%);
+  animation: balleBackdropFloat 8s ease-in-out infinite alternate;
+  z-index: 0;
+}
+.app.balle-bg-active #chatArea,
+.app.balle-bg-active .input-shell,
+.app.balle-bg-active .topbar { position: relative; z-index: 1; }
+@keyframes balleBackdropFloat { from { transform: translateY(0); } to { transform: translateY(-10px); } }
+
+.balle-stage-wrap { margin-top: 10px; }
+.balle-stage-title { font-weight: 800; color: #6d28d9; margin-bottom: 8px; }
+.balle-stage-canvas {
+  height: min(44vh, 320px);
+  border-radius: 14px;
+  border: 1px solid #d1d5db;
+  background: #e5e7eb;
+  position: relative;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.5), 0 12px 28px rgba(15,23,42,.14);
+}
+.balle-stage-canvas::before {
+  content: "";
+  position: absolute;
+  inset: -20%;
+  background: conic-gradient(from 0deg, rgba(34,197,94,.16), rgba(250,204,21,.16), rgba(239,68,68,.16), rgba(168,85,247,.2), rgba(34,197,94,.16));
+  animation: balleSweep 4.6s linear infinite;
+}
+@keyframes balleSweep { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+.balle-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(1px);
+  animation: orbFloat 4.8s ease-in-out infinite;
+  box-shadow: 0 0 24px currentColor;
+}
+.balle-orb.orb-green { width: 110px; height: 110px; left: 8%; top: 18%; color: rgba(34,197,94,.65); background: rgba(34,197,94,.38); }
+.balle-orb.orb-yellow { width: 90px; height: 90px; right: 14%; top: 16%; color: rgba(250,204,21,.7); background: rgba(250,204,21,.4); animation-delay: .5s; }
+.balle-orb.orb-red { width: 120px; height: 120px; left: 22%; bottom: 10%; color: rgba(239,68,68,.64); background: rgba(239,68,68,.36); animation-delay: 1.1s; }
+.balle-orb.orb-purple { width: 100px; height: 100px; right: 26%; bottom: 8%; color: rgba(168,85,247,.72); background: rgba(168,85,247,.42); animation-delay: 1.6s; }
+@keyframes orbFloat {
+  0%,100% { transform: translateY(0px) scale(1); }
+  50% { transform: translateY(-14px) scale(1.08); }
+}
+.balle-core-fish {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 140px;
+  transform: translate(-50%, -50%);
+  filter: drop-shadow(0 0 14px rgba(255,255,255,.75));
+}
+
+.math-studio-panel {
+    width: 96vw;
+    height: 78vh;
+    right: 2vw;
+    top: 78px;
+  }
+  .math-studio-input {
+    height: 260px;
+    min-height: 220px;
+    font-size: 1rem;
+  }
+}
+
+@media (max-width: 560px) {
+  #clearChat { display: none; }
+  
+
+@keyframes balleBubbleDrift { from { transform: translateX(-4%); } to { transform: translateX(6%); } }
+
+.balle-model-badge {
+  color: #4c1d95 !important;
+  border-color: #d946ef !important;
+  background: linear-gradient(120deg, rgba(34,197,94,.16), rgba(250,204,21,.16), rgba(239,68,68,.14), rgba(168,85,247,.2));
+  background-size: 240% 100%;
+  animation: balleBadgeGlow 2.5s linear infinite;
+  box-shadow: 0 0 0 1px rgba(255,255,255,.55) inset, 0 0 16px rgba(217,70,239,.28);
+}
+@keyframes balleBadgeGlow { from { background-position: 0% 50%; } to { background-position: 220% 50%; } }
+
+.app.balle-bg-active::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 8% 20%, rgba(34,197,94,.18) 0 7%, transparent 8%),
+              radial-gradient(circle at 26% 58%, rgba(250,204,21,.2) 0 6%, transparent 7%),
+              radial-gradient(circle at 52% 22%, rgba(239,68,68,.18) 0 7%, transparent 8%),
+              radial-gradient(circle at 77% 62%, rgba(168,85,247,.22) 0 7%, transparent 8%),
+              radial-gradient(circle at 88% 18%, rgba(250,204,21,.14) 0 5%, transparent 6%);
+  animation: balleBackdropFloat 8s ease-in-out infinite alternate;
+  z-index: 0;
+}
+.app.balle-bg-active #chatArea,
+.app.balle-bg-active .input-shell,
+.app.balle-bg-active .topbar { position: relative; z-index: 1; }
+@keyframes balleBackdropFloat { from { transform: translateY(0); } to { transform: translateY(-10px); } }
+
+.balle-stage-wrap { margin-top: 10px; }
+.balle-stage-title { font-weight: 800; color: #6d28d9; margin-bottom: 8px; }
+.balle-stage-canvas {
+  height: min(44vh, 320px);
+  border-radius: 14px;
+  border: 1px solid #d1d5db;
+  background: #e5e7eb;
+  position: relative;
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.5), 0 12px 28px rgba(15,23,42,.14);
+}
+.balle-stage-canvas::before {
+  content: "";
+  position: absolute;
+  inset: -20%;
+  background: conic-gradient(from 0deg, rgba(34,197,94,.16), rgba(250,204,21,.16), rgba(239,68,68,.16), rgba(168,85,247,.2), rgba(34,197,94,.16));
+  animation: balleSweep 4.6s linear infinite;
+}
+@keyframes balleSweep { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+.balle-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(1px);
+  animation: orbFloat 4.8s ease-in-out infinite;
+  box-shadow: 0 0 24px currentColor;
+}
+.balle-orb.orb-green { width: 110px; height: 110px; left: 8%; top: 18%; color: rgba(34,197,94,.65); background: rgba(34,197,94,.38); }
+.balle-orb.orb-yellow { width: 90px; height: 90px; right: 14%; top: 16%; color: rgba(250,204,21,.7); background: rgba(250,204,21,.4); animation-delay: .5s; }
+.balle-orb.orb-red { width: 120px; height: 120px; left: 22%; bottom: 10%; color: rgba(239,68,68,.64); background: rgba(239,68,68,.36); animation-delay: 1.1s; }
+.balle-orb.orb-purple { width: 100px; height: 100px; right: 26%; bottom: 8%; color: rgba(168,85,247,.72); background: rgba(168,85,247,.42); animation-delay: 1.6s; }
+@keyframes orbFloat {
+  0%,100% { transform: translateY(0px) scale(1); }
+  50% { transform: translateY(-14px) scale(1.08); }
+}
+.balle-core-fish {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 140px;
+  transform: translate(-50%, -50%);
+  filter: drop-shadow(0 0 14px rgba(255,255,255,.75));
+}
+
+.math-studio-panel {
+    width: 98vw;
+    right: 1vw;
+    height: 80vh;
+  }
+  .math-studio-input {
+    height: 230px;
+    min-height: 200px;
+  }
+}
+
+/* plus menu compact + glowing clickable mode options */
+.plus-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 11px;
+  font-size: 1.15rem;
+  border: 1.4px solid #7c3aed;
+  background: radial-gradient(circle at 28% 24%, #faf5ff 0%, #ede9fe 48%, #ddd6fe 100%);
+  color: #5b21b6;
+  box-shadow: 0 0 0 1px rgba(167, 139, 250, .35), 0 0 14px rgba(124, 58, 237, .25);
+  transition: transform .14s ease, box-shadow .2s ease, filter .2s ease;
+}
+.plus-btn:hover {
+  transform: translateY(-1px) scale(1.02);
+  box-shadow: 0 0 0 1px rgba(167, 139, 250, .45), 0 0 20px rgba(124, 58, 237, .35), 0 0 28px rgba(59, 130, 246, .18);
+}
+.plus-btn:active { transform: translateY(0) scale(.98); }
+
+.plus-menu {
+  min-width: 188px;
+  padding: 8px;
+  border-radius: 12px;
+  border: 1px solid #ddd6fe;
+  background: linear-gradient(180deg, #ffffff, #faf7ff);
+}
+
+.image-mode-label {
+  position: relative;
+  gap: 6px;
+  font-size: .8rem;
+  font-weight: 700;
+  line-height: 1.2;
+  padding: 6px 8px;
+  border-radius: 10px;
+  cursor: pointer;
+  user-select: none;
+  transition: transform .12s ease, box-shadow .2s ease, filter .2s ease;
+}
+.image-mode-label:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 0 0 1px rgba(139, 92, 246, .22), 0 0 18px rgba(124, 58, 237, .16);
+  filter: brightness(1.03);
+}
+
+.image-mode-label input[type="checkbox"] {
+  width: 14px;
+  height: 14px;
+  accent-color: #6d28d9;
+  cursor: pointer;
+}
+.image-mode-label .mode-icon { font-size: .9rem; line-height: 1; }
+.image-mode-label .mode-spark {
+  font-size: .78rem;
+  line-height: 1;
+  text-shadow: 0 0 8px rgba(147, 51, 234, .45), 0 0 14px rgba(59, 130, 246, .25);
+}
+
+.math-mode-label,
+.web-mode-label {
+  padding: 6px 8px;
+  border-radius: 10px;
+  font-size: .78rem;
+}
+.math-mode-pill {
+  padding: 3px 8px;
+  font-size: .76rem;
+  border-radius: 999px;
+}
+
+@media (max-width: 700px) {
+  .plus-btn {
+    width: 34px;
+    height: 34px;
+    font-size: 1.02rem;
+  }
+  .plus-menu {
+    min-width: 174px;
+    padding: 7px;
+  }
+  .image-mode-label {
+    padding: 5px 7px;
+    font-size: .74rem;
+  }
+  .math-mode-pill {
+    font-size: .7rem;
+    padding: 2px 7px;
+  }
+}
+
+.bmw-video-card {
+  max-width: min(420px, 92vw);
+  padding: 10px;
+  border: 1px solid #c7d2fe;
+  background: linear-gradient(180deg, #ffffff, #eef2ff);
+}
+.bmw-video-card iframe {
+  width: 100%;
+  aspect-ratio: 9 / 16;
+  border: 0;
+  border-radius: 12px;
+  background: #000;
+  box-shadow: 0 8px 18px rgba(30, 58, 138, .22);
+}
+
+/* drawer + premium purchase UI */
+.side-drawer {
+  position: fixed;
+  top: 72px;
+  right: 12px;
+  width: min(280px, 88vw);
+  z-index: 90;
+  background: linear-gradient(180deg, #ffffff, #f8fafc);
+  border: 1px solid #dbeafe;
+  border-radius: 14px;
+  padding: 12px;
+  box-shadow: 0 16px 34px rgba(15, 23, 42, .18);
+}
+.drawer-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+.drawer-head h3 { margin: 0; color: #1e3a8a; font-size: 1rem; }
+.drawer-head button { border: none; background: #eff6ff; border-radius: 8px; padding: 4px 8px; cursor: pointer; }
+.drawer-btn {
+  width: 100%;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 9px 10px;
+  margin-bottom: 8px;
+  background: #fff;
+  font-weight: 700;
+  cursor: pointer;
+}
+.premium-glow {
+  border-color: #a78bfa;
+  background: linear-gradient(90deg, #faf5ff, #eef2ff);
+  box-shadow: 0 0 0 1px rgba(167,139,250,.35), 0 0 20px rgba(124,58,237,.24);
+  animation: premiumPulse 1.5s ease-in-out infinite alternate;
+}
+@keyframes premiumPulse { from { filter: brightness(1); } to { filter: brightness(1.08); } }
+.premium-owned { color: #065f46; font-weight: 800; margin: 4px 2px 0; }
+.premium-pending { color: #92400e; font-weight: 700; margin: 4px 2px 0; }
+
+.premium-expiry { color: #334155; font-weight: 700; margin: 2px 2px 0; font-size: 12px; }
+
+body.premium-active .chat-area,
+body.premium-active .input-shell,
+body.premium-active .topbar {
+  box-shadow: 0 10px 26px rgba(79, 70, 229, 0.10);
+}
+
+body.premium-active .model-badge,
+body.premium-active .memory-btn,
+body.premium-active .plus-btn,
+body.premium-active .clear-btn {
+  border-width: 1.5px;
+}
+
+.premium-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 320;
+  display: grid;
+  place-items: center;
+}
+.premium-backdrop { position: absolute; inset: 0; background: rgba(12, 14, 24, .62); backdrop-filter: blur(2px); }
+.premium-card {
+  position: relative;
+  width: min(520px, 92vw);
+  background: linear-gradient(180deg, #ffffff, #f5f3ff);
+  border: 1px solid #c4b5fd;
+  border-radius: 16px;
+  padding: 14px;
+  box-shadow: 0 20px 44px rgba(76, 29, 149, .26);
+}
+.premium-title-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 8px; }
+.premium-title-row h3 { margin: 0; color: #5b21b6; }
+.premium-title-row button { border: none; background: #ede9fe; border-radius: 8px; cursor: pointer; padding: 4px 8px; }
+.premium-card ul { margin: 10px 0; padding-left: 18px; display: grid; gap: 6px; color: #334155; }
+.premium-actions { display: flex; gap: 10px; }
+.premium-buy-btn,
+.premium-confirm-btn {
+  flex: 1;
+  border: 1px solid #a78bfa;
+  background: linear-gradient(90deg, #ede9fe, #dbeafe);
+  border-radius: 10px;
+  padding: 9px 10px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+@media (max-width: 700px) {
+  .side-drawer { top: 66px; right: 6px; width: 92vw; }
+}
+
+.premium-modal.hidden { display: none !important; }
+
+.premium-verify-note {
+  margin: 6px 0 10px;
+  font-size: .84rem;
+  color: #475569;
+}
+.premium-code-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+#premiumCodeInput {
+  border: 1px solid #c4b5fd;
+  border-radius: 10px;
+  padding: 9px 10px;
+  font-weight: 700;
+  letter-spacing: .4px;
+}
+
+.premium-code-row.hidden { display: none !important; }
+
+
+.model-badge.premium-model-badge {
+  color: #7e22ce;
+  border-color: #c084fc;
+  background: linear-gradient(90deg, #f5d0fe, #ede9fe);
+  box-shadow: 0 0 0 1px rgba(192, 132, 252, .3), 0 0 12px rgba(168, 85, 247, .25);
+}
+
+.web-wiki-excerpt {
+  margin-top: 12px;
+  padding: 10px;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  background: #f8fafc;
+}
+.web-wiki-excerpt h4 {
+  margin: 0 0 8px;
+  color: #1e293b;
+  font-size: .95rem;
+}
+.web-wiki-excerpt p {
+  margin: 0 0 8px;
+  color: #334155;
+  line-height: 1.55;
+  max-height: 280px;
+  overflow: auto;
+  white-space: normal;
+}
+.web-wiki-excerpt a {
+  color: #4c1d95;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.web-main-answer {
+  margin-top: 4px;
+  padding: 10px;
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  background: #f8fafc;
+}
+.web-main-answer h4 {
+  margin: 0 0 8px;
+  color: #1e293b;
+  font-size: .95rem;
+}
+.web-answer-text {
+  margin: 0;
+  color: #334155;
+  line-height: 1.55;
+  white-space: normal;
+}
+.web-read-more {
+  margin-top: 8px;
+  border: 1px solid #a78bfa;
+  background: #ede9fe;
+  color: #5b21b6;
+  border-radius: 8px;
+  font-weight: 700;
+  padding: 6px 10px;
+  cursor: pointer;
+}
+.web-sources {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px dashed #cbd5e1;
+}
+.web-sources h5 {
+  margin: 0 0 8px;
+  color: #475569;
+  font-size: .88rem;
+}
+.web-source-list {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+}
+.web-source-list a,
+.web-source-main {
+  color: #4c1d95;
+  font-weight: 700;
+  text-decoration: none;
+}
+.web-source-main {
+  display: inline-block;
+  margin-top: 8px;
+}
+
+
+/* background settings */
+.background-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 360;
+  display: grid;
+  place-items: center;
+}
+.background-modal.hidden { display: none !important; }
+.background-backdrop { position: absolute; inset: 0; background: rgba(15, 23, 42, .6); backdrop-filter: blur(2px); }
+.background-card {
+  position: relative;
+  width: min(560px, 92vw);
+  background: #f8fafc;
+  border: 1px solid #cbd5e1;
+  border-radius: 14px;
+  padding: 14px;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, .26);
+  display: grid;
+  gap: 10px;
+}
+.background-title-row { display: flex; justify-content: space-between; align-items: center; }
+.background-title-row h3 { margin: 0; color: #312e81; }
+.background-title-row button { border: none; border-radius: 8px; background: #e2e8f0; padding: 5px 10px; cursor: pointer; }
+.background-row { display: grid; gap: 6px; }
+.background-row label { font-size: .88rem; color: #475569; font-weight: 700; }
+.background-row select,
+.background-row input[type="range"] { width: 100%; border: 1px solid #cbd5e1; border-radius: 10px; padding: 8px; }
+.background-note { margin: 2px 0 0; font-size: .82rem; color: #64748b; }
+
+body[class*="bg-theme-"] {
+  position: relative;
+  overflow-x: hidden;
+}
+body[class*="bg-theme-"]::before,
+body[class*="bg-theme-"]::after {
+  content: "";
+  position: fixed;
+  inset: -10%;
+  pointer-events: none;
+  z-index: -1;
+}
+body.bg-theme-1 { background: radial-gradient(circle at 20% 20%, #111827, #0f172a 65%); }
+body.bg-theme-1::before { background-image: radial-gradient(circle, rgba(255,255,255,.45) 1px, transparent 1px); background-size: 4px 4px; opacity: .22; animation: bgStarMove 3s linear infinite; }
+body.bg-theme-1::after { background: radial-gradient(circle at 0% 50%, rgba(168,85,247,.24), transparent 55%), radial-gradient(circle at 100% 50%, rgba(99,102,241,.22), transparent 45%); }
+body.bg-theme-2 { background: linear-gradient(120deg, #0f172a, #1e293b, #0b3b57); }
+body.bg-theme-3 { background: linear-gradient(140deg, #1f2937, #312e81, #1f2937); }
+body.bg-theme-4 { background: linear-gradient(120deg, #111827, #334155); }
+body.bg-theme-5 { background: linear-gradient(120deg, #0f172a, #155e75); }
+body.bg-theme-6 { background: linear-gradient(120deg, #1f2937, #7c3aed); }
+body.bg-theme-7 { background: linear-gradient(120deg, #020617, #1d4ed8, #701a75); }
+body.bg-theme-8 { background: linear-gradient(120deg, #052e16, #14532d, #0f172a); }
+body.bg-theme-9 { background: linear-gradient(120deg, #0f172a, #334155, #1e1b4b); }
+body.bg-theme-10 { background: linear-gradient(120deg, #111827, #1e3a8a, #0f172a); }
+
+body.bg-theme-7,
+body.bg-theme-9 {
+  background-size: 170% 170%;
+  animation: softGradientFlow 16s ease-in-out infinite;
+}
+
+body.bg-theme-7::before,
+body.bg-theme-9::before {
+  opacity: .2;
+  filter: saturate(1.25) blur(.2px);
+  animation: bgStarMove 5.8s linear infinite;
+}
+
+body.bg-theme-7::after,
+body.bg-theme-9::after {
+  background:
+    radial-gradient(circle at 14% 35%, rgba(168,85,247,.26), transparent 48%),
+    radial-gradient(circle at 82% 62%, rgba(96,165,250,.24), transparent 52%),
+    radial-gradient(circle at 55% 20%, rgba(244,114,182,.14), transparent 46%);
+  animation: neonGlowDrift 9.5s ease-in-out infinite alternate;
+}
+body.bg-theme-2::before,
+body.bg-theme-3::before,
+body.bg-theme-4::before,
+body.bg-theme-5::before,
+body.bg-theme-6::before,
+body.bg-theme-7::before,
+body.bg-theme-8::before,
+body.bg-theme-9::before,
+body.bg-theme-10::before {
+  background-image: radial-gradient(circle, rgba(255,255,255,.25) 1px, transparent 1px);
+  background-size: 5px 5px;
+  opacity: .12;
+  animation: bgStarMove 4s linear infinite;
+}
+body.bg-theme-2::after,
+body.bg-theme-3::after,
+body.bg-theme-4::after,
+body.bg-theme-5::after,
+body.bg-theme-6::after,
+body.bg-theme-7::after,
+body.bg-theme-8::after,
+body.bg-theme-9::after,
+body.bg-theme-10::after {
+  background: radial-gradient(circle at 10% 30%, rgba(168,85,247,.14), transparent 45%), radial-gradient(circle at 85% 70%, rgba(59,130,246,.16), transparent 45%);
+}
+@keyframes bgStarMove {
+  from { transform: translateX(-8px) translateY(0); }
+  to { transform: translateX(8px) translateY(-8px); }
+}
+
+@keyframes softGradientFlow {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
+@keyframes neonGlowDrift {
+  0% { transform: translateY(0px) scale(1); opacity: .72; }
+  100% { transform: translateY(-10px) scale(1.06); opacity: .95; }
+}
+
+/* baluk.lens */
+.lens-panel {
+  position: fixed;
+  right: 18px;
+  bottom: 86px;
+  width: min(660px, 96vw);
+  max-height: 78vh;
+  overflow: auto;
+  background: #f8fafc;
+  border: 1px solid #cbd5e1;
+  border-radius: 16px;
+  box-shadow: 0 22px 48px rgba(15, 23, 42, .28);
+  padding: 12px;
+  z-index: 390;
+}
+.lens-panel.hidden { display: none !important; }
+
+.lens-panel.lens-analyzing {
+  box-shadow: 0 0 0 1px rgba(139, 92, 246, .45), 0 0 28px rgba(99, 102, 241, .35), 0 22px 48px rgba(15, 23, 42, .28);
+  animation: lensPulse 1.1s ease-in-out infinite alternate;
+}
+@keyframes lensPulse {
+  from { transform: translateY(0); }
+  to { transform: translateY(-1px); }
+}
+
+.lens-head { display: flex; justify-content: space-between; align-items: center; gap: 8px; }
+.lens-head h3 { margin: 0; color: #312e81; }
+.lens-head button { border: none; background: #e2e8f0; border-radius: 8px; padding: 5px 10px; cursor: pointer; }
+.lens-hint { margin: 8px 0; color: #475569; font-size: .86rem; }
+.lens-drop-zone {
+  border: 1px dashed #94a3b8;
+  border-radius: 12px;
+  min-height: 92px;
+  display: grid;
+  place-content: center;
+  gap: 7px;
+  text-align: center;
+  color: #475569;
+  background: #fff;
+}
+.lens-drop-zone.dragging { border-color: #6366f1; background: #eef2ff; }
+.lens-pick-btn {
+  border: none;
+  border-radius: 10px;
+  background: linear-gradient(135deg,#7c3aed,#4f46e5);
+  color: #fff;
+  padding: 8px 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.lens-canvas-wrap { margin-top: 10px; border-radius: 12px; overflow: hidden; border: 1px solid #cbd5e1; background: conic-gradient(#f8fafc 0 25%, #e2e8f0 0 50%, #f8fafc 0 75%, #e2e8f0 0) 0 0/16px 16px; }
+.lens-canvas-wrap.lens-canvas-live { box-shadow: inset 0 0 0 1px rgba(129, 140, 248, .3), 0 0 18px rgba(129, 140, 248, .35); }
+#lensCanvas { width: 100%; height: auto; display: block; cursor: crosshair; touch-action: none; }
+.lens-actions { display: flex; justify-content: flex-end; margin-top: 10px; }
+.lens-analyze-btn {
+  border: none;
+  border-radius: 10px;
+  background: linear-gradient(135deg,#111827,#312e81);
+  color: #fff;
+  padding: 8px 12px;
+  cursor: pointer;
+  font-weight: 700;
+}
+.lens-status {
+  margin-top: 8px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: #eef2ff;
+  border: 1px solid #c7d2fe;
+  color: #3730a3;
+  font-size: .86rem;
+}
+.lens-status-live {
+  animation: lensStatusShimmer 1.2s linear infinite;
+  background-image: linear-gradient(90deg, #eef2ff 0%, #ddd6fe 35%, #eef2ff 70%);
+  background-size: 220% 100%;
+}
+@keyframes lensStatusShimmer {
+  from { background-position: 200% 0; }
+  to { background-position: -20% 0; }
+}
+.lens-results {
+  margin-top: 10px;
+  padding: 10px;
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  background: #fff;
+}
+.lens-results h4 { margin: 0 0 8px; color: #0f172a; }
+.lens-results ol { margin: 0 0 8px 18px; padding: 0; }
+.lens-results a { color: #1d4ed8; text-decoration: none; }
+.lens-results a:hover { text-decoration: underline; }
+
+@media (max-width: 760px) {
+  #lensCanvas { cursor: default; }
+  .lens-panel {
+    left: 8px;
+    right: 8px;
+    bottom: 74px;
+    width: auto;
+    max-height: 68vh;
+  }
+}
+
+
+.typing-active::after {
+  content: "▌";
+  display: inline-block;
+  margin-left: 2px;
+  color: #6366f1;
+  animation: typingCaretBlink 0.8s steps(1) infinite;
+}
+
+@keyframes typingCaretBlink {
+  0%, 49% { opacity: 1; }
+  50%, 100% { opacity: 0; }
+}
+
+/* BALL.E visual refinement overrides */
+.app.balle-bg-active::before {
+  background:
+    radial-gradient(circle at 10% 20%, rgba(34,197,94,.42) 0 8%, rgba(34,197,94,0) 9%),
+    radial-gradient(circle at 25% 72%, rgba(250,204,21,.45) 0 8%, rgba(250,204,21,0) 9%),
+    radial-gradient(circle at 45% 32%, rgba(239,68,68,.4) 0 8%, rgba(239,68,68,0) 9%),
+    radial-gradient(circle at 72% 62%, rgba(168,85,247,.44) 0 8%, rgba(168,85,247,0) 9%),
+    radial-gradient(circle at 87% 26%, rgba(250,204,21,.34) 0 7%, rgba(250,204,21,0) 8%),
+    linear-gradient(120deg, rgba(16,185,129,.18), rgba(234,179,8,.18), rgba(239,68,68,.16), rgba(168,85,247,.22));
+  background-size: 180% 180%;
+  animation: balleBackdropFloat 10s ease-in-out infinite alternate, balleBgShift 7s linear infinite;
+}
+@keyframes balleBgShift { from { background-position: 0% 50%; } to { background-position: 160% 50%; } }
+
+.balle-stage-canvas {
+  border: 1px solid #d4d4d8;
+  background: #e5e7eb;
+}
+.balle-stage-canvas::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(95deg, transparent 0%, rgba(255,255,255,.5) 48%, transparent 100%);
+  transform: translateX(-120%);
+  animation: balleCrossShine 2s linear infinite;
+}
+@keyframes balleCrossShine {
+  from { transform: translateX(-120%); }
+  to { transform: translateX(120%); }
+}
+
+.balle-core-title {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  font-weight: 900;
+  letter-spacing: .08em;
+  background: linear-gradient(120deg, #22c55e, #facc15, #ef4444, #a855f7, #22c55e);
+  background-size: 260% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-shadow: 0 0 20px rgba(255,255,255,.35);
+  animation: balleWordGlow 2.8s linear infinite;
+  z-index: 3;
+}
+@keyframes balleWordGlow {
+  from { background-position: 0% 50%; filter: drop-shadow(0 0 8px rgba(168,85,247,.45)); }
+  to { background-position: 220% 50%; filter: drop-shadow(0 0 16px rgba(234,179,8,.55)); }
+}
+.balle-neon-scan {
+  position: absolute;
+  inset: 10px;
+  border-radius: 12px;
+  border: 2px solid rgba(255,255,255,.35);
+  box-shadow: 0 0 14px rgba(34,197,94,.35), 0 0 18px rgba(250,204,21,.28), 0 0 20px rgba(239,68,68,.24), 0 0 22px rgba(168,85,247,.32);
+  animation: balleBorderPulse 2s ease-in-out infinite;
+  z-index: 2;
+}
+@keyframes balleBorderPulse {
+  0%,100% { opacity: .75; }
+  50% { opacity: 1; }
+}
+
+.balle-orb { filter: blur(.4px); opacity: .92; }
+
+
+.account-icon-btn.guest-default {
+  border-radius: 999px;
+  padding: 0;
+  background: #f8fafc;
+  border: 1.5px solid #cbd5e1;
+}
+.account-icon-btn .account-toggle-avatar { width: 30px; height: 30px; display: block; }
+.account-icon-btn.has-photo {
+  border-radius: 999px;
+  overflow: hidden;
+  padding: 0;
+  border: 1.5px solid #cbd5e1;
+}
+.account-icon-btn.has-photo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.voice-mode-icon {
+  position: relative;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid #111;
+  display: grid;
+  place-items: center;
+}
+.voice-mode-icon .vm-lines {
+  width: 12px;
+  height: 14px;
+  border-left: 3px solid #111;
+  border-right: 3px solid #111;
+  opacity: .85;
+}
+.voice-mode-panel {
+  position: fixed;
+  inset: 0;
+  background: rgba(17,24,39,.38);
+  z-index: 120;
+  display: grid;
+  place-items: center;
+}
+.voice-mode-shell {
+  width: min(320px, 90vw);
+  height: min(620px, 84vh);
+  border-radius: 30px;
+  border: 3px solid #111;
+  background: #f8fafc;
+  padding: 18px;
+  display: grid;
+  grid-template-rows: 1fr auto auto;
+}
+.voice-mode-core {
+  align-self: center;
+  justify-self: center;
+  width: min(230px, 62vw);
+  aspect-ratio: 1/1;
+  border-radius: 50%;
+  border: 3px solid #111;
+  display: grid;
+  place-items: center;
+  position: relative;
+  background: radial-gradient(circle at 35% 35%, #fff, #eef2ff);
+}
+.voice-logo {
+  font-weight: 900;
+  color: #334155;
+  letter-spacing: .03em;
+}
+.voice-mode-status {
+  text-align: center;
+  color: #475569;
+  font-weight: 700;
+}
+.voice-mode-actions {
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
-
-#arama {
-  padding: 8px;
-  border-radius: 5px;
-  border: none;
+.voice-mute-btn,
+.voice-web-btn,
+.voice-close-btn {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  border: 2px solid #111;
+  background: #fff;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+.voice-mute-btn {
+  background: #ef4444;
+  color: #fff;
+}
+.voice-mute-btn.muted { background: #9ca3af; }
+.voice-web-btn {
+  background: #dbeafe;
+  color: #0f172a;
+  border-color: #93c5fd;
+  box-shadow: 0 8px 18px rgba(96,165,250,.35);
+}
+.voice-web-btn.active {
+  background: linear-gradient(135deg, #60a5fa, #38bdf8);
+  color: #fff;
+  border-color: #38bdf8;
 }
 
-.video-galeri {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 15px;
-  justify-content: center;
-  padding: 20px;
-}
 
-.video {
-  background: #1a1a1a;
-  padding: 10px;
-  border-radius: 10px;
-  width: 200px;
-  text-align: center;
+
+.voice-mode-panel.hidden { display: none !important; }
+.voice-center-logo {
+  width: min(150px, 45vw);
+  color: #111827;
+  filter: drop-shadow(0 0 8px rgba(99,102,241,.35));
+}
+.voice-mode-core.speaking .voice-center-logo {
+  color: #4f46e5;
+  animation: voiceLogoPulse .9s ease-in-out infinite;
+}
+@keyframes voiceLogoPulse {
+  0%,100% { transform: scale(1); }
+  50% { transform: scale(1.08); }
+}
+.voice-close-btn { z-index: 2; }
+
+
+#chatSubmitBtn .voice-mode-icon {
   position: relative;
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
 }
-
-.video video {
-  width: 100%;
-  border-radius: 5px;
-}
-
-.video button {
+#chatSubmitBtn .voice-mode-icon .vm-wave {
   position: absolute;
-  top: 5px;
-  right: 5px;
-  background: red;
-  color: white;
-  border: none;
+  inset: 0;
   border-radius: 50%;
-  padding: 5px;
-  cursor: pointer;
+  border: 2px solid currentColor;
+  opacity: .88;
 }
-
-#profil {
-  text-align: center;
-  margin-top: 20px;
-}
-
-#profil img {
-  width: 100px;
-  height: 100px;
+#chatSubmitBtn .voice-mode-icon .vm-wave::before,
+#chatSubmitBtn .voice-mode-icon .vm-wave::after {
+  content: "";
+  position: absolute;
+  inset: -5px;
+  border: 2px solid currentColor;
   border-radius: 50%;
-  object-fit: cover;
-  background-color: white;
+  opacity: .38;
 }
-
-#videoDosyasi, #videoBaslik {
-  display: block;
-  margin: 10px auto;
-  padding: 8px;
-  width: 80%;
+#chatSubmitBtn .voice-mode-icon .vm-wave::after {
+  inset: -10px;
+  opacity: .2;
 }
-
-nav#altMenu {
-  position: fixed;
-  bottom: 0;
-  width: 100%;
-  background: #111;
+#chatSubmitBtn .voice-mode-icon .vm-bars {
+  position: relative;
+  z-index: 1;
   display: flex;
-  justify-content: space-around;
-  padding: 10px 0;
+  align-items: end;
+  gap: 3px;
+  height: 12px;
+}
+#chatSubmitBtn .voice-mode-icon .vm-bars span {
+  width: 3px;
+  border-radius: 999px;
+  background: currentColor;
+  animation: vmBarsPulse 1.1s ease-in-out infinite;
+}
+#chatSubmitBtn .voice-mode-icon .vm-bars span:nth-child(1) { height: 6px; animation-delay: 0s; }
+#chatSubmitBtn .voice-mode-icon .vm-bars span:nth-child(2) { height: 11px; animation-delay: .12s; }
+#chatSubmitBtn .voice-mode-icon .vm-bars span:nth-child(3) { height: 8px; animation-delay: .24s; }
+@keyframes vmBarsPulse {
+  0%, 100% { transform: scaleY(.82); opacity: .72; }
+  50% { transform: scaleY(1.08); opacity: 1; }
 }
 
-nav button {
-  background: none;
-  border: none;
-  color: white;
-  font-size: 24px;
-  cursor: pointer;
+
+/* Voice/send unified button refinements */
+#chatSubmitBtn {
+  background: #fff;
+  color: #111827;
+  border-color: #111827;
+}
+#chatSubmitBtn.voice-launch {
+  border-radius: 14px;
+  border-color: #7c3aed;
+  background: linear-gradient(135deg, #7c3aed, #9333ea);
+  color: #fff;
+  box-shadow: 0 8px 18px rgba(124,58,237,.32);
+}
+#chatSubmitBtn.voice-launch .voice-mode-icon {
+  border-color: rgba(255,255,255,.95);
+}
+#chatSubmitBtn.voice-launch .voice-mode-icon .vm-wave,
+#chatSubmitBtn.voice-launch .voice-mode-icon .vm-wave::before,
+#chatSubmitBtn.voice-launch .voice-mode-icon .vm-wave::after,
+#chatSubmitBtn.voice-launch .voice-mode-icon .vm-bars span {
+  color: rgba(255,255,255,.95);
+  border-color: rgba(255,255,255,.95);
+  background: rgba(255,255,255,.95);
+}
+
+/* Full-screen voice panel */
+.voice-mode-panel {
+  inset: 0;
+  background: rgba(15, 23, 42, .5);
+  backdrop-filter: blur(2px);
+}
+.voice-mode-shell {
+  width: min(460px, 96vw);
+  height: min(760px, 94vh);
+  border-radius: 34px;
+  border: 3px solid #0f172a;
+  background: linear-gradient(180deg, #f8fafc, #eef2ff);
+  box-shadow: 0 22px 46px rgba(15,23,42,.34);
+}
+.voice-mode-core {
+  width: min(250px, 66vw);
+  border-color: #0f172a;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,.65), 0 8px 18px rgba(15,23,42,.18);
+}
+.voice-mode-actions {
+  padding: 0 2px 4px;
+}
+.voice-mute-btn {
+  background: linear-gradient(180deg, #ef4444, #dc2626);
+  color: #fff;
+  border-color: #111;
+}
+.voice-close-btn {
+  background: #fff;
+  color: #111;
+  border-color: #111;
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "index.html", "use": "@vercel/static" },
+    { "src": "assets/**", "use": "@vercel/static" },
+    { "src": "style.css", "use": "@vercel/static" },
+    { "src": "script.js", "use": "@vercel/static" }
+  ],
+  "routes": [
+    { "src": "/assets/(.*)", "dest": "/assets/$1" },
+    { "src": "/style.css", "dest": "/style.css" },
+    { "src": "/script.js", "dest": "/script.js" },
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Replace the previous small demo with a full client-side single-page static app named `baluk.ai` that offers a conversational assistant, memory, voice, image-lens, math studio and premium features. 
- Prepare repository and site for static hosting workflows and prevent accidental binary commits by adding attributes and ignore rules.

### Description

- Add deployment and repo files: `.gitattributes`, `.gitignore`, `netlify.toml`, `vercel.json`, and `package.json` to support static builds and hosting. 
- Replace and expand `index.html` to provide a new intro gate, transition, main app shell (`#appRoot`), UI panels (memory, account, lens, math studio, premium, background settings), accessibility attributes and form wiring. 
- Replace `script.js` with a comprehensive client-side application implementing chat processing, model selection, memory persistence, web search integration, Baluk.lens (image analysis via TFJS/mobilenet), voice input/output, background audio, premium flow, profanity/ban rules, geometry/math helpers, UI state management and many utility functions. 
- Replace `style.css` with a complete theming and responsive stylesheet for the new UI (intro, transitions, topbar, chat, panels, lens, math studio, animations and premium visuals).

### Testing

- Executed the trivial build script with `npm run build` (defined in `package.json`) and it completed successfully. 
- No automated unit or integration tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69860b89f670832cb0acddb94a94102b)