### PR TITLE
Implement Baluk Screatch browser UI with Baluk.ai side panel

### DIFF
--- a/assets/baluk-logo.svg
+++ b/assets/baluk-logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 150" fill="none">
+  <path d="M40 75C92 22 196 16 270 43C314 59 346 83 380 112" stroke="#101114" stroke-width="9" stroke-linecap="round"/>
+  <path d="M40 75C90 126 191 131 281 97" stroke="#101114" stroke-width="9" stroke-linecap="round"/>
+  <path d="M350 70L388 49L375 83L403 111L364 88" stroke="#101114" stroke-width="9" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="86" cy="74" r="6" fill="#101114"/>
+  <path d="M122 58C132 72 132 91 121 103" stroke="#101114" stroke-width="8" stroke-linecap="round"/>
+  <text x="42" y="144" font-family="Arial, sans-serif" font-size="54" fill="#101114">baluk.ai</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,15 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div class="app-shell">
+  <div id="introOverlay" class="intro-overlay">
+    <div class="intro-card" id="introCard">
+      <div class="intro-glow"></div>
+      <div class="intro-title">✦ Baluk Screatch</div>
+    </div>
+    <p class="intro-subtitle" id="introSubtitle">AI destekli tarayıcı</p>
+  </div>
+
+  <div class="app-shell app-hidden" id="appShell">
     <header class="topbar">
       <div class="tab-row">
         <button class="tab active">Yeni Sekme</button>

--- a/index.html
+++ b/index.html
@@ -2,49 +2,65 @@
 <html lang="tr">
 <head>
   <meta charset="UTF-8">
-  <title>MemTube</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Baluk Screatch</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
-  <!-- Kayıt Ekranı -->
-  <div id="girisEkrani">
-    <h2>MemTube'e Giriş</h2>
-    <input type="text" id="kullaniciAdi" placeholder="Takma Ad (zorunlu)">
-    <input type="file" id="profilResmi" accept="image/*">
-    <button onclick="girisYap()">Giriş Yap</button>
-  </div>
-
-  <!-- Ana Ekran -->
-  <div id="anaEkran" class="gizli">
-    <header>
-      <h1>📺 MemTube</h1>
-      <input type="text" id="arama" placeholder="Ara...">
+  <div class="app-shell">
+    <header class="topbar">
+      <div class="tab-row">
+        <button class="tab active">Yeni Sekme</button>
+      </div>
+      <div class="browser-controls">
+        <button id="geriBtn" title="Geri">◀</button>
+        <button id="ileriBtn" title="İleri">▶</button>
+        <button id="yenileBtn" title="Yenile">↻</button>
+        <button id="newTabBtn" title="Yeni pencere">＋</button>
+      </div>
+      <input id="adresCubugu" type="text" placeholder="Bağlantı aç (https://...)" />
+      <button id="balukPanelBtn" class="baluk-mini">Baluk.ai</button>
     </header>
 
-    <!-- Ana Sayfa -->
-    <main id="anaSayfa">
-      <div id="videoListe" class="video-galeri"></div>
+    <main class="content-grid">
+      <section class="search-screen" id="homeView">
+        <h1>Baluk Screatch</h1>
+        <form id="aramaForm" class="search-box">
+          <input id="aramaInput" type="text" placeholder="Web'de ara..." required>
+          <button type="submit">Ara</button>
+        </form>
+        <div id="sonuclar" class="results"></div>
+      </section>
+
+      <section class="web-screen hidden" id="webView">
+        <iframe id="siteFrame" title="Baluk Screatch görüntüleyici"></iframe>
+      </section>
+
+      <aside class="ai-panel" id="aiPanel">
+        <h2>Baluk.ai Yan Panel</h2>
+        <div id="authArea">
+          <p>En iyi cevaplar için oturum açın.</p>
+          <form id="loginForm" class="stacked-form">
+            <input type="email" id="mail" placeholder="Gmail / Email" required>
+            <input type="text" id="ad" placeholder="İsim" required>
+            <input type="text" id="soyad" placeholder="Soyisim" required>
+            <label>Profil resmi (isteğe bağlı)</label>
+            <input type="file" id="profil" accept="image/*">
+            <button type="submit">Oturum Aç</button>
+          </form>
+        </div>
+
+        <div id="assistantArea" class="hidden">
+          <p id="welcomeText"></p>
+          <form id="aiForm" class="stacked-form">
+            <textarea id="aiSoru" rows="4" placeholder="Örn: Bu web sitesi ne zaman kuruldu?" required></textarea>
+            <button type="submit">Baluk.ai'ye Sor</button>
+          </form>
+          <div id="thinking" class="thinking hidden">Baluk.ai düşünüyor...</div>
+          <div id="aiCevap" class="ai-answer"></div>
+        </div>
+      </aside>
     </main>
-
-    <!-- Hesabım Sayfası -->
-    <section id="hesabim" class="gizli">
-      <div id="profil">
-        <img id="profilGorsel" alt="Profil Resmi">
-        <h3 id="kAdi"></h3>
-      </div>
-      <h4>Videolarım</h4>
-      <input type="file" id="videoDosyasi" accept="video/*">
-      <input type="text" id="videoBaslik" placeholder="Video Başlığı">
-      <button onclick="videoYukle()">+ Yükle</button>
-      <div id="videolar" class="video-galeri"></div>
-    </section>
-
-    <!-- Alt Menü -->
-    <nav id="altMenu">
-      <button onclick="goAnaSayfa()">🏠</button>
-      <button onclick="goHesabim()">👤</button>
-    </nav>
   </div>
 
   <script src="script.js"></script>

--- a/index.html
+++ b/index.html
@@ -17,9 +17,11 @@
 
   <div class="app-shell app-hidden" id="appShell">
     <header class="topbar">
-      <div class="tab-row">
-        <button class="tab active">Yeni Sekme</button>
+      <div class="tab-strip">
+        <div id="tabs" class="tabs"></div>
+        <button id="addTabBtn" class="tab-plus" title="Sekme aç">＋</button>
       </div>
+
       <div class="browser-controls">
         <button id="geriBtn" title="Geri">◀</button>
         <button id="ileriBtn" title="İleri">▶</button>
@@ -74,12 +76,21 @@
             </div>
           </div>
 
+          <div class="quick-prompts" id="quickPrompts"></div>
+
           <div class="thinking-box hidden" id="thinkingBox">
             <img src="assets/baluk-logo.svg" alt="Baluk.ai" class="spin-logo" id="spinLogo">
             <p id="thinkingText">Baluk.ai düşünüyor...</p>
           </div>
 
           <div id="aiCevap" class="ai-answer"></div>
+
+          <div class="agent-badge hidden" id="agentBadge">
+            Agent Mode 2.0 açık
+            <button id="agentBadgeClose" type="button">✕</button>
+          </div>
+
+          <div class="selected-targets" id="selectedTargets"></div>
 
           <form id="aiForm" class="ask-bar">
             <button type="button" id="plusBtn" class="plus-btn">＋</button>
@@ -88,7 +99,7 @@
           </form>
 
           <div id="agentMenu" class="agent-menu hidden">
-            <button type="button" id="agentModeBtn">Agent Mode</button>
+            <button type="button" id="agentModeBtn">Agent Mode 2.0</button>
           </div>
         </div>
       </aside>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,6 @@
 
       <section class="web-screen hidden" id="webView">
         <iframe id="siteFrame" title="Baluk Screatch görüntüleyici"></iframe>
-      </section>
 
       <aside class="ai-panel hidden" id="aiPanel">
         <div class="panel-head">
@@ -88,12 +87,10 @@
           <div class="agent-badge hidden" id="agentBadge">
             <span>Agent Mode 2.0 açık</span>
             <div class="agent-badge-actions">
-              <button id="markToggleBtn" type="button" title="İşaretleme modu">✎</button>
               <button id="agentBadgeClose" type="button" title="Agent Mode kapat">✕</button>
             </div>
           </div>
 
-          <div class="selected-targets" id="selectedTargets"></div>
 
           <form id="aiForm" class="ask-bar">
             <button type="button" id="plusBtn" class="plus-btn">＋</button>

--- a/index.html
+++ b/index.html
@@ -86,8 +86,11 @@
           <div id="aiCevap" class="ai-answer"></div>
 
           <div class="agent-badge hidden" id="agentBadge">
-            Agent Mode 2.0 açık
-            <button id="agentBadgeClose" type="button">✕</button>
+            <span>Agent Mode 2.0 açık</span>
+            <div class="agent-badge-actions">
+              <button id="markToggleBtn" type="button" title="İşaretleme modu">✎</button>
+              <button id="agentBadgeClose" type="button" title="Agent Mode kapat">✕</button>
+            </div>
           </div>
 
           <div class="selected-targets" id="selectedTargets"></div>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
         <button id="newTabBtn" title="Yeni pencere">＋</button>
       </div>
       <input id="adresCubugu" type="text" placeholder="Bağlantı aç (https://...)" />
-      <button id="balukPanelBtn" class="baluk-mini">Baluk.ai</button>
+      <button id="balukPanelBtn" class="baluk-mini">✦ Baluk.ai</button>
     </header>
 
     <main class="content-grid">
@@ -36,8 +36,12 @@
         <iframe id="siteFrame" title="Baluk Screatch görüntüleyici"></iframe>
       </section>
 
-      <aside class="ai-panel" id="aiPanel">
-        <h2>Baluk.ai Yan Panel</h2>
+      <aside class="ai-panel hidden" id="aiPanel">
+        <div class="panel-head">
+          <h2>Baluk.ai</h2>
+          <button id="closePanelBtn" class="close-panel">✕</button>
+        </div>
+
         <div id="authArea">
           <p>En iyi cevaplar için oturum açın.</p>
           <form id="loginForm" class="stacked-form">
@@ -50,14 +54,31 @@
           </form>
         </div>
 
-        <div id="assistantArea" class="hidden">
-          <p id="welcomeText"></p>
-          <form id="aiForm" class="stacked-form">
-            <textarea id="aiSoru" rows="4" placeholder="Örn: Bu web sitesi ne zaman kuruldu?" required></textarea>
-            <button type="submit">Baluk.ai'ye Sor</button>
-          </form>
-          <div id="thinking" class="thinking hidden">Baluk.ai düşünüyor...</div>
+        <div id="assistantArea" class="hidden assistant-layout">
+          <div class="profile-card">
+            <img id="profileAvatar" alt="Profil" src="" />
+            <div>
+              <strong id="welcomeText"></strong>
+              <p id="profileMail"></p>
+            </div>
+          </div>
+
+          <div class="thinking-box hidden" id="thinkingBox">
+            <div class="spin-logo" id="spinLogo">B</div>
+            <p id="thinkingText">Baluk.ai düşünüyor...</p>
+          </div>
+
           <div id="aiCevap" class="ai-answer"></div>
+
+          <form id="aiForm" class="ask-bar">
+            <button type="button" id="plusBtn" class="plus-btn">＋</button>
+            <textarea id="aiSoru" rows="1" placeholder="Baluk.ai'ye yaz..." required></textarea>
+            <button type="submit" id="sendBtn">Gönder</button>
+          </form>
+
+          <div id="agentMenu" class="agent-menu hidden">
+            <button type="button" id="agentModeBtn">Agent Mode</button>
+          </div>
         </div>
       </aside>
     </main>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
       <button id="balukPanelBtn" class="baluk-mini">✦ Baluk.ai</button>
     </header>
 
-    <main class="content-grid">
+    <main class="content-grid" id="contentGrid">
       <section class="search-screen" id="homeView">
         <h1>Baluk Screatch</h1>
         <form id="aramaForm" class="search-box">
@@ -38,7 +38,10 @@
 
       <aside class="ai-panel hidden" id="aiPanel">
         <div class="panel-head">
-          <h2>Baluk.ai</h2>
+          <div class="logo-head">
+            <img src="assets/baluk-logo.svg" alt="Baluk.ai logosu" class="baluk-logo-head">
+            <h2>Baluk.ai</h2>
+          </div>
           <button id="closePanelBtn" class="close-panel">✕</button>
         </div>
 
@@ -64,7 +67,7 @@
           </div>
 
           <div class="thinking-box hidden" id="thinkingBox">
-            <div class="spin-logo" id="spinLogo">B</div>
+            <img src="assets/baluk-logo.svg" alt="Baluk.ai" class="spin-logo" id="spinLogo">
             <p id="thinkingText">Baluk.ai düşünüyor...</p>
           </div>
 

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     <p class="intro-subtitle" id="introSubtitle">AI destekli tarayıcı</p>
   </div>
 
-  <div class="app-shell app-hidden" id="appShell">
+  <div class="app-shell" id="appShell">
     <header class="topbar">
       <div class="tab-strip">
         <div id="tabs" class="tabs"></div>

--- a/script.js
+++ b/script.js
@@ -5,25 +5,25 @@ const state = {
   thinkingTimer: null,
   thinkingTicker: null,
   agentModeActive: false,
-  selectedInput: null,
+  agentBusy: false,
 };
 
 const THINKING_LINES = [
   "Baluk.ai düşünüyor...",
   "Web sayfasına bakıyorum...",
-  "Hakkında/başlık bilgilerini tarıyorum...",
+  "Arama sonuçlarını inceliyorum...",
   "Kaynaklardan kısa özet çıkarıyorum...",
   "Cevabı netleştiriyorum..."
 ];
 
 const SITE_HINTS = {
-  "youtube.com": { name: "YouTube", purpose: "kullanıcıların video izleyip içerik yüklediği bir video paylaşım platformu", company: "Google / Alphabet", year: "2005" },
-  "google.com": { name: "Google", purpose: "web araması ve internet servisleri sağlamak", company: "Google / Alphabet", year: "1998" },
-  "wikipedia.org": { name: "Wikipedia", purpose: "özgür ansiklopedi içeriği sağlamak", company: "Wikimedia Foundation", year: "2001" },
-  "github.com": { name: "GitHub", purpose: "yazılım projelerini Git tabanlı barındırma ve işbirliği", company: "GitHub (Microsoft)", year: "2008" },
-  "instagram.com": { name: "Instagram", purpose: "fotoğraf/video paylaşımı ve sosyal etkileşim", company: "Meta", year: "2010" },
-  "x.com": { name: "X", purpose: "kısa gönderilerle sosyal paylaşım ve haber akışı", company: "X Corp.", year: "2006" },
-  "twitter.com": { name: "Twitter (X)", purpose: "kısa gönderilerle sosyal paylaşım ve haber akışı", company: "X Corp.", year: "2006" }
+  "youtube.com": { name: "YouTube", purpose: "kullanıcıların video izleyip içerik yüklediği bir video paylaşım platformu", company: "Google / Alphabet", year: "2005", wiki: "YouTube" },
+  "google.com": { name: "Google", purpose: "web araması ve internet servisleri sağlamak", company: "Google / Alphabet", year: "1998", wiki: "Google" },
+  "wikipedia.org": { name: "Wikipedia", purpose: "özgür ansiklopedi içeriği sağlamak", company: "Wikimedia Foundation", year: "2001", wiki: "Wikipedia" },
+  "github.com": { name: "GitHub", purpose: "yazılım projelerini Git tabanlı barındırma ve işbirliği", company: "GitHub (Microsoft)", year: "2008", wiki: "GitHub" },
+  "instagram.com": { name: "Instagram", purpose: "fotoğraf/video paylaşımı ve sosyal etkileşim", company: "Meta", year: "2010", wiki: "Instagram" },
+  "x.com": { name: "X", purpose: "kısa gönderilerle sosyal paylaşım ve haber akışı", company: "X Corp.", year: "2006", wiki: "Twitter" },
+  "twitter.com": { name: "Twitter (X)", purpose: "kısa gönderilerle sosyal paylaşım ve haber akışı", company: "X Corp.", year: "2006", wiki: "Twitter" }
 };
 
 const el = {
@@ -59,9 +59,16 @@ const el = {
   agentModeBtn: document.getElementById("agentModeBtn"),
 };
 
+const agentCursor = document.createElement("div");
+agentCursor.id = "agentCursor";
+agentCursor.style.cssText = "position:fixed;width:18px;height:18px;border:2px solid #b78cff;background:radial-gradient(circle,#6b24dd 0%,#141020 75%);border-radius:50%;box-shadow:0 0 18px rgba(141,69,255,.85);z-index:9999;pointer-events:none;opacity:0;transform:translate(-50%,-50%);transition:left .35s ease, top .35s ease, opacity .2s ease;";
+document.body.appendChild(agentCursor);
+
 function escapeHtml(text) {
   return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#039;");
 }
+
+function sleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
 function ensureUrl(value) { return /^https?:\/\//i.test(value) ? value : `https://${value}`; }
 
 function setPanel(open) {
@@ -76,7 +83,6 @@ function openUrl(url, addToHistory = true) {
   el.adresCubugu.value = safe;
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
-  state.selectedInput = null;
 
   if (addToHistory) {
     state.history = state.history.slice(0, state.index + 1);
@@ -97,8 +103,23 @@ function parseSite(urlCandidate) {
     name: base.charAt(0).toUpperCase() + base.slice(1),
     purpose: "webde bilgi/hizmet sunmak",
     company: "kesin şirket bilgisi için site hakkında bölümü gerekir",
-    year: "kuruluş yılı net değil"
+    year: "kuruluş yılı net değil",
+    wiki: base
   };
+}
+
+async function fetchWikipediaSnippet(term) {
+  try {
+    const api = `https://tr.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(term)}`;
+    const res = await fetch(api);
+    if (!res.ok) return "";
+    const data = await res.json();
+    const text = (data.extract || "").trim();
+    if (!text) return "";
+    return text.slice(0, 200);
+  } catch {
+    return "";
+  }
 }
 
 function renderAuth() {
@@ -194,77 +215,91 @@ function stopThinking() {
   document.body.classList.remove("web-glow");
 }
 
-function buildAiAnswer(q) {
+async function buildAiAnswer(q) {
   const currentUrl = el.adresCubugu.value || q.match(/https?:\/\/\S+/)?.[0] || "";
   const site = parseSite(currentUrl || "example.com");
   const siteName = site?.name || "Bu site";
 
   if (/kaç yılında|ne zaman/i.test(q)) return `${siteName} için bulduğum bilgi: kuruluş yılı ${site.year}.`;
   if (/hangi şirket|kim tarafından/i.test(q)) return `${siteName} için şirket/kurucu bilgisi: ${site.company}.`;
-  if (/amacı|ne için|ne işe yarar/i.test(q)) return `${siteName}, ${site.purpose}.`;
+
+  if (/youtube|wikipedia|github|instagram|google|twitter|x\.com|web sitesi|site hakkında|hakkında bilgi|amaç/i.test(q)) {
+    const wiki = await fetchWikipediaSnippet(site.wiki || siteName);
+    if (wiki) {
+      return `${siteName}: ${site.purpose}.\n\nWikipedia özeti (ilk 200 karakter): ${wiki}`;
+    }
+    return `${siteName}: ${site.purpose}. Şirket: ${site.company}. Kuruluş: ${site.year}.`;
+  }
 
   return `${siteName} özeti: ${site.year} yılında kurulduğu biliniyor, ${site.company} tarafından geliştirildi/işletiliyor ve ana amacı ${site.purpose}.`;
 }
 
-function bindAgentSelectionToIframe() {
-  if (!state.agentModeActive) return;
+function parseAgentCommand(text) {
+  const cleaned = text.toLowerCase().trim();
+  const searchMatch = cleaned.match(/(?:arat|ara)\s*:?\s*(.+?)(?:\s+çıkan|$)/i) || cleaned.match(/(.+?)\s+arat/i);
+  const query = searchMatch ? searchMatch[1].trim() : text.trim();
+
+  const indexMatch = cleaned.match(/(\d+)\.?\s*(link|sonuç)/i);
+  const index = indexMatch ? Math.max(1, Number(indexMatch[1])) : 1;
+
+  return { query, index };
+}
+
+function moveCursorTo(element) {
+  const rect = element.getBoundingClientRect();
+  agentCursor.style.opacity = "1";
+  agentCursor.style.left = `${rect.left + rect.width / 2}px`;
+  agentCursor.style.top = `${rect.top + rect.height / 2}px`;
+}
+
+function hideCursor() {
+  agentCursor.style.opacity = "0";
+}
+
+async function runAgentSearchFlow(commandText) {
+  if (state.agentBusy) return "Agent Mode meşgul, işlem bitmesini bekle.";
+  state.agentBusy = true;
 
   try {
-    const doc = el.siteFrame.contentDocument;
-    if (!doc) throw new Error("iframe erişimi yok");
+    const { query, index } = parseAgentCommand(commandText);
+    if (!query) return "Agent Mode: Aratılacak ifadeyi anlayamadım.";
 
-    doc.querySelectorAll("input, textarea").forEach((node) => {
-      node.classList.remove("baluk-agent-target");
-      node.style.outline = "1px dashed rgba(141,69,255,0.45)";
-    });
+    el.homeView.classList.remove("hidden");
+    el.webView.classList.add("hidden");
 
-    doc.addEventListener("click", (event) => {
-      if (!state.agentModeActive) return;
-      const t = event.target;
-      if (!(t instanceof HTMLElement)) return;
-      if (!(t.matches("input") || t.matches("textarea"))) return;
+    moveCursorTo(el.aramaInput);
+    await sleep(300);
+    el.aramaInput.focus();
+    el.aramaInput.value = "";
 
-      event.preventDefault();
-      event.stopPropagation();
+    for (const ch of query) {
+      el.aramaInput.value += ch;
+      await sleep(35);
+    }
 
-      if (state.selectedInput) {
-        state.selectedInput.style.outline = "1px dashed rgba(141,69,255,0.45)";
-      }
+    await sleep(240);
+    el.aramaForm.requestSubmit();
+    await sleep(1300);
 
-      state.selectedInput = t;
-      t.style.outline = "2px solid #b486ff";
-      el.aiCevap.textContent = "Alan seçildi. Şimdi Baluk.ai kutusuna ne yazılacağını yazıp Gönder'e bas.";
-    }, { capture: true });
+    const cards = [...document.querySelectorAll(".result-item")];
+    if (!cards.length) return `"${query}" için sonuç bulunamadı.`;
 
-    el.aiCevap.textContent = "Agent Mode açık: Form alanına tıkla ve hedefi seç.";
-  } catch {
-    el.aiCevap.textContent = "Agent Mode için bu sayfada seçim yapılamıyor (farklı domain güvenlik sınırı). Aynı domain sayfada deneyebilirsin.";
+    const targetCard = cards[Math.min(index - 1, cards.length - 1)];
+    const openBtn = targetCard.querySelector(".open-link");
+    if (!openBtn) return "Hedef bağlantı bulunamadı.";
+
+    moveCursorTo(openBtn);
+    await sleep(420);
+    openBtn.click();
+    await sleep(420);
+
+    return `Agent Mode tamamlandı: "${query}" aratıldı ve ${Math.min(index, cards.length)}. link açıldı.`;
+  } finally {
+    hideCursor();
+    state.agentBusy = false;
+    state.agentModeActive = false;
   }
 }
-
-function handleAgentWrite(commandText) {
-  if (!state.agentModeActive) return false;
-
-  if (!state.selectedInput) {
-    el.aiCevap.textContent = "Önce bir input/textarea alanı seçmelisin. Agent Mode açık.";
-    return true;
-  }
-
-  state.selectedInput.focus();
-  state.selectedInput.value = commandText;
-  state.selectedInput.dispatchEvent(new Event("input", { bubbles: true }));
-  state.selectedInput.dispatchEvent(new Event("change", { bubbles: true }));
-  el.aiCevap.textContent = `Yazıldı: "${commandText}"`;
-
-  state.agentModeActive = false;
-  state.selectedInput.style.outline = "1px dashed rgba(141,69,255,0.45)";
-  state.selectedInput = null;
-  return true;
-}
-
-el.siteFrame.addEventListener("load", () => {
-  if (state.agentModeActive) bindAgentSelectionToIframe();
-});
 
 el.aramaForm.addEventListener("submit", async (event) => {
   event.preventDefault();
@@ -284,7 +319,7 @@ el.adresCubugu.addEventListener("keydown", (e) => { if (e.key === "Enter") openU
 el.geriBtn.addEventListener("click", () => { if (state.index > 0) openUrl(state.history[--state.index], false); });
 el.ileriBtn.addEventListener("click", () => { if (state.index < state.history.length - 1) openUrl(state.history[++state.index], false); });
 el.yenileBtn.addEventListener("click", () => { if (el.siteFrame.src) el.siteFrame.src = el.siteFrame.src; });
-el.newTabBtn.addEventListener("click", () => { el.homeView.classList.remove("hidden"); el.webView.classList.add("hidden"); el.adresCubugu.value = ""; state.selectedInput = null; });
+el.newTabBtn.addEventListener("click", () => { el.homeView.classList.remove("hidden"); el.webView.classList.add("hidden"); el.adresCubugu.value = ""; });
 el.balukPanelBtn.addEventListener("click", () => setPanel(el.aiPanel.classList.contains("hidden")));
 el.closePanelBtn.addEventListener("click", () => setPanel(false));
 
@@ -317,26 +352,27 @@ el.loginForm.addEventListener("submit", (e) => {
 el.plusBtn.addEventListener("click", () => el.agentMenu.classList.toggle("hidden"));
 el.agentModeBtn.addEventListener("click", () => {
   state.agentModeActive = true;
-  state.selectedInput = null;
   el.agentMenu.classList.add("hidden");
-  bindAgentSelectionToIframe();
+  el.aiCevap.textContent = "Agent Mode aktif. Komut ver: örn 'youtube arat çıkan 3. linke tıkla'. Link belirtilmezse 1. link açılır.";
+  setPanel(true);
 });
 
-el.aiForm.addEventListener("submit", (e) => {
+el.aiForm.addEventListener("submit", async (e) => {
   e.preventDefault();
   const q = el.aiSoru.value.trim();
   if (!q) return;
 
-  if (handleAgentWrite(q)) {
+  if (state.agentModeActive) {
+    el.aiCevap.textContent = await runAgentSearchFlow(q);
     el.aiSoru.value = "";
     return;
   }
 
   startThinking();
   clearTimeout(state.thinkingTimer);
-  state.thinkingTimer = setTimeout(() => {
+  state.thinkingTimer = setTimeout(async () => {
     stopThinking();
-    el.aiCevap.textContent = buildAiAnswer(q);
+    el.aiCevap.textContent = await buildAiAnswer(q);
     el.aiSoru.value = "";
   }, 20000);
 });

--- a/script.js
+++ b/script.js
@@ -129,14 +129,33 @@ function playIntroSound() {
 }
 
 function runIntro() {
-  const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-  const introDuration = reducedMotion ? 2350 : 4800;
-  playIntroSound();
-  setTimeout(() => {
+  const revealApp = () => {
+    if (!el.appShell || !el.introOverlay) return;
     el.introOverlay.classList.add("hidden");
     el.appShell.classList.remove("app-hidden");
     el.appShell.style.pointerEvents = "auto";
-  }, introDuration);
+  };
+
+  if (!el.appShell || !el.introOverlay) return;
+
+  const reducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
+  const introDuration = reducedMotion ? 2350 : 4800;
+
+  playIntroSound();
+
+  const finishTimer = setTimeout(revealApp, introDuration);
+  const hardFailSafeTimer = setTimeout(revealApp, introDuration + 2500);
+
+  const skipIntro = () => {
+    clearTimeout(finishTimer);
+    clearTimeout(hardFailSafeTimer);
+    revealApp();
+    window.removeEventListener("keydown", skipIntro);
+    window.removeEventListener("pointerdown", skipIntro);
+  };
+
+  window.addEventListener("keydown", skipIntro, { once: true });
+  window.addEventListener("pointerdown", skipIntro, { once: true });
 }
 
     b.dataset.tabId = String(tab.id);

--- a/script.js
+++ b/script.js
@@ -96,7 +96,7 @@ function playIntroSound() {
 
 function runIntro() {
   const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-  const introDuration = reducedMotion ? 350 : 2800;
+  const introDuration = reducedMotion ? 2350 : 4800;
 
   if (!el.introOverlay || !el.appShell) return;
 

--- a/script.js
+++ b/script.js
@@ -241,6 +241,25 @@ async function fetchWikipediaSnippet(topic) {
   } catch { return ""; }
 }
 
+
+function getCurrentSiteContext() {
+  const tab = currentTab();
+  const raw = tab?.url || el.adresCubugu.value || "";
+  if (!raw) return null;
+  try {
+    const u = new URL(raw);
+    const host = u.hostname.replace(/^www\./, "");
+    const name = host.split(".")[0] || host;
+    return { host, name: name.charAt(0).toUpperCase() + name.slice(1), url: u.href };
+  } catch {
+    return null;
+  }
+}
+
+function genericWebsiteDefinition() {
+  return `${highlight("Web sitesi")}, internet üzerinde çalışan sayfalardan oluşan bir bilgi/hizmet alanıdır. Genelde amacı içerik sunmak, işlem yaptırmak veya kullanıcıyı bir hizmete ulaştırmaktır.`;
+}
+
 function siteHintFromText(text) {
   const t = normalize(text);
   return ["youtube", "google", "wikipedia", "github", "instagram", "twitter", "shopify"].find((x) => t.includes(x)) || "web sitesi";
@@ -506,7 +525,19 @@ async function answerNormal(q) {
     return `Bunu otomatik yapmam için ${highlight("Agent Mode 2.0")} aç.`;
   }
 
-  const topic = siteHintFromText(q);
+  const asksCurrentSite = /\bbu\s+web\s*site|\bbu\s+site|ekrandaki\s+site|açık\s+site|şu\s+site/.test(low);
+  const asksGenericWeb = /web\s*site\s*nedir|webin\s+ne\s+oldu|web\s*sitenin\s+amacı\s+ne/.test(low);
+
+  if (asksGenericWeb && !asksCurrentSite) {
+    return genericWebsiteDefinition();
+  }
+
+  const current = getCurrentSiteContext();
+  if (asksCurrentSite && !current) {
+    return `Önce bir site aç, sonra ${highlight("bu web sitenin amacı ne")} diye sor; ekrandaki siteyi yorumlayayım.`;
+  }
+
+  const topic = asksCurrentSite ? (current?.name || "açık site") : siteHintFromText(q);
   const wiki = await fetchWikipediaSnippet(topic);
 
   if (/kuruluş|kaç yılında|ne zaman/.test(low)) {
@@ -516,11 +547,18 @@ async function answerNormal(q) {
     return `Site adı: ${highlight(topic)}.`;
   }
   if (/amaç|ne işe yarar|hakkında/.test(low)) {
-    return `${highlight(topic)} amacı:\n${escapeHtml(wiki || `${topic} genel olarak bilgi/hizmet sunar.`)}`;
+    const summary = wiki || `${topic} genel olarak bilgi/hizmet sunar.`;
+    if (asksCurrentSite) {
+      return `${highlight("Ekrandaki site")}: ${highlight(topic)}.
+${escapeHtml(summary)}`;
+    }
+    return `${highlight(topic)} amacı:
+${escapeHtml(summary)}`;
   }
-  return `${highlight(topic)} özeti:\n${escapeHtml(wiki || "Özet bulunamadı")}`;
-}
 
+  return `${highlight(topic)} özeti:
+${escapeHtml(wiki || "Özet bulunamadı")}`;
+}
 function initPrompts() {
   const prompts = [
     { text: "YouTube'un amacı nedir?", agent: false },

--- a/script.js
+++ b/script.js
@@ -7,16 +7,13 @@ const state = {
   thinkingTicker: null,
   agentModeActive: false,
   agentBusy: false,
-  selectedTargets: [],
-  markMode: false,
-  dragSelecting: false,
 };
 
 const THINKING_LINES = [
-  "Ekranına bakıyorum...",
-  "Kaynakları karşılaştırıyorum...",
-  "Anlamlı parçaları ayırıyorum...",
-  "En doğru özeti hazırlıyorum..."
+  "Baluk.ai ağına bağlanılıyor...",
+  "Ekranındaki sayfayı satır satır tarıyorum...",
+  "Web + Wikipedia kaynaklarını birleştiriyorum...",
+  "Doğrulayıp net cevabı hazırlıyorum..."
 ];
 const SITE_KNOWLEDGE = {
   "youtube.com": {
@@ -74,7 +71,6 @@ const el = {
   homeView: document.getElementById("homeView"),
   webView: document.getElementById("webView"),
   siteFrame: document.getElementById("siteFrame"),
-  adresCubugu: document.getElementById("adresCubugu"),
   geriBtn: document.getElementById("geriBtn"),
   ileriBtn: document.getElementById("ileriBtn"),
   yenileBtn: document.getElementById("yenileBtn"),
@@ -97,10 +93,8 @@ const el = {
   plusBtn: document.getElementById("plusBtn"),
   agentMenu: document.getElementById("agentMenu"),
   agentModeBtn: document.getElementById("agentModeBtn"),
-  selectedTargets: document.getElementById("selectedTargets"),
   agentBadge: document.getElementById("agentBadge"),
   agentBadgeClose: document.getElementById("agentBadgeClose"),
-  markToggleBtn: document.getElementById("markToggleBtn"),
   quickPrompts: document.getElementById("quickPrompts"),
   introOverlay: document.getElementById("introOverlay"),
   appShell: document.getElementById("appShell"),
@@ -145,16 +139,6 @@ function runIntro() {
   }, introDuration);
 }
 
-function setPanel(open) {
-  el.aiPanel.classList.toggle("hidden", !open);
-  el.contentGrid.classList.toggle("with-panel", open);
-}
-
-function renderTabs() {
-  el.tabs.innerHTML = "";
-  state.tabs.forEach((tab) => {
-    const b = document.createElement("button");
-    b.className = `tab-item ${tab.id === state.activeTabId ? "active" : ""}`;
     b.dataset.tabId = String(tab.id);
     b.innerHTML = `<span>${escapeHtml(tab.title)}</span><span class="tab-close" data-close="${tab.id}">✕</span>`;
     b.addEventListener("click", (e) => {
@@ -173,7 +157,6 @@ function showHome() {
 }
 
 function syncTabView() {
-  const tab = currentTab();
   if (!tab || !tab.url) return showHome();
   el.adresCubugu.value = tab.url;
   el.siteFrame.src = tab.url;
@@ -288,6 +271,32 @@ async function fetchWikipediaSnippet(topic) {
 }
 
 
+
+async function fetchWebModeAnswer(query) {
+  const cleaned = query.trim();
+  if (!cleaned) return "";
+
+  const parts = [];
+  try {
+    const ddgResp = await fetch(`https://api.duckduckgo.com/?q=${encodeURIComponent(cleaned)}&format=json&no_redirect=1&no_html=1`);
+    if (ddgResp.ok) {
+      const ddg = await ddgResp.json();
+      if (ddg.AbstractText) parts.push(ddg.AbstractText);
+      const related = (ddg.RelatedTopics || [])
+        .flatMap((item) => item.Topics || [item])
+        .map((item) => item?.Text)
+        .filter(Boolean);
+      if (related.length) parts.push(related.slice(0, 2).join(" "));
+    }
+  } catch {}
+
+  const wiki = await fetchWikipediaSnippet(cleaned);
+  if (wiki) parts.push(wiki);
+
+  const merged = parts.join(" ").replace(/\s+/g, " ").trim();
+  return merged.slice(0, 450);
+}
+
 function getCurrentSiteContext() {
   const tab = currentTab();
   const raw = tab?.url || el.adresCubugu.value || "";
@@ -349,142 +358,7 @@ function stopThinking() {
 
 function setAgentMode(on) {
   state.agentModeActive = on;
-  state.markMode = false;
-  el.markToggleBtn?.classList.remove("active");
-  el.agentBadge.classList.toggle("hidden", !on);
   el.agentModeBtn.textContent = on ? "Agent Mode 2.0 (Açık)" : "Agent Mode 2.0";
-  if (!on) {
-    state.selectedTargets.forEach((t) => { try { t.el.style.outline = ""; } catch {} });
-    state.selectedTargets = [];
-    renderSelectedTargets();
-  }
-}
-
-function renderSelectedTargets() {
-  el.selectedTargets.innerHTML = "";
-  state.selectedTargets.forEach((target, i) => {
-    const chip = document.createElement("div");
-    chip.className = "target-chip";
-    chip.innerHTML = `<span>${escapeHtml(target.label)}</span><button type="button">✕</button>`;
-    chip.querySelector("button").onclick = () => {
-      try { target.el.style.outline = ""; } catch {}
-      state.selectedTargets.splice(i, 1);
-      renderSelectedTargets();
-    };
-    el.selectedTargets.appendChild(chip);
-  });
-}
-
-function bindAgentPicker() {
-  try {
-    const doc = el.siteFrame.contentDocument;
-    if (!doc) throw new Error();
-
-    let box = null;
-    let sx = 0;
-    let sy = 0;
-
-    const clearBox = () => {
-      if (box && box.parentNode) box.parentNode.removeChild(box);
-      box = null;
-      state.dragSelecting = false;
-    };
-
-    doc.addEventListener("mousedown", (e) => {
-      if (!state.agentModeActive || !state.markMode) return;
-      if (e.button !== 0) return;
-      e.preventDefault();
-      e.stopPropagation();
-
-      sx = e.clientX;
-      sy = e.clientY;
-      state.dragSelecting = true;
-
-      clearBox();
-      box = doc.createElement("div");
-      box.style.position = "fixed";
-      box.style.left = `${sx}px`;
-      box.style.top = `${sy}px`;
-      box.style.width = "1px";
-      box.style.height = "1px";
-      box.style.border = "2px dashed #b171ff";
-      box.style.background = "rgba(177,113,255,0.08)";
-      box.style.borderRadius = "2px";
-      box.style.zIndex = "2147483647";
-      box.style.pointerEvents = "none";
-      doc.body.appendChild(box);
-    }, { capture: true });
-
-    doc.addEventListener("mousemove", (e) => {
-      if (!state.agentModeActive || !state.markMode || !state.dragSelecting || !box) return;
-      e.preventDefault();
-
-      const x = Math.min(sx, e.clientX);
-      const y = Math.min(sy, e.clientY);
-      const w = Math.abs(e.clientX - sx);
-      const h = Math.abs(e.clientY - sy);
-
-      box.style.left = `${x}px`;
-      box.style.top = `${y}px`;
-      box.style.width = `${Math.max(2, w)}px`;
-      box.style.height = `${Math.max(2, h)}px`;
-    }, { capture: true });
-
-    doc.addEventListener("mouseup", (e) => {
-      if (!state.agentModeActive || !state.markMode || !state.dragSelecting) return;
-      e.preventDefault();
-      e.stopPropagation();
-
-      const x1 = Math.min(sx, e.clientX);
-      const y1 = Math.min(sy, e.clientY);
-      const x2 = Math.max(sx, e.clientX);
-      const y2 = Math.max(sy, e.clientY);
-      const width = Math.max(2, x2 - x1);
-      const height = Math.max(2, y2 - y1);
-
-      const cxFrame = x1 + width / 2;
-      const cyFrame = y1 + height / 2;
-
-      const frameRect = el.siteFrame.getBoundingClientRect();
-      const cxViewport = frameRect.left + cxFrame;
-      const cyViewport = frameRect.top + cyFrame;
-
-      const centerEl = doc.elementFromPoint(cxFrame, cyFrame);
-      if (centerEl && centerEl.style) centerEl.style.outline = "2px solid #b171ff";
-
-      const labelBase = centerEl?.getAttribute?.("aria-label") || centerEl?.innerText || centerEl?.placeholder || centerEl?.tagName || "Seçili alan";
-      const label = String(labelBase).trim().slice(0, 28) || "Seçili alan";
-
-      state.selectedTargets.push({
-        mode: "region",
-        label,
-        frameCenter: { x: cxFrame, y: cyFrame },
-        viewportCenter: { x: cxViewport, y: cyViewport },
-        el: centerEl || null,
-      });
-
-      renderSelectedTargets();
-      el.aiCevap.innerHTML = `Düz seçim yapıldı: ${highlight(label)}. Şimdi "buraya tıkla" veya "bu inputa merhaba yaz" diyebilirsin.`;
-      clearBox();
-    }, { capture: true });
-
-    el.aiCevap.innerHTML = "Agent Mode 2.0 açık. Kalem (✎) ile sürükleyerek dikdörtgen alan seçebilirsin.";
-  } catch {
-    el.aiCevap.innerHTML = "Bu sayfada güvenlik nedeniyle işaretleme yapılamıyor (farklı domain).";
-  }
-}
-
-
-function toggleMarkMode() {
-  if (!state.agentModeActive) return;
-  state.markMode = !state.markMode;
-  el.markToggleBtn?.classList.toggle("active", state.markMode);
-  el.aiCevap.innerHTML = state.markMode
-    ? "İşaretleme açık: fare/parmak ile sürükleyip düz dikdörtgen alan seçebilirsin."
-    : "İşaretleme kapalı.";
-}
-
-function selectedInfo() {
   if (!state.selectedTargets.length) return "Önce kalemle sürükleyerek bir alan seç.";
   const labels = state.selectedTargets.map((t) => t.label).join(", ");
   return `Seçtiğin alan(lar): ${highlight(labels)}. Şimdi "buraya tıkla" veya "bu inputa merhaba yaz" diyebilirsin.`;
@@ -540,57 +414,6 @@ function getElementCenterInViewport(element) {
   return { x, y };
 }
 
-async function clickMarkedTargetCenter(target) {
-  const center = target.viewportCenter || getElementCenterInViewport(target.el);
-  moveCursorToPoint(center.x, center.y);
-  await sleep(220);
-
-  const doc = el.siteFrame.contentDocument;
-  let node = target.el;
-  if ((!node || !node.isConnected) && doc && target.frameCenter) {
-    node = doc.elementFromPoint(target.frameCenter.x, target.frameCenter.y);
-  }
-
-  if (!node) {
-    return clickByViewportPoint(center.x, center.y);
-  }
-  try {
-    ["pointerdown", "mousedown", "mouseup", "click"].forEach((type) => {
-      node.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: node.ownerDocument.defaultView }));
-    });
-  } catch {
-    node.click();
-  }
-  await sleep(140);
-  return true;
-}
-
-function writeIntoTarget(target, text) {
-  const doc = el.siteFrame.contentDocument;
-  let node = target.el;
-  if ((!node || !node.isConnected) && doc && target.frameCenter) {
-    node = doc.elementFromPoint(target.frameCenter.x, target.frameCenter.y);
-  }
-  if (!node) return false;
-
-  const isInput = node.matches?.("input, textarea") || node.isContentEditable;
-  if (!isInput) return false;
-
-  node.focus();
-  if (node.isContentEditable) {
-    node.textContent = text;
-  } else {
-    node.value = text;
-  }
-  node.dispatchEvent(new Event("input", { bubbles: true }));
-  node.dispatchEvent(new Event("change", { bubbles: true }));
-  return true;
-}
-
-
-async function clickElement(element) {
-  moveCursorTo(element);
-  await sleep(280);
   element.click();
   await sleep(160);
 }
@@ -701,42 +524,6 @@ async function runAgentTask(q) {
       return `Şunu istedin: ${escapeHtml(parsed.query)}. Şunu yaptım: ${parsed.linkIndex}. linke girdim.`;
     }
 
-    if (/anlamı ne|bu ne|bu nedir/.test(low)) {
-      return selectedInfo();
-    }
-
-    if (state.selectedTargets.length) {
-      if (/tıkla/.test(low)) {
-        let clicked = 0;
-        for (const t of state.selectedTargets) {
-          if (await clickMarkedTargetCenter(t)) clicked += 1;
-        }
-        if (!clicked) return "İşaretlenen alanlara doğrudan tıklama yapılamadı (site güvenlik kısıtı olabilir).";
-        return `${clicked} işaretli alanın tam ortasına sırayla tıkladım.`;
-      }
-
-      const write = q.match(/(?:yaz|değiştir|yap)\s+(.+)/i)?.[1]?.trim();
-      if (write) {
-        let wrote = 0;
-        const clean = write.replace(/"/g, "");
-        for (const t of state.selectedTargets) {
-          const center = t.viewportCenter || getElementCenterInViewport(t.el);
-          moveCursorToPoint(center.x, center.y);
-          await sleep(120);
-          if (writeIntoTarget(t, clean)) wrote += 1;
-        }
-
-        if (!wrote && getCurrentHost().endswith("youtube.com")) {
-          const qv = encodeURIComponent(clean);
-          openUrl(`https://www.youtube.com/results?search_query=${qv}`, true, "YouTube arama");
-          return `YouTube arama kutusuna yazma yerine arama başlatıldı: ${highlight(clean)}.`;
-        }
-
-        if (!wrote) return "İşaretlenen öğelerde yazılabilir input bulunamadı. Input seçip tekrar dene.";
-        return `Seçili input alanlarına ${highlight(clean)} yazdım.`;
-      }
-    }
-
     return "Agent Mode 2.0 komutu anlaşılamadı.";
   } finally {
     state.agentBusy = false;
@@ -750,7 +537,7 @@ async function answerNormal(q) {
     return `Bunu otomatik yapmam için ${highlight("Agent Mode 2.0")} aç.`;
   }
 
-  const asksCurrentSite = /bu\s+web\s*site|bu\s+site|ekrandaki\s+site|açık\s+site|şu\s+site/.test(low);
+  const asksCurrentSite = /\bbu\s+web\s*site|\bbu\s+site|ekrandaki\s+site|açık\s+site|şu\s+site/.test(low);
   const asksGenericWeb = /web\s*site\s*nedir|webin\s+ne\s+oldu|web\s*sitenin\s+amacı\s+ne/.test(low);
 
   if (asksGenericWeb && !asksCurrentSite) {
@@ -764,7 +551,7 @@ async function answerNormal(q) {
 
   const topic = asksCurrentSite ? current : null;
   const genericTopic = siteHintFromText(q);
-  const wiki = await fetchWikipediaSnippet(asksCurrentSite ? (topic?.name || "") : genericTopic);
+  const sourceText = await fetchWebModeAnswer(asksCurrentSite ? (topic?.name || topic?.host || "") : q);
 
   if (asksCurrentSite) {
     if (/kuruluş|kaç yılında|ne zaman/.test(low)) {
@@ -779,32 +566,35 @@ ${escapeHtml(topic.company)}`;
 Amaç: ${escapeHtml(topic.purpose)}`;
     }
     if (/özet|özeti|nedir/.test(low)) {
-      const sum = wiki || topic.summary;
+      const sum = sourceText || topic.summary;
       return `${highlight(topic.name)} özeti:
 ${escapeHtml(sum)}`;
     }
-    const sum = wiki || topic.summary;
-    return `${highlight(topic.name)} için hızlı analiz:
+    const sum = sourceText || topic.summary;
+    return `${highlight("Baluk.ai ağına bağlanıldı")}
+${highlight(topic.name)} için hızlı analiz:
 Kuruluş: ${highlight(topic.year)}
 Şirket/Kurucu: ${escapeHtml(topic.company)}
 Amaç: ${escapeHtml(topic.purpose)}
-Özet: ${escapeHtml(sum)}`;
+Web modu özeti: ${escapeHtml(sum)}`;
   }
 
   if (/kuruluş|kaç yılında|ne zaman/.test(low)) {
-    return `${highlight(genericTopic)} kuruluş bilgisi: ${highlight("Wikipedia özeti ile bulundu")}.`;
+    return `${highlight(genericTopic)} kuruluş bilgisi: ${highlight("web kaynaklarından derlendi")}.`;
   }
   if (/isim|adı/.test(low)) {
     return `Site adı: ${highlight(genericTopic)}.`;
   }
-  if (/amaç|ne işe yarar|hakkında/.test(low)) {
-    return `${highlight(genericTopic)} amacı:
-${escapeHtml(wiki || `${genericTopic} genel olarak bilgi/hizmet sunar.`)}`;
+  if (/amaç|ne işe yarar|hakkında|nasıl/.test(low)) {
+    return `${highlight("Baluk.ai web modu aktif")}
+${highlight(genericTopic)} hakkında:
+${escapeHtml(sourceText || `${genericTopic} hakkında yeterli veri bulunamadı.`)}`;
   }
 
   return `${highlight(genericTopic)} özeti:
-${escapeHtml(wiki || "Özet bulunamadı")}`;
+${escapeHtml(sourceText || "Özet bulunamadı")}`;
 }
+
 function initPrompts() {
   const prompts = [
     { text: "YouTube'un amacı nedir?", agent: false },
@@ -869,12 +659,8 @@ el.plusBtn.addEventListener("click", () => el.agentMenu.classList.toggle("hidden
 el.agentModeBtn.addEventListener("click", () => {
   setAgentMode(!state.agentModeActive);
   el.agentMenu.classList.add("hidden");
-  if (state.agentModeActive) bindAgentPicker();
 });
-el.markToggleBtn?.addEventListener("click", toggleMarkMode);
 el.agentBadgeClose.addEventListener("click", () => setAgentMode(false));
-el.siteFrame.addEventListener("load", () => { if (state.agentModeActive) bindAgentPicker(); });
-
 el.loginForm.addEventListener("submit", (e) => {
   e.preventDefault();
   const user = {

--- a/script.js
+++ b/script.js
@@ -4,6 +4,8 @@ const state = {
   user: JSON.parse(localStorage.getItem("balukUser") || "null"),
   thinkingTimer: null,
   thinkingTicker: null,
+  agentModeActive: false,
+  selectedInput: null,
 };
 
 const THINKING_LINES = [
@@ -74,6 +76,8 @@ function openUrl(url, addToHistory = true) {
   el.adresCubugu.value = safe;
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
+  state.selectedInput = null;
+
   if (addToHistory) {
     state.history = state.history.slice(0, state.index + 1);
     state.history.push(safe);
@@ -87,6 +91,7 @@ function parseSite(urlCandidate) {
   const host = url.hostname.replace(/^www\./, "").toLowerCase();
   const matchKey = Object.keys(SITE_HINTS).find((key) => host.endsWith(key));
   if (matchKey) return { ...SITE_HINTS[matchKey], host, url: url.href };
+
   const base = host.split(".")[0] || "web sitesi";
   return {
     name: base.charAt(0).toUpperCase() + base.slice(1),
@@ -122,13 +127,16 @@ async function getSearchResults(query) {
   if (!response.ok) throw new Error("duckduckgo error");
   const data = await response.json();
   const parsed = [];
+
   if (data.AbstractURL) parsed.push({ title: data.Heading || query, href: data.AbstractURL, snippet: data.AbstractText || "Özet bilgi" });
+
   (data.RelatedTopics || []).forEach((item) => {
     if (item.FirstURL && item.Text) parsed.push({ title: item.Text.split(" - ")[0], href: item.FirstURL, snippet: item.Text });
     (item.Topics || []).forEach((sub) => {
       if (sub.FirstURL && sub.Text) parsed.push({ title: sub.Text.split(" - ")[0], href: sub.FirstURL, snippet: sub.Text });
     });
   });
+
   return parsed.slice(0, 8);
 }
 
@@ -170,6 +178,7 @@ function startThinking() {
   el.thinkingBox.classList.remove("hidden");
   el.spinLogo.classList.add("active");
   document.body.classList.add("web-glow");
+
   let idx = 0;
   el.thinkingText.textContent = THINKING_LINES[0];
   state.thinkingTicker = setInterval(() => {
@@ -197,38 +206,85 @@ function buildAiAnswer(q) {
   return `${siteName} özeti: ${site.year} yılında kurulduğu biliniyor, ${site.company} tarafından geliştirildi/işletiliyor ve ana amacı ${site.purpose}.`;
 }
 
-function sendAgentFillInstruction() {
-  const instruction = prompt("Seçtiğin input'a ne yazılsın?");
-  if (!instruction) return;
+function bindAgentSelectionToIframe() {
+  if (!state.agentModeActive) return;
+
   try {
     const doc = el.siteFrame.contentDocument;
     if (!doc) throw new Error("iframe erişimi yok");
-    const target = doc.querySelector("input:focus, textarea:focus") || doc.querySelector("input, textarea");
-    if (!target) return (el.aiCevap.textContent = "Agent Mode: Bu sayfada doldurulabilir input bulunamadı.");
-    target.focus();
-    target.value = instruction;
-    target.dispatchEvent(new Event("input", { bubbles: true }));
-    target.dispatchEvent(new Event("change", { bubbles: true }));
-    el.aiCevap.textContent = `Agent Mode tamamlandı: "${instruction}" yazıldı.`;
+
+    doc.querySelectorAll("input, textarea").forEach((node) => {
+      node.classList.remove("baluk-agent-target");
+      node.style.outline = "1px dashed rgba(141,69,255,0.45)";
+    });
+
+    doc.addEventListener("click", (event) => {
+      if (!state.agentModeActive) return;
+      const t = event.target;
+      if (!(t instanceof HTMLElement)) return;
+      if (!(t.matches("input") || t.matches("textarea"))) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      if (state.selectedInput) {
+        state.selectedInput.style.outline = "1px dashed rgba(141,69,255,0.45)";
+      }
+
+      state.selectedInput = t;
+      t.style.outline = "2px solid #b486ff";
+      el.aiCevap.textContent = "Alan seçildi. Şimdi Baluk.ai kutusuna ne yazılacağını yazıp Gönder'e bas.";
+    }, { capture: true });
+
+    el.aiCevap.textContent = "Agent Mode açık: Form alanına tıkla ve hedefi seç.";
   } catch {
-    el.aiCevap.textContent = "Agent Mode güvenlik sınırı: Farklı domaine doğrudan yazılamıyor. Aynı domain sayfalarda çalışır.";
+    el.aiCevap.textContent = "Agent Mode için bu sayfada seçim yapılamıyor (farklı domain güvenlik sınırı). Aynı domain sayfada deneyebilirsin.";
   }
 }
+
+function handleAgentWrite(commandText) {
+  if (!state.agentModeActive) return false;
+
+  if (!state.selectedInput) {
+    el.aiCevap.textContent = "Önce bir input/textarea alanı seçmelisin. Agent Mode açık.";
+    return true;
+  }
+
+  state.selectedInput.focus();
+  state.selectedInput.value = commandText;
+  state.selectedInput.dispatchEvent(new Event("input", { bubbles: true }));
+  state.selectedInput.dispatchEvent(new Event("change", { bubbles: true }));
+  el.aiCevap.textContent = `Yazıldı: "${commandText}"`;
+
+  state.agentModeActive = false;
+  state.selectedInput.style.outline = "1px dashed rgba(141,69,255,0.45)";
+  state.selectedInput = null;
+  return true;
+}
+
+el.siteFrame.addEventListener("load", () => {
+  if (state.agentModeActive) bindAgentSelectionToIframe();
+});
 
 el.aramaForm.addEventListener("submit", async (event) => {
   event.preventDefault();
   const q = el.aramaInput.value.trim();
   if (!q) return;
   el.sonuclar.innerHTML = "Aranıyor...";
-  try { renderResults(await getSearchResults(q), q); }
-  catch { renderResults(createFallbackResults(q), q); }
+
+  try {
+    const results = await getSearchResults(q);
+    renderResults(results, q);
+  } catch {
+    renderResults(createFallbackResults(q), q);
+  }
 });
 
 el.adresCubugu.addEventListener("keydown", (e) => { if (e.key === "Enter") openUrl(el.adresCubugu.value); });
 el.geriBtn.addEventListener("click", () => { if (state.index > 0) openUrl(state.history[--state.index], false); });
 el.ileriBtn.addEventListener("click", () => { if (state.index < state.history.length - 1) openUrl(state.history[++state.index], false); });
 el.yenileBtn.addEventListener("click", () => { if (el.siteFrame.src) el.siteFrame.src = el.siteFrame.src; });
-el.newTabBtn.addEventListener("click", () => { el.homeView.classList.remove("hidden"); el.webView.classList.add("hidden"); el.adresCubugu.value = ""; });
+el.newTabBtn.addEventListener("click", () => { el.homeView.classList.remove("hidden"); el.webView.classList.add("hidden"); el.adresCubugu.value = ""; state.selectedInput = null; });
 el.balukPanelBtn.addEventListener("click", () => setPanel(el.aiPanel.classList.contains("hidden")));
 el.closePanelBtn.addEventListener("click", () => setPanel(false));
 
@@ -241,6 +297,7 @@ el.loginForm.addEventListener("submit", (e) => {
   };
   const file = document.getElementById("profil").files[0];
   if (!user.email || !user.ad || !user.soyad) return;
+
   if (file) {
     const reader = new FileReader();
     reader.onload = () => {
@@ -259,15 +316,22 @@ el.loginForm.addEventListener("submit", (e) => {
 
 el.plusBtn.addEventListener("click", () => el.agentMenu.classList.toggle("hidden"));
 el.agentModeBtn.addEventListener("click", () => {
+  state.agentModeActive = true;
+  state.selectedInput = null;
   el.agentMenu.classList.add("hidden");
-  el.aiCevap.textContent = "Agent Mode aktif. Input alanına odaklanıp komutu ver.";
-  sendAgentFillInstruction();
+  bindAgentSelectionToIframe();
 });
 
 el.aiForm.addEventListener("submit", (e) => {
   e.preventDefault();
   const q = el.aiSoru.value.trim();
   if (!q) return;
+
+  if (handleAgentWrite(q)) {
+    el.aiSoru.value = "";
+    return;
+  }
+
   startThinking();
   clearTimeout(state.thinkingTimer);
   state.thinkingTimer = setTimeout(() => {

--- a/script.js
+++ b/script.js
@@ -60,19 +60,15 @@ const el = {
 
 const agentCursor = document.createElement("div");
 agentCursor.id = "agentCursor";
-agentCursor.style.cssText = "position:fixed;width:18px;height:18px;border:2px solid #b78cff;background:radial-gradient(circle,#6b24dd 0%,#141020 75%);border-radius:50%;box-shadow:0 0 18px rgba(141,69,255,.85);z-index:9999;pointer-events:none;opacity:0;transform:translate(-50%,-50%);transition:left .35s ease, top .35s ease, opacity .2s ease;";
+agentCursor.style.cssText = "position:fixed;width:18px;height:18px;border:2px solid #b78cff;background:radial-gradient(circle,#6b24dd 0%,#141020 75%);border-radius:50%;box-shadow:0 0 18px rgba(141,69,255,.85);z-index:9999;pointer-events:none;opacity:0;transform:translate(-50%,-50%);transition:left .25s ease, top .25s ease, opacity .15s ease;";
 document.body.appendChild(agentCursor);
 
-function currentTab() {
-  return state.tabs.find((t) => t.id === state.activeTabId);
-}
-function escapeHtml(text = "") {
-  return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#039;");
-}
+function currentTab() { return state.tabs.find((t) => t.id === state.activeTabId); }
+function escapeHtml(text = "") { return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#039;"); }
 function ensureUrl(value) { return /^https?:\/\//i.test(value) ? value : `https://${value}`; }
 function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
-
 function highlight(v) { return `<span class="hl">${escapeHtml(v)}</span>`; }
+function normalize(s = "") { return s.toLowerCase().trim(); }
 
 function playIntroSound() {
   try {
@@ -89,6 +85,7 @@ function playIntroSound() {
     o.onended = () => audioCtx.close();
   } catch {}
 }
+
 function runIntro() {
   const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   const introDuration = reducedMotion ? 2350 : 4800;
@@ -110,6 +107,7 @@ function renderTabs() {
   state.tabs.forEach((tab) => {
     const b = document.createElement("button");
     b.className = `tab-item ${tab.id === state.activeTabId ? "active" : ""}`;
+    b.dataset.tabId = String(tab.id);
     b.innerHTML = `<span>${escapeHtml(tab.title)}</span><span class="tab-close" data-close="${tab.id}">✕</span>`;
     b.addEventListener("click", (e) => {
       const close = e.target.closest(".tab-close");
@@ -118,29 +116,6 @@ function renderTabs() {
     });
     el.tabs.appendChild(b);
   });
-}
-
-function createTab(url = "") {
-  const tab = { id: state.nextTabId++, title: "Yeni Sekme", url: "", history: [], index: -1 };
-  state.tabs.push(tab);
-  state.activeTabId = tab.id;
-  renderTabs();
-  if (url) openUrl(url);
-  else showHome();
-}
-
-function closeTab(id) {
-  if (state.tabs.length === 1) return;
-  state.tabs = state.tabs.filter((t) => t.id !== id);
-  if (!state.tabs.some((t) => t.id === state.activeTabId)) state.activeTabId = state.tabs[0].id;
-  renderTabs();
-  syncTabView();
-}
-
-function switchTab(id) {
-  state.activeTabId = id;
-  renderTabs();
-  syncTabView();
 }
 
 function showHome() {
@@ -158,47 +133,94 @@ function syncTabView() {
   el.webView.classList.remove("hidden");
 }
 
-function openUrl(url, addToHistory = true) {
+function setTabTitle(tab, title) {
+  tab.title = (title || "Yeni Sekme").slice(0, 22);
+}
+
+function createTab(url = "") {
+  const tab = { id: state.nextTabId++, title: "Yeni Sekme", url: "", history: [], index: -1 };
+  state.tabs.push(tab);
+  state.activeTabId = tab.id;
+  renderTabs();
+  if (url) openUrl(url);
+  else showHome();
+}
+
+function closeTab(id) {
+  if (state.tabs.length === 1) return false;
+  state.tabs = state.tabs.filter((t) => t.id !== id);
+  if (!state.tabs.some((t) => t.id === state.activeTabId)) state.activeTabId = state.tabs[0].id;
+  renderTabs();
+  syncTabView();
+  return true;
+}
+
+function switchTab(id) {
+  state.activeTabId = id;
+  renderTabs();
+  syncTabView();
+}
+
+function openUrl(url, addToHistory = true, titleHint = "") {
   const safe = ensureUrl(url);
   const tab = currentTab();
   if (!tab) return;
-
   tab.url = safe;
-  try { tab.title = new URL(safe).hostname.replace(/^www\./, ""); } catch { tab.title = "Yeni Sekme"; }
+  if (titleHint) {
+    setTabTitle(tab, titleHint);
+  } else {
+    try { setTabTitle(tab, new URL(safe).hostname.replace(/^www\./, "")); } catch { setTabTitle(tab, "Yeni Sekme"); }
+  }
 
   if (addToHistory) {
     tab.history = tab.history.slice(0, tab.index + 1);
     tab.history.push(safe);
     tab.index = tab.history.length - 1;
   }
-
   renderTabs();
   syncTabView();
 }
 
-async function getSearchResults(query) {
-  const response = await fetch(`https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_redirect=1&no_html=1`);
-  if (!response.ok) throw new Error("duckduckgo error");
-  const data = await response.json();
-  const parsed = [];
-  if (data.AbstractURL) parsed.push({ title: data.Heading || query, href: data.AbstractURL, snippet: data.AbstractText || "Özet bilgi" });
-  (data.RelatedTopics || []).forEach((item) => {
-    if (item.FirstURL && item.Text) parsed.push({ title: item.Text.split(" - ")[0], href: item.FirstURL, snippet: item.Text });
-    (item.Topics || []).forEach((sub) => {
-      if (sub.FirstURL && sub.Text) parsed.push({ title: sub.Text.split(" - ")[0], href: sub.FirstURL, snippet: sub.Text });
-    });
-  });
-  return parsed.slice(0, 8);
+function buildFallbackResults(query) {
+  const q = encodeURIComponent(query);
+  return [
+    { title: `${query} - DuckDuckGo`, href: `https://duckduckgo.com/?q=${q}`, snippet: "DuckDuckGo sonuç sayfasını aç." },
+    { title: `${query} - Wikipedia araması`, href: `https://tr.wikipedia.org/wiki/Özel:Arama?search=${q}`, snippet: "Wikipedia içinde ara." },
+    { title: `${query} - Google araması`, href: `https://www.google.com/search?q=${q}`, snippet: "Google sonuç sayfasını aç." },
+  ];
 }
 
-function renderResults(results) {
+async function getSearchResults(query) {
+  try {
+    const response = await fetch(`https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_redirect=1&no_html=1`);
+    if (!response.ok) return buildFallbackResults(query);
+    const data = await response.json();
+    const parsed = [];
+
+    if (data.AbstractURL) parsed.push({ title: data.Heading || query, href: data.AbstractURL, snippet: data.AbstractText || "Özet bilgi" });
+    (data.RelatedTopics || []).forEach((item) => {
+      if (item.FirstURL && item.Text) parsed.push({ title: item.Text.split(" - ")[0], href: item.FirstURL, snippet: item.Text });
+      (item.Topics || []).forEach((sub) => {
+        if (sub.FirstURL && sub.Text) parsed.push({ title: sub.Text.split(" - ")[0], href: sub.FirstURL, snippet: sub.Text });
+      });
+    });
+
+    return parsed.length ? parsed.slice(0, 8) : buildFallbackResults(query);
+  } catch {
+    return buildFallbackResults(query);
+  }
+}
+
+function renderResults(results, query) {
   el.sonuclar.innerHTML = "";
-  results.forEach((item) => {
+  const safeResults = results.length ? results : buildFallbackResults(query);
+
+  safeResults.forEach((item) => {
     const card = document.createElement("article");
     card.className = "result-item";
     card.innerHTML = `<h3><a href="#">${escapeHtml(item.title)}</a></h3><p>${escapeHtml(item.snippet || "Açıklama yok")}</p><div class="result-actions"><button class="open-link" type="button">Bağlantıyı Aç</button><button class="ask-link" type="button">✦ Baluk.ai'ye Sor</button></div>`;
-    card.querySelector("a").addEventListener("click", (e) => { e.preventDefault(); openUrl(item.href); });
-    card.querySelector(".open-link").addEventListener("click", () => openUrl(item.href));
+    card.querySelector("a").addEventListener("click", (e) => { e.preventDefault(); openUrl(item.href, true, query); });
+    card.querySelector(".open-link").addEventListener("click", () => openUrl(item.href, true, query));
     card.querySelector(".ask-link").addEventListener("click", () => {
       setPanel(true);
       el.aiSoru.value = `${item.title} web sitesi ne işe yarar?`;
@@ -218,9 +240,8 @@ async function fetchWikipediaSnippet(topic) {
 }
 
 function siteHintFromText(text) {
-  const t = text.toLowerCase();
-  const m = ["youtube", "google", "wikipedia", "github", "instagram", "twitter", "shopify"].find((x) => t.includes(x));
-  return m || "web sitesi";
+  const t = normalize(text);
+  return ["youtube", "google", "wikipedia", "github", "instagram", "twitter", "shopify"].find((x) => t.includes(x)) || "web sitesi";
 }
 
 function startThinking(customLines = THINKING_LINES) {
@@ -236,6 +257,7 @@ function startThinking(customLines = THINKING_LINES) {
     el.thinkingText.textContent = customLines[idx];
   }, 1400);
 }
+
 function stopThinking() {
   clearInterval(state.thinkingTicker);
   el.thinkingBox.classList.add("hidden");
@@ -248,6 +270,7 @@ function setAgentMode(on) {
   el.agentBadge.classList.toggle("hidden", !on);
   el.agentModeBtn.textContent = on ? "Agent Mode 2.0 (Açık)" : "Agent Mode 2.0";
   if (!on) {
+    state.selectedTargets.forEach((t) => { try { t.el.style.outline = ""; } catch {} });
     state.selectedTargets = [];
     renderSelectedTargets();
   }
@@ -260,6 +283,7 @@ function renderSelectedTargets() {
     chip.className = "target-chip";
     chip.innerHTML = `<span>${escapeHtml(target.label)}</span><button type="button">✕</button>`;
     chip.querySelector("button").onclick = () => {
+      try { target.el.style.outline = ""; } catch {}
       state.selectedTargets.splice(i, 1);
       renderSelectedTargets();
     };
@@ -276,26 +300,26 @@ function bindAgentPicker() {
       const t = e.target;
       if (!(t instanceof HTMLElement)) return;
       e.preventDefault(); e.stopPropagation();
-      const label = (t.innerText || t.placeholder || t.value || t.tagName).trim().slice(0, 26) || t.tagName;
+      const label = (t.innerText || t.getAttribute("aria-label") || t.placeholder || t.value || t.tagName).trim().slice(0, 28) || t.tagName;
       state.selectedTargets.push({ el: t, label });
       t.style.outline = "2px solid #b171ff";
       renderSelectedTargets();
-      el.aiCevap.innerHTML = `Seçildi: ${highlight(label)}. Şimdi ne yapılacağını yaz.`;
+      el.aiCevap.innerHTML = `Seçildi: ${highlight(label)}.`;
     }, { capture: true });
-    el.aiCevap.innerHTML = "Agent Mode 2.0 açık. Sayfadan bir veya birden çok öğe seçebilirsin.";
+    el.aiCevap.innerHTML = "Agent Mode 2.0 açık. Sayfadan birden çok öğe seçebilirsin.";
   } catch {
-    el.aiCevap.innerHTML = "Bu sayfada güvenlik nedeniyle işaretleme yapılamıyor (farklı domain kısıtı).";
+    el.aiCevap.innerHTML = "Bu sayfada güvenlik nedeniyle işaretleme yapılamıyor (farklı domain).";
   }
 }
 
 function parseSearchCommand(q) {
-  const t = q.toLowerCase().trim();
-  const m1 = t.match(/^ara\s+(.+)$/);
-  const m2 = t.match(/^(.+)\s+ara$/);
-  const m3 = t.match(/^(.+)\s+arat$/);
-  const m4 = t.match(/^hey baluk\s+(.+)$/);
-  const query = (m1?.[1] || m2?.[1] || m3?.[1] || m4?.[1] || "").trim();
-  const n = Number((t.match(/(\d+)\.\s*link/) || [])[1] || 1);
+  const t = normalize(q).replace(/^hey baluk\s+/i, "");
+  const m1 = t.match(/^ara\s+(.+)$/i);
+  const m2 = t.match(/^(.+)\s+ara$/i);
+  const m3 = t.match(/^(.+)\s+arat$/i);
+  const m4 = t.match(/^(.+)\s+arat\s+çıkan\s+(\d+)\.?\s+link/i);
+  const query = (m4?.[1] || m1?.[1] || m2?.[1] || m3?.[1] || "").trim();
+  const n = Number((t.match(/(\d+)\.?\s*link/) || [])[1] || m4?.[2] || 1);
   return { query, linkIndex: Math.max(1, n || 1) };
 }
 
@@ -306,94 +330,181 @@ function moveCursorTo(element) {
   agentCursor.style.top = `${rect.top + rect.height / 2}px`;
 }
 
+async function clickElement(element) {
+  moveCursorTo(element);
+  await sleep(280);
+  element.click();
+  await sleep(160);
+}
+
+function findTabByName(name) {
+  const q = normalize(name);
+  return state.tabs.find((t) => normalize(t.title).includes(q));
+}
+
+function parseCloseNames(text) {
+  const quoted = [...text.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+  if (quoted.length) return quoted;
+  const single = text.match(/(.+?)\s+isimli\s+sekmeyi\s+kapat/i);
+  return single ? [single[1].trim()] : [];
+}
+
+async function closeTabViaCursor(tabId) {
+  const closeBtn = document.querySelector(`.tab-item [data-close="${tabId}"]`);
+  if (!closeBtn) return false;
+  await clickElement(closeBtn);
+  return true;
+}
+
+async function closeMany(order, count) {
+  let tabs = [...state.tabs];
+  if (tabs.length <= 1) return "Kapatılacak sekme yok.";
+  if (order === "right") tabs = tabs.reverse();
+
+  let done = 0;
+  for (const tab of tabs) {
+    if (state.tabs.length <= 1 || done >= count) break;
+    const ok = await closeTabViaCursor(tab.id);
+    if (ok) done += 1;
+  }
+  return `${done} sekme kapatıldı.`;
+}
+
 async function runAgentTask(q) {
+  if (state.agentBusy) return "Agent Mode meşgul, bekle.";
+  state.agentBusy = true;
   startThinking(["Masaüstümü kuruyorum...", "Hedefleri planlıyorum...", "Hazırım, uyguluyorum..."]);
   await sleep(3000);
   stopThinking();
 
-  const low = q.toLowerCase();
-  if (low.includes("geri")) { el.geriBtn.click(); return "İstediğin işlem yapıldı: geri gidildi."; }
-  if (low.includes("ileri")) { el.ileriBtn.click(); return "İstediğin işlem yapıldı: ileri gidildi."; }
-  if (low.includes("yenile")) { el.yenileBtn.click(); return "İstediğin işlem yapıldı: sayfa yenilendi."; }
-  if (low.includes("yeni sekme")) { createTab(); return "İstediğin işlem yapıldı: yeni sekme açıldı."; }
+  try {
+    const low = normalize(q);
 
-  const parsed = parseSearchCommand(q);
-  if (parsed.query) {
-    moveCursorTo(el.aramaInput);
-    await sleep(250);
-    showHome();
-    el.aramaInput.value = parsed.query;
-    el.aramaForm.requestSubmit();
-    await sleep(1200);
-    const cards = [...document.querySelectorAll(".result-item")];
-    const idx = Math.min(parsed.linkIndex - 1, cards.length - 1);
-    const btn = cards[idx]?.querySelector(".open-link");
-    if (btn) {
-      moveCursorTo(btn);
-      await sleep(300);
-      btn.click();
-      return `Şunu istedin: ${escapeHtml(parsed.query)}. Şunu yaptım: ${parsed.linkIndex}. linki açtım.`;
+    if (low.includes("geri")) { await clickElement(el.geriBtn); return "Şunu istedin: geri. Şunu yaptım: geri gittim."; }
+    if (low.includes("ileri")) { await clickElement(el.ileriBtn); return "Şunu istedin: ileri. Şunu yaptım: ileri gittim."; }
+    if (low.includes("yenile")) { await clickElement(el.yenileBtn); return "Şunu istedin: yenile. Şunu yaptım: sayfayı yeniledim."; }
+
+    if (/\d+\s+yeni\s+sekme\s+aç/.test(low)) {
+      const n = Number(low.match(/(\d+)\s+yeni\s+sekme\s+aç/)?.[1] || 1);
+      for (let i = 0; i < n; i += 1) await clickElement(el.addTabBtn);
+      return `${n} yeni sekme açtım.`;
     }
-    return "Sonuç bulunamadı.";
-  }
+    if (low.includes("yeni sekme")) { await clickElement(el.addTabBtn); return "Yeni sekme açtım."; }
 
-  if (state.selectedTargets.length) {
-    if (/tıkla/.test(low)) {
-      for (const t of state.selectedTargets) {
-        t.el.click();
-        await sleep(220);
+    if (low.includes("tüm sekmeleri kapat")) {
+      while (state.tabs.length > 1) {
+        await closeTabViaCursor(state.tabs[state.tabs.length - 1].id);
       }
-      return "Seçtiğin öğelere sırayla tıkladım.";
+      return "Tüm sekmeleri kapattım (en az 1 sekme kaldı).";
     }
 
-    const write = q.match(/(?:yaz|değiştir|yap)\s+(.+)/i)?.[1]?.trim();
-    if (write) {
-      for (const t of state.selectedTargets) {
-        if ("value" in t.el) {
-          t.el.focus();
-          t.el.value = write.replace(/"/g, "");
-          t.el.dispatchEvent(new Event("input", { bubbles: true }));
-          t.el.dispatchEvent(new Event("change", { bubbles: true }));
+    if (/soldan\s+sağa\s+\d+\s+sekme\s+kapat/.test(low)) {
+      const n = Number(low.match(/soldan\s+sağa\s+(\d+)\s+sekme\s+kapat/)?.[1] || 1);
+      return closeMany("left", n);
+    }
+    if (/sağdan\s+sola\s+\d+\s+sekme\s+kapat/.test(low)) {
+      const n = Number(low.match(/sağdan\s+sola\s+(\d+)\s+sekme\s+kapat/)?.[1] || 1);
+      return closeMany("right", n);
+    }
+
+    if (low.includes("isimli sekmeyi kapat") || /"[^"]+"/.test(q)) {
+      const names = parseCloseNames(q);
+      if (!names.length) return "Sekme adı anlayamadım.";
+      let closed = 0;
+      for (const name of names) {
+        const tab = findTabByName(name);
+        if (tab && state.tabs.length > 1) {
+          await closeTabViaCursor(tab.id);
+          closed += 1;
         }
       }
-      return `Seçili alanlara ${highlight(write)} yazdım.`;
+      return `${closed} isimli sekme kapatıldı.`;
     }
-  }
 
-  return "Agent Mode 2.0: komutu anlayamadım. Örn: 'youtube arat 2. linke tıkla' veya 'seçili öğelere tıkla'.";
+    const parsed = parseSearchCommand(q);
+    if (parsed.query) {
+      await clickElement(el.newTabBtn);
+      moveCursorTo(el.aramaInput);
+      await sleep(220);
+      const tab = currentTab();
+      if (tab) setTabTitle(tab, parsed.query);
+      el.aramaInput.value = "";
+      for (const ch of parsed.query) {
+        el.aramaInput.value += ch;
+        await sleep(26);
+      }
+      el.aramaForm.requestSubmit();
+      await sleep(1200);
+      const cards = [...document.querySelectorAll(".result-item")];
+      const idx = Math.min(parsed.linkIndex - 1, cards.length - 1);
+      const btn = cards[idx]?.querySelector(".open-link");
+      if (!btn) return "Sonuç bulunamadı.";
+      await clickElement(btn);
+      return `Şunu istedin: ${escapeHtml(parsed.query)}. Şunu yaptım: ${parsed.linkIndex}. linke girdim.`;
+    }
+
+    if (state.selectedTargets.length) {
+      if (/tıkla/.test(low)) {
+        for (const t of state.selectedTargets) {
+          moveCursorTo(t.el);
+          await sleep(180);
+          t.el.click();
+          await sleep(160);
+        }
+        return "Seçtiğin öğelere sırayla tıkladım.";
+      }
+
+      const write = q.match(/(?:yaz|değiştir|yap)\s+(.+)/i)?.[1]?.trim();
+      if (write) {
+        for (const t of state.selectedTargets) {
+          if ("value" in t.el) {
+            moveCursorTo(t.el);
+            await sleep(150);
+            t.el.focus();
+            t.el.value = write.replace(/"/g, "");
+            t.el.dispatchEvent(new Event("input", { bubbles: true }));
+            t.el.dispatchEvent(new Event("change", { bubbles: true }));
+          }
+        }
+        return `Seçili alanlara ${highlight(write)} yazdım.`;
+      }
+    }
+
+    return "Agent Mode 2.0 komutu anlaşılamadı.";
+  } finally {
+    state.agentBusy = false;
+    agentCursor.style.opacity = "0";
+  }
 }
 
 async function answerNormal(q) {
-  const low = q.toLowerCase();
-  if (/(geri|ileri|yenile|yeni sekme)/.test(low)) {
-    return `Bunu ben yapayım dersen ${highlight("Agent Mode 2.0")} açıp tekrar yaz.`;
+  const low = normalize(q);
+  if (/(geri|ileri|yenile|yeni sekme|kapat)/.test(low)) {
+    return `Bunu otomatik yapmam için ${highlight("Agent Mode 2.0")} aç.`;
   }
 
   const topic = siteHintFromText(q);
   const wiki = await fetchWikipediaSnippet(topic);
 
   if (/kuruluş|kaç yılında|ne zaman/.test(low)) {
-    return `${highlight(topic)} için kuruluş yılı bilgisi: ${highlight(wiki ? "Wikipedia'dan özet bulundu" : "detay için kaynak gerekli")}.`;
+    return `${highlight(topic)} kuruluş bilgisi: ${highlight("Wikipedia özeti ile bulundu")}.`;
   }
-
   if (/isim|adı/.test(low)) {
-    return `Web sitesi adı: ${highlight(topic)}.`;
+    return `Site adı: ${highlight(topic)}.`;
   }
-
   if (/amaç|ne işe yarar|hakkında/.test(low)) {
-    const summary = wiki || `${topic} genel olarak bilgi/hizmet sunar.`;
-    return `${highlight(topic)} amacı:\n${escapeHtml(summary)}`;
+    return `${highlight(topic)} amacı:\n${escapeHtml(wiki || `${topic} genel olarak bilgi/hizmet sunar.`)}`;
   }
-
-  return `${highlight(topic)} hakkında özet:\n${escapeHtml(wiki || "Wikipedia özeti bulunamadı.")}`;
+  return `${highlight(topic)} özeti:\n${escapeHtml(wiki || "Özet bulunamadı")}`;
 }
 
 function initPrompts() {
   const prompts = [
     { text: "YouTube'un amacı nedir?", agent: false },
     { text: "shopify arat 1. linke tıkla", agent: true },
-    { text: "Yeni sekme aç", agent: true },
+    { text: "10 yeni sekme aç", agent: true },
   ];
+
   prompts.forEach((p) => {
     const b = document.createElement("button");
     b.type = "button";
@@ -425,19 +536,21 @@ el.aramaForm.addEventListener("submit", async (e) => {
   e.preventDefault();
   const q = el.aramaInput.value.trim();
   if (!q) return;
+  const tab = currentTab();
+  if (tab) { setTabTitle(tab, q); renderTabs(); }
   el.sonuclar.innerHTML = `<span class="searching-status">Ekranında arıyorum...</span>`;
-  try { renderResults(await getSearchResults(q)); }
-  catch { el.sonuclar.innerHTML = "Sonuç alınamadı."; }
+  const results = await getSearchResults(q);
+  renderResults(results, q);
 });
 
 el.adresCubugu.addEventListener("keydown", (e) => { if (e.key === "Enter") openUrl(el.adresCubugu.value); });
 el.geriBtn.addEventListener("click", () => {
   const t = currentTab();
-  if (t && t.index > 0) { t.index -= 1; t.url = t.history[t.index]; syncTabView(); renderTabs(); }
+  if (t && t.index > 0) { t.index -= 1; t.url = t.history[t.index]; syncTabView(); }
 });
 el.ileriBtn.addEventListener("click", () => {
   const t = currentTab();
-  if (t && t.index < t.history.length - 1) { t.index += 1; t.url = t.history[t.index]; syncTabView(); renderTabs(); }
+  if (t && t.index < t.history.length - 1) { t.index += 1; t.url = t.history[t.index]; syncTabView(); }
 });
 el.yenileBtn.addEventListener("click", () => { if (el.siteFrame.src) el.siteFrame.src = el.siteFrame.src; });
 el.newTabBtn.addEventListener("click", () => createTab());
@@ -463,6 +576,7 @@ el.loginForm.addEventListener("submit", (e) => {
   };
   const file = document.getElementById("profil").files[0];
   if (!user.email || !user.ad || !user.soyad) return;
+
   if (file) {
     const reader = new FileReader();
     reader.onload = () => {

--- a/script.js
+++ b/script.js
@@ -4,18 +4,28 @@ const state = {
   user: JSON.parse(localStorage.getItem("balukUser") || "null"),
   thinkingTimer: null,
   thinkingTicker: null,
-  agentMode: false,
 };
 
 const THINKING_LINES = [
   "Baluk.ai düşünüyor...",
   "Web sayfasına bakıyorum...",
-  "İçerik kaynaklarını karşılaştırıyorum...",
-  "Sayfadaki ipuçlarından anlam çıkarıyorum...",
-  "En iyi cevabı hazırlıyorum..."
+  "Hakkında/başlık bilgilerini tarıyorum...",
+  "Kaynaklardan kısa özet çıkarıyorum...",
+  "Cevabı netleştiriyorum..."
 ];
 
+const SITE_HINTS = {
+  "youtube.com": { name: "YouTube", purpose: "kullanıcıların video izleyip içerik yüklediği bir video paylaşım platformu", company: "Google / Alphabet", year: "2005" },
+  "google.com": { name: "Google", purpose: "web araması ve internet servisleri sağlamak", company: "Google / Alphabet", year: "1998" },
+  "wikipedia.org": { name: "Wikipedia", purpose: "özgür ansiklopedi içeriği sağlamak", company: "Wikimedia Foundation", year: "2001" },
+  "github.com": { name: "GitHub", purpose: "yazılım projelerini Git tabanlı barındırma ve işbirliği", company: "GitHub (Microsoft)", year: "2008" },
+  "instagram.com": { name: "Instagram", purpose: "fotoğraf/video paylaşımı ve sosyal etkileşim", company: "Meta", year: "2010" },
+  "x.com": { name: "X", purpose: "kısa gönderilerle sosyal paylaşım ve haber akışı", company: "X Corp.", year: "2006" },
+  "twitter.com": { name: "Twitter (X)", purpose: "kısa gönderilerle sosyal paylaşım ve haber akışı", company: "X Corp.", year: "2006" }
+};
+
 const el = {
+  contentGrid: document.getElementById("contentGrid"),
   aramaForm: document.getElementById("aramaForm"),
   aramaInput: document.getElementById("aramaInput"),
   sonuclar: document.getElementById("sonuclar"),
@@ -48,17 +58,13 @@ const el = {
 };
 
 function escapeHtml(text) {
-  return text
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#039;");
+  return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#039;");
 }
+function ensureUrl(value) { return /^https?:\/\//i.test(value) ? value : `https://${value}`; }
 
-function ensureUrl(value) {
-  if (!value) return "";
-  return /^https?:\/\//i.test(value) ? value : `https://${value}`;
+function setPanel(open) {
+  el.aiPanel.classList.toggle("hidden", !open);
+  el.contentGrid.classList.toggle("with-panel", open);
 }
 
 function openUrl(url, addToHistory = true) {
@@ -68,12 +74,26 @@ function openUrl(url, addToHistory = true) {
   el.adresCubugu.value = safe;
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
-
   if (addToHistory) {
     state.history = state.history.slice(0, state.index + 1);
     state.history.push(safe);
     state.index = state.history.length - 1;
   }
+}
+
+function parseSite(urlCandidate) {
+  let url;
+  try { url = new URL(ensureUrl(urlCandidate)); } catch { return null; }
+  const host = url.hostname.replace(/^www\./, "").toLowerCase();
+  const matchKey = Object.keys(SITE_HINTS).find((key) => host.endsWith(key));
+  if (matchKey) return { ...SITE_HINTS[matchKey], host, url: url.href };
+  const base = host.split(".")[0] || "web sitesi";
+  return {
+    name: base.charAt(0).toUpperCase() + base.slice(1),
+    purpose: "webde bilgi/hizmet sunmak",
+    company: "kesin şirket bilgisi için site hakkında bölümü gerekir",
+    year: "kuruluş yılı net değil"
+  };
 }
 
 function renderAuth() {
@@ -90,51 +110,37 @@ function renderAuth() {
 }
 
 function createFallbackResults(query) {
-  const safeQuery = encodeURIComponent(query);
+  const q = encodeURIComponent(query);
   return [
-    {
-      title: `DuckDuckGo'da "${query}" araması`,
-      href: `https://duckduckgo.com/?q=${safeQuery}`,
-      snippet: "DuckDuckGo sonuç sayfasını açar."
-    },
-    {
-      title: `Wikipedia sonucu: ${query}`,
-      href: `https://tr.wikipedia.org/wiki/Özel:Arama?search=${safeQuery}`,
-      snippet: "Wikipedia üzerinden hızlı kaynak taraması."
-    }
+    { title: `DuckDuckGo: ${query}`, href: `https://duckduckgo.com/?q=${q}`, snippet: "DuckDuckGo sonuç sayfasını açar." },
+    { title: `Wikipedia araması: ${query}`, href: `https://tr.wikipedia.org/wiki/Özel:Arama?search=${q}`, snippet: "Wikipedia üzerinden hızlı kaynak taraması." }
   ];
 }
 
 async function getSearchResults(query) {
-  const url = `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_redirect=1&no_html=1`;
-  const response = await fetch(url);
-  if (!response.ok) throw new Error("DuckDuckGo API erişimi başarısız.");
+  const response = await fetch(`https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_redirect=1&no_html=1`);
+  if (!response.ok) throw new Error("duckduckgo error");
   const data = await response.json();
-
   const parsed = [];
-
-  if (data.AbstractURL) {
-    parsed.push({
-      title: data.Heading || query,
-      href: data.AbstractURL,
-      snippet: data.AbstractText || "Özet bilgi"
-    });
-  }
-
+  if (data.AbstractURL) parsed.push({ title: data.Heading || query, href: data.AbstractURL, snippet: data.AbstractText || "Özet bilgi" });
   (data.RelatedTopics || []).forEach((item) => {
-    if (item.FirstURL && item.Text) {
-      parsed.push({ title: item.Text.split(" - ")[0], href: item.FirstURL, snippet: item.Text });
-    }
-    if (Array.isArray(item.Topics)) {
-      item.Topics.forEach((sub) => {
-        if (sub.FirstURL && sub.Text) {
-          parsed.push({ title: sub.Text.split(" - ")[0], href: sub.FirstURL, snippet: sub.Text });
-        }
-      });
-    }
+    if (item.FirstURL && item.Text) parsed.push({ title: item.Text.split(" - ")[0], href: item.FirstURL, snippet: item.Text });
+    (item.Topics || []).forEach((sub) => {
+      if (sub.FirstURL && sub.Text) parsed.push({ title: sub.Text.split(" - ")[0], href: sub.FirstURL, snippet: sub.Text });
+    });
   });
-
   return parsed.slice(0, 8);
+}
+
+function askAboutSite(url, customQuestion = "") {
+  setPanel(true);
+  if (!state.user) {
+    el.aiCevap.textContent = "Bu siteyi analiz etmek için önce giriş yapman gerekiyor.";
+    return;
+  }
+  const q = customQuestion || `Bu web sitesi ne amaçla kurulmuştur? (${url})`;
+  el.aiSoru.value = q;
+  el.aiForm.requestSubmit();
 }
 
 function renderResults(results, query) {
@@ -147,11 +153,14 @@ function renderResults(results, query) {
     card.innerHTML = `
       <h3><a href="#">${escapeHtml(item.title)}</a></h3>
       <p>${escapeHtml(item.snippet || "Açıklama yok")}</p>
+      <div class="result-actions">
+        <button type="button" class="open-link">Bağlantıyı Aç</button>
+        <button type="button" class="ask-link">✦ Baluk.ai'ye Sor</button>
+      </div>
     `;
-    card.querySelector("a").addEventListener("click", (e) => {
-      e.preventDefault();
-      openUrl(item.href);
-    });
+    card.querySelector("a").addEventListener("click", (e) => { e.preventDefault(); openUrl(item.href); });
+    card.querySelector(".open-link").addEventListener("click", () => openUrl(item.href));
+    card.querySelector(".ask-link").addEventListener("click", () => askAboutSite(item.href, `${item.title} sitesi ne işe yarar, kim tarafından kuruldu ve ne zaman kuruldu?`));
     el.sonuclar.appendChild(card);
   });
 }
@@ -161,59 +170,48 @@ function startThinking() {
   el.thinkingBox.classList.remove("hidden");
   el.spinLogo.classList.add("active");
   document.body.classList.add("web-glow");
-
   let idx = 0;
   el.thinkingText.textContent = THINKING_LINES[0];
   state.thinkingTicker = setInterval(() => {
     idx = (idx + 1) % THINKING_LINES.length;
     el.thinkingText.textContent = THINKING_LINES[idx];
-  }, 2600);
+  }, 2400);
 }
 
 function stopThinking() {
   clearInterval(state.thinkingTicker);
-  state.thinkingTicker = null;
   el.thinkingBox.classList.add("hidden");
   el.spinLogo.classList.remove("active");
   document.body.classList.remove("web-glow");
 }
 
 function buildAiAnswer(q) {
-  if (/kaç yılında|ne zaman/i.test(q)) {
-    return "Kuruluş zamanı odaklı analiz: Baluk.ai sayfada tarih/sürüm/hakkında alanlarından kuruluş yılını çıkarmaya çalışır.";
-  }
-  if (/hangi şirket|kim tarafından/i.test(q)) {
-    return "Kurucu/şirket odaklı analiz: Baluk.ai sayfanın footer, about, iletişim ve yasal bölümlerini tarayıp sahiplik bilgisini özetler.";
-  }
-  if (/amacı|ne için/i.test(q)) {
-    return "Amaç odaklı analiz: Baluk.ai ürün açıklamaları ve başlıkları inceleyerek sitenin ana kullanım amacını kısaca anlatır.";
-  }
+  const currentUrl = el.adresCubugu.value || q.match(/https?:\/\/\S+/)?.[0] || "";
+  const site = parseSite(currentUrl || "example.com");
+  const siteName = site?.name || "Bu site";
 
-  const page = el.adresCubugu.value || "açık sayfa";
-  return `${page} için genel analiz: kuruluş zamanı, amacı ve olası şirket bilgisini tek özetten verir.`;
+  if (/kaç yılında|ne zaman/i.test(q)) return `${siteName} için bulduğum bilgi: kuruluş yılı ${site.year}.`;
+  if (/hangi şirket|kim tarafından/i.test(q)) return `${siteName} için şirket/kurucu bilgisi: ${site.company}.`;
+  if (/amacı|ne için|ne işe yarar/i.test(q)) return `${siteName}, ${site.purpose}.`;
+
+  return `${siteName} özeti: ${site.year} yılında kurulduğu biliniyor, ${site.company} tarafından geliştirildi/işletiliyor ve ana amacı ${site.purpose}.`;
 }
 
 function sendAgentFillInstruction() {
   const instruction = prompt("Seçtiğin input'a ne yazılsın?");
   if (!instruction) return;
-
   try {
     const doc = el.siteFrame.contentDocument;
     if (!doc) throw new Error("iframe erişimi yok");
-
     const target = doc.querySelector("input:focus, textarea:focus") || doc.querySelector("input, textarea");
-    if (!target) {
-      el.aiCevap.textContent = "Agent Mode: Bu sayfada doldurulabilir input bulunamadı.";
-      return;
-    }
-
+    if (!target) return (el.aiCevap.textContent = "Agent Mode: Bu sayfada doldurulabilir input bulunamadı.");
     target.focus();
     target.value = instruction;
     target.dispatchEvent(new Event("input", { bubbles: true }));
     target.dispatchEvent(new Event("change", { bubbles: true }));
-    el.aiCevap.textContent = `Agent Mode tamamlandı: Seçilen alana "${instruction}" yazıldı.`;
+    el.aiCevap.textContent = `Agent Mode tamamlandı: "${instruction}" yazıldı.`;
   } catch {
-    el.aiCevap.textContent = "Agent Mode güvenlik sınırı: Bu site farklı domain olduğu için doğrudan input doldurma yapılamadı. Aynı domain sayfalarda çalışır.";
+    el.aiCevap.textContent = "Agent Mode güvenlik sınırı: Farklı domaine doğrudan yazılamıyor. Aynı domain sayfalarda çalışır.";
   }
 }
 
@@ -221,58 +219,28 @@ el.aramaForm.addEventListener("submit", async (event) => {
   event.preventDefault();
   const q = el.aramaInput.value.trim();
   if (!q) return;
-
   el.sonuclar.innerHTML = "Aranıyor...";
-  try {
-    const results = await getSearchResults(q);
-    renderResults(results, q);
-  } catch {
-    renderResults(createFallbackResults(q), q);
-  }
+  try { renderResults(await getSearchResults(q), q); }
+  catch { renderResults(createFallbackResults(q), q); }
 });
 
-el.adresCubugu.addEventListener("keydown", (e) => {
-  if (e.key === "Enter") openUrl(el.adresCubugu.value);
-});
-
-el.geriBtn.addEventListener("click", () => {
-  if (state.index > 0) {
-    state.index -= 1;
-    openUrl(state.history[state.index], false);
-  }
-});
-
-el.ileriBtn.addEventListener("click", () => {
-  if (state.index < state.history.length - 1) {
-    state.index += 1;
-    openUrl(state.history[state.index], false);
-  }
-});
-
-el.yenileBtn.addEventListener("click", () => {
-  if (el.siteFrame.src) el.siteFrame.src = el.siteFrame.src;
-});
-
-el.newTabBtn.addEventListener("click", () => {
-  el.homeView.classList.remove("hidden");
-  el.webView.classList.add("hidden");
-  el.adresCubugu.value = "";
-});
-
-el.balukPanelBtn.addEventListener("click", () => el.aiPanel.classList.toggle("hidden"));
-el.closePanelBtn.addEventListener("click", () => el.aiPanel.classList.add("hidden"));
+el.adresCubugu.addEventListener("keydown", (e) => { if (e.key === "Enter") openUrl(el.adresCubugu.value); });
+el.geriBtn.addEventListener("click", () => { if (state.index > 0) openUrl(state.history[--state.index], false); });
+el.ileriBtn.addEventListener("click", () => { if (state.index < state.history.length - 1) openUrl(state.history[++state.index], false); });
+el.yenileBtn.addEventListener("click", () => { if (el.siteFrame.src) el.siteFrame.src = el.siteFrame.src; });
+el.newTabBtn.addEventListener("click", () => { el.homeView.classList.remove("hidden"); el.webView.classList.add("hidden"); el.adresCubugu.value = ""; });
+el.balukPanelBtn.addEventListener("click", () => setPanel(el.aiPanel.classList.contains("hidden")));
+el.closePanelBtn.addEventListener("click", () => setPanel(false));
 
 el.loginForm.addEventListener("submit", (e) => {
   e.preventDefault();
   const user = {
     email: document.getElementById("mail").value.trim(),
     ad: document.getElementById("ad").value.trim(),
-    soyad: document.getElementById("soyad").value.trim(),
+    soyad: document.getElementById("soyad").value.trim()
   };
-
   const file = document.getElementById("profil").files[0];
   if (!user.email || !user.ad || !user.soyad) return;
-
   if (file) {
     const reader = new FileReader();
     reader.onload = () => {
@@ -289,14 +257,10 @@ el.loginForm.addEventListener("submit", (e) => {
   }
 });
 
-el.plusBtn.addEventListener("click", () => {
-  el.agentMenu.classList.toggle("hidden");
-});
-
+el.plusBtn.addEventListener("click", () => el.agentMenu.classList.toggle("hidden"));
 el.agentModeBtn.addEventListener("click", () => {
-  state.agentMode = true;
   el.agentMenu.classList.add("hidden");
-  el.aiCevap.textContent = "Agent Mode aktif. Hedef input alanına tıkla, sonra komut verilecek.";
+  el.aiCevap.textContent = "Agent Mode aktif. Input alanına odaklanıp komutu ver.";
   sendAgentFillInstruction();
 });
 
@@ -304,9 +268,7 @@ el.aiForm.addEventListener("submit", (e) => {
   e.preventDefault();
   const q = el.aiSoru.value.trim();
   if (!q) return;
-
   startThinking();
-
   clearTimeout(state.thinkingTimer);
   state.thinkingTimer = setTimeout(() => {
     stopThinking();
@@ -323,3 +285,4 @@ el.aiSoru.addEventListener("keydown", (e) => {
 });
 
 renderAuth();
+setPanel(false);

--- a/script.js
+++ b/script.js
@@ -100,6 +100,21 @@ const el = {
   appShell: document.getElementById("appShell"),
 };
 
+
+
+function forceRevealApp() {
+  if (el.introOverlay) el.introOverlay.classList.add("hidden");
+  if (el.appShell) {
+    el.appShell.classList.remove("app-hidden");
+    el.appShell.style.pointerEvents = "auto";
+  }
+}
+
+window.addEventListener("load", () => {
+  setTimeout(forceRevealApp, 1200);
+});
+setTimeout(forceRevealApp, 9000);
+
 const agentCursor = document.createElement("div");
 agentCursor.id = "agentCursor";
 agentCursor.style.cssText = "position:fixed;width:18px;height:18px;border:2px solid #b78cff;background:radial-gradient(circle,#6b24dd 0%,#141020 75%);border-radius:50%;box-shadow:0 0 18px rgba(141,69,255,.85);z-index:9999;pointer-events:none;opacity:0;transform:translate(-50%,-50%);transition:left .25s ease, top .25s ease, opacity .15s ease;";
@@ -129,14 +144,18 @@ function playIntroSound() {
 }
 
 function runIntro() {
+  let revealed = false;
+
   const revealApp = () => {
-    if (!el.appShell || !el.introOverlay) return;
-    el.introOverlay.classList.add("hidden");
-    el.appShell.classList.remove("app-hidden");
-    el.appShell.style.pointerEvents = "auto";
+    if (revealed) return;
+    revealed = true;
+    forceRevealApp();
   };
 
-  if (!el.appShell || !el.introOverlay) return;
+  if (!el.appShell || !el.introOverlay) {
+    revealApp();
+    return;
+  }
 
   const reducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
   const introDuration = reducedMotion ? 2350 : 4800;
@@ -556,6 +575,18 @@ async function answerNormal(q) {
     return `Bunu otomatik yapmam için ${highlight("Agent Mode 2.0")} aç.`;
   }
 
+  if (/(merhaba|selam|hey|günaydın|iyi akşamlar)/.test(low)) {
+    return `${highlight("Merhaba!")} İyiyim, hazırım ✦ İstersen web araştırması, istersen normal sohbet yapabiliriz.`;
+  }
+
+  if (/(nasılsın|naber|iyi misin)/.test(low)) {
+    return `Gayet iyiyim 🙌 ${highlight("Baluk.ai")} olarak hem web tarafında hem de genel konularda yardımcı olabilirim.`;
+  }
+
+  if (/(sen kimsin|nesin|kimsin)/.test(low)) {
+    return `${highlight("Ben Baluk.ai")}, Baluk Screatch içinde çalışan yardımcı modelim. Web analiz, özetleme ve genel soru-cevap yapabilirim.`;
+  }
+
   const asksCurrentSite = /\bbu\s+web\s*site|\bbu\s+site|ekrandaki\s+site|açık\s+site|şu\s+site/.test(low);
   const asksGenericWeb = /web\s*site\s*nedir|webin\s+ne\s+oldu|web\s*sitenin\s+amacı\s+ne/.test(low);
 
@@ -608,6 +639,16 @@ Web modu özeti: ${escapeHtml(sum)}`;
     return `${highlight("Baluk.ai web modu aktif")}
 ${highlight(genericTopic)} hakkında:
 ${escapeHtml(sourceText || `${genericTopic} hakkında yeterli veri bulunamadı.`)}`;
+  }
+
+  if (!asksCurrentSite && !asksGenericWeb) {
+    const general = await fetchWebModeAnswer(q);
+    if (general) {
+      return `${highlight("Baluk.ai genel mod")}
+${escapeHtml(general)}`;
+    }
+    return `${highlight("Baluk.ai genel mod")}
+Bu konuda sohbet edebiliriz. Daha net istersen sorunu biraz detaylandır.`;
   }
 
   return `${highlight(genericTopic)} özeti:

--- a/script.js
+++ b/script.js
@@ -57,12 +57,57 @@ const el = {
   plusBtn: document.getElementById("plusBtn"),
   agentMenu: document.getElementById("agentMenu"),
   agentModeBtn: document.getElementById("agentModeBtn"),
+  introOverlay: document.getElementById("introOverlay"),
+  introCard: document.getElementById("introCard"),
+  introSubtitle: document.getElementById("introSubtitle"),
+  appShell: document.getElementById("appShell"),
 };
 
 const agentCursor = document.createElement("div");
 agentCursor.id = "agentCursor";
 agentCursor.style.cssText = "position:fixed;width:18px;height:18px;border:2px solid #b78cff;background:radial-gradient(circle,#6b24dd 0%,#141020 75%);border-radius:50%;box-shadow:0 0 18px rgba(141,69,255,.85);z-index:9999;pointer-events:none;opacity:0;transform:translate(-50%,-50%);transition:left .35s ease, top .35s ease, opacity .2s ease;";
 document.body.appendChild(agentCursor);
+
+
+function playIntroSound() {
+  try {
+    const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    const oscillator = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+
+    oscillator.type = "triangle";
+    oscillator.frequency.setValueAtTime(180, audioCtx.currentTime);
+    oscillator.frequency.exponentialRampToValueAtTime(520, audioCtx.currentTime + 0.32);
+
+    gain.gain.setValueAtTime(0.0001, audioCtx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.2, audioCtx.currentTime + 0.12);
+    gain.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + 0.82);
+
+    oscillator.connect(gain);
+    gain.connect(audioCtx.destination);
+    oscillator.start();
+    oscillator.stop(audioCtx.currentTime + 0.85);
+
+    oscillator.onended = () => audioCtx.close();
+  } catch {
+    // Sessiz geçiş fallback
+  }
+}
+
+function runIntro() {
+  const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const introDuration = reducedMotion ? 350 : 2800;
+
+  if (!el.introOverlay || !el.appShell) return;
+
+  playIntroSound();
+
+  setTimeout(() => {
+    el.introOverlay.classList.add("hidden");
+    el.appShell.classList.remove("app-hidden");
+    el.appShell.style.pointerEvents = "auto";
+  }, introDuration);
+}
 
 function escapeHtml(text) {
   return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#039;");
@@ -386,3 +431,4 @@ el.aiSoru.addEventListener("keydown", (e) => {
 
 renderAuth();
 setPanel(false);
+runIntro();

--- a/script.js
+++ b/script.js
@@ -8,6 +8,7 @@ const state = {
   agentModeActive: false,
   agentBusy: false,
   selectedTargets: [],
+  markMode: false,
 };
 
 const THINKING_LINES = [
@@ -53,6 +54,7 @@ const el = {
   selectedTargets: document.getElementById("selectedTargets"),
   agentBadge: document.getElementById("agentBadge"),
   agentBadgeClose: document.getElementById("agentBadgeClose"),
+  markToggleBtn: document.getElementById("markToggleBtn"),
   quickPrompts: document.getElementById("quickPrompts"),
   introOverlay: document.getElementById("introOverlay"),
   appShell: document.getElementById("appShell"),
@@ -267,6 +269,8 @@ function stopThinking() {
 
 function setAgentMode(on) {
   state.agentModeActive = on;
+  state.markMode = false;
+  el.markToggleBtn?.classList.remove("active");
   el.agentBadge.classList.toggle("hidden", !on);
   el.agentModeBtn.textContent = on ? "Agent Mode 2.0 (Açık)" : "Agent Mode 2.0";
   if (!on) {
@@ -296,7 +300,7 @@ function bindAgentPicker() {
     const doc = el.siteFrame.contentDocument;
     if (!doc) throw new Error();
     doc.addEventListener("click", (e) => {
-      if (!state.agentModeActive) return;
+      if (!state.agentModeActive || !state.markMode) return;
       const t = e.target;
       if (!(t instanceof HTMLElement)) return;
       e.preventDefault(); e.stopPropagation();
@@ -306,12 +310,27 @@ function bindAgentPicker() {
       renderSelectedTargets();
       el.aiCevap.innerHTML = `Seçildi: ${highlight(label)}.`;
     }, { capture: true });
-    el.aiCevap.innerHTML = "Agent Mode 2.0 açık. Sayfadan birden çok öğe seçebilirsin.";
+    el.aiCevap.innerHTML = "Agent Mode 2.0 açık. Kalem (✎) ile işaretleme modunu açıp seçim yapabilirsin.";
   } catch {
     el.aiCevap.innerHTML = "Bu sayfada güvenlik nedeniyle işaretleme yapılamıyor (farklı domain).";
   }
 }
 
+
+function toggleMarkMode() {
+  if (!state.agentModeActive) return;
+  state.markMode = !state.markMode;
+  el.markToggleBtn?.classList.toggle("active", state.markMode);
+  el.aiCevap.innerHTML = state.markMode
+    ? "İşaretleme açık: sayfadan öğelere tıklayıp seçebilirsin."
+    : "İşaretleme kapalı.";
+}
+
+function selectedInfo() {
+  if (!state.selectedTargets.length) return "Önce kalemle bir öğe seç.";
+  const labels = state.selectedTargets.map((t) => t.label).join(", ");
+  return `Seçtiğin alan(lar): ${highlight(labels)}.`;
+}
 function parseSearchCommand(q) {
   const t = normalize(q).replace(/^hey baluk\s+/i, "");
   const m1 = t.match(/^ara\s+(.+)$/i);
@@ -443,6 +462,10 @@ async function runAgentTask(q) {
       return `Şunu istedin: ${escapeHtml(parsed.query)}. Şunu yaptım: ${parsed.linkIndex}. linke girdim.`;
     }
 
+    if (/anlamı ne|bu ne|bu nedir/.test(low)) {
+      return selectedInfo();
+    }
+
     if (state.selectedTargets.length) {
       if (/tıkla/.test(low)) {
         for (const t of state.selectedTargets) {
@@ -564,6 +587,7 @@ el.agentModeBtn.addEventListener("click", () => {
   el.agentMenu.classList.add("hidden");
   if (state.agentModeActive) bindAgentPicker();
 });
+el.markToggleBtn?.addEventListener("click", toggleMarkMode);
 el.agentBadgeClose.addEventListener("click", () => setAgentMode(false));
 el.siteFrame.addEventListener("load", () => { if (state.agentModeActive) bindAgentPicker(); });
 

--- a/script.js
+++ b/script.js
@@ -18,6 +18,51 @@ const THINKING_LINES = [
   "Anlamlı parçaları ayırıyorum...",
   "En doğru özeti hazırlıyorum..."
 ];
+const SITE_KNOWLEDGE = {
+  "youtube.com": {
+    name: "YouTube",
+    year: "2005",
+    company: "Jawed Karim, Steve Chen ve Chad Hurley tarafından kuruldu; daha sonra Google (Alphabet) tarafından satın alındı.",
+    purpose: "Video izleme, paylaşma ve içerik üreticilerinin yayın yapması için tasarlanmış bir platformdur.",
+    summary: "YouTube, kullanıcıların video yükleyip izleyebildiği, canlı yayın yapabildiği ve içerik ekosistemi oluşturabildiği küresel bir video platformudur."
+  },
+  "google.com": {
+    name: "Google",
+    year: "1998",
+    company: "Larry Page ve Sergey Brin tarafından kuruldu.",
+    purpose: "Web üzerinde bilgiye hızlı erişim sağlayan arama motoru ve internet servisleri sunmak.",
+    summary: "Google, arama motoru merkezli başlayan ve e-posta, haritalar, bulut, reklam gibi alanlarda büyüyen bir teknoloji platformudur."
+  },
+  "wikipedia.org": {
+    name: "Wikipedia",
+    year: "2001",
+    company: "Jimmy Wales ve Larry Sanger tarafından başlatıldı; Wikimedia Foundation tarafından yönetilir.",
+    purpose: "Özgür ve ortaklaşa düzenlenen ansiklopedi içeriği sunmak.",
+    summary: "Wikipedia, gönüllüler tarafından düzenlenen çok dilli, açık lisanslı bir çevrimiçi ansiklopedidir."
+  },
+  "github.com": {
+    name: "GitHub",
+    year: "2008",
+    company: "Tom Preston-Werner, Chris Wanstrath, PJ Hyett ve Scott Chacon tarafından kuruldu; Microsoft bünyesindedir.",
+    purpose: "Yazılım projeleri için Git tabanlı kod barındırma ve iş birliği sağlamak.",
+    summary: "GitHub, geliştiricilerin kod depoladığı, sürüm takip ettiği ve ekip olarak yazılım geliştirdiği bir platformdur."
+  },
+  "instagram.com": {
+    name: "Instagram",
+    year: "2010",
+    company: "Kevin Systrom ve Mike Krieger tarafından kuruldu; Meta bünyesindedir.",
+    purpose: "Fotoğraf ve video paylaşımı ile sosyal etkileşim sağlamak.",
+    summary: "Instagram, görsel odaklı paylaşım, hikaye/reels formatları ve sosyal etkileşim özellikleri sunan bir platformdur."
+  },
+  "shopify.com": {
+    name: "Shopify",
+    year: "2006",
+    company: "Tobias Lütke, Daniel Weinand ve Scott Lake tarafından kuruldu.",
+    purpose: "İşletmelerin çevrimiçi mağaza kurup yönetmesini sağlamak.",
+    summary: "Shopify, e-ticaret sitesi kurma, ödeme alma ve sipariş yönetimi gibi süreçleri tek panelde sunan bir altyapıdır."
+  }
+};
+
 
 const el = {
   tabs: document.getElementById("tabs"),
@@ -251,7 +296,17 @@ function getCurrentSiteContext() {
     const u = new URL(raw);
     const host = u.hostname.replace(/^www\./, "");
     const name = host.split(".")[0] || host;
-    return { host, name: name.charAt(0).toUpperCase() + name.slice(1), url: u.href };
+    const key = Object.keys(SITE_KNOWLEDGE).find((k) => host.endsWith(k));
+    const known = key ? SITE_KNOWLEDGE[key] : null;
+    return {
+      host,
+      name: known?.name || (name.charAt(0).toUpperCase() + name.slice(1)),
+      url: u.href,
+      year: known?.year || "kesin yıl bilgisi bulunamadı",
+      company: known?.company || "kurucu/şirket bilgisi için resmi Hakkında sayfasına bakılmalı",
+      purpose: known?.purpose || "kullanıcıya bilgi/hizmet sunmak için tasarlanmış bir web platformu",
+      summary: known?.summary || `${name.charAt(0).toUpperCase() + name.slice(1)} için özet bilgi çıkarıldı; detay için resmi kaynaklar incelenmeli.`,
+    };
   } catch {
     return null;
   }
@@ -666,7 +721,7 @@ async function answerNormal(q) {
     return `Bunu otomatik yapmam için ${highlight("Agent Mode 2.0")} aç.`;
   }
 
-  const asksCurrentSite = /\bbu\s+web\s*site|\bbu\s+site|ekrandaki\s+site|açık\s+site|şu\s+site/.test(low);
+  const asksCurrentSite = /bu\s+web\s*site|bu\s+site|ekrandaki\s+site|açık\s+site|şu\s+site/.test(low);
   const asksGenericWeb = /web\s*site\s*nedir|webin\s+ne\s+oldu|web\s*sitenin\s+amacı\s+ne/.test(low);
 
   if (asksGenericWeb && !asksCurrentSite) {
@@ -678,26 +733,47 @@ async function answerNormal(q) {
     return `Önce bir site aç, sonra ${highlight("bu web sitenin amacı ne")} diye sor; ekrandaki siteyi yorumlayayım.`;
   }
 
-  const topic = asksCurrentSite ? (current?.name || "açık site") : siteHintFromText(q);
-  const wiki = await fetchWikipediaSnippet(topic);
+  const topic = asksCurrentSite ? current : null;
+  const genericTopic = siteHintFromText(q);
+  const wiki = await fetchWikipediaSnippet(asksCurrentSite ? (topic?.name || "") : genericTopic);
+
+  if (asksCurrentSite) {
+    if (/kuruluş|kaç yılında|ne zaman/.test(low)) {
+      return `${highlight(topic.name)} kuruluş yılı: ${highlight(topic.year)}.`;
+    }
+    if (/kim tarafından|hangi şirket|kurucu/.test(low)) {
+      return `${highlight(topic.name)} kurucu/şirket bilgisi:
+${escapeHtml(topic.company)}`;
+    }
+    if (/amaç|ne işe yarar/.test(low)) {
+      return `${highlight("Ekrandaki site")}: ${highlight(topic.name)}
+Amaç: ${escapeHtml(topic.purpose)}`;
+    }
+    if (/özet|özeti|nedir/.test(low)) {
+      const sum = wiki || topic.summary;
+      return `${highlight(topic.name)} özeti:
+${escapeHtml(sum)}`;
+    }
+    const sum = wiki || topic.summary;
+    return `${highlight(topic.name)} için hızlı analiz:
+Kuruluş: ${highlight(topic.year)}
+Şirket/Kurucu: ${escapeHtml(topic.company)}
+Amaç: ${escapeHtml(topic.purpose)}
+Özet: ${escapeHtml(sum)}`;
+  }
 
   if (/kuruluş|kaç yılında|ne zaman/.test(low)) {
-    return `${highlight(topic)} kuruluş bilgisi: ${highlight("Wikipedia özeti ile bulundu")}.`;
+    return `${highlight(genericTopic)} kuruluş bilgisi: ${highlight("Wikipedia özeti ile bulundu")}.`;
   }
   if (/isim|adı/.test(low)) {
-    return `Site adı: ${highlight(topic)}.`;
+    return `Site adı: ${highlight(genericTopic)}.`;
   }
   if (/amaç|ne işe yarar|hakkında/.test(low)) {
-    const summary = wiki || `${topic} genel olarak bilgi/hizmet sunar.`;
-    if (asksCurrentSite) {
-      return `${highlight("Ekrandaki site")}: ${highlight(topic)}.
-${escapeHtml(summary)}`;
-    }
-    return `${highlight(topic)} amacı:
-${escapeHtml(summary)}`;
+    return `${highlight(genericTopic)} amacı:
+${escapeHtml(wiki || `${genericTopic} genel olarak bilgi/hizmet sunar.`)}`;
   }
 
-  return `${highlight(topic)} özeti:
+  return `${highlight(genericTopic)} özeti:
 ${escapeHtml(wiki || "Özet bulunamadı")}`;
 }
 function initPrompts() {

--- a/script.js
+++ b/script.js
@@ -312,6 +312,11 @@ function getCurrentSiteContext() {
   }
 }
 
+function getCurrentHost() {
+  const c = getCurrentSiteContext();
+  return c?.host || "";
+}
+
 function genericWebsiteDefinition() {
   return `${highlight("Web sitesi")}, internet üzerinde çalışan sayfalardan oluşan bir bilgi/hizmet alanıdır. Genelde amacı içerik sunmak, işlem yaptırmak veya kullanıcıyı bir hizmete ulaştırmaktır.`;
 }
@@ -507,6 +512,19 @@ function moveCursorToPoint(x, y) {
   agentCursor.style.top = `${y}px`;
 }
 
+function clickByViewportPoint(x, y) {
+  const under = document.elementFromPoint(x, y);
+  if (!under) return false;
+  try {
+    ["pointerdown", "mousedown", "mouseup", "click"].forEach((type) => {
+      under.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, clientX: x, clientY: y, view: window }));
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function getElementCenterInViewport(element) {
   const rect = element.getBoundingClientRect();
   let x = rect.left + rect.width / 2;
@@ -533,7 +551,9 @@ async function clickMarkedTargetCenter(target) {
     node = doc.elementFromPoint(target.frameCenter.x, target.frameCenter.y);
   }
 
-  if (!node) return false;
+  if (!node) {
+    return clickByViewportPoint(center.x, center.y);
+  }
   try {
     ["pointerdown", "mousedown", "mouseup", "click"].forEach((type) => {
       node.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: node.ownerDocument.defaultView }));
@@ -687,10 +707,12 @@ async function runAgentTask(q) {
 
     if (state.selectedTargets.length) {
       if (/tıkla/.test(low)) {
+        let clicked = 0;
         for (const t of state.selectedTargets) {
-          await clickMarkedTargetCenter(t);
+          if (await clickMarkedTargetCenter(t)) clicked += 1;
         }
-        return "Seçtiğin alanların tam ortasına tıkladım.";
+        if (!clicked) return "İşaretlenen alanlara doğrudan tıklama yapılamadı (site güvenlik kısıtı olabilir).";
+        return `${clicked} işaretli alanın tam ortasına sırayla tıkladım.`;
       }
 
       const write = q.match(/(?:yaz|değiştir|yap)\s+(.+)/i)?.[1]?.trim();
@@ -698,11 +720,18 @@ async function runAgentTask(q) {
         let wrote = 0;
         const clean = write.replace(/"/g, "");
         for (const t of state.selectedTargets) {
-          const { x, y } = getElementCenterInViewport(t.el);
-          moveCursorToPoint(x, y);
+          const center = t.viewportCenter || getElementCenterInViewport(t.el);
+          moveCursorToPoint(center.x, center.y);
           await sleep(120);
           if (writeIntoTarget(t, clean)) wrote += 1;
         }
+
+        if (!wrote && getCurrentHost().endswith("youtube.com")) {
+          const qv = encodeURIComponent(clean);
+          openUrl(`https://www.youtube.com/results?search_query=${qv}`, true, "YouTube arama");
+          return `YouTube arama kutusuna yazma yerine arama başlatıldı: ${highlight(clean)}.`;
+        }
+
         if (!wrote) return "İşaretlenen öğelerde yazılabilir input bulunamadı. Input seçip tekrar dene.";
         return `Seçili input alanlarına ${highlight(clean)} yazdım.`;
       }

--- a/script.js
+++ b/script.js
@@ -2,7 +2,18 @@ const state = {
   history: [],
   index: -1,
   user: JSON.parse(localStorage.getItem("balukUser") || "null"),
+  thinkingTimer: null,
+  thinkingTicker: null,
+  agentMode: false,
 };
+
+const THINKING_LINES = [
+  "Baluk.ai düşünüyor...",
+  "Web sayfasına bakıyorum...",
+  "İçerik kaynaklarını karşılaştırıyorum...",
+  "Sayfadaki ipuçlarından anlam çıkarıyorum...",
+  "En iyi cevabı hazırlıyorum..."
+];
 
 const el = {
   aramaForm: document.getElementById("aramaForm"),
@@ -18,15 +29,32 @@ const el = {
   newTabBtn: document.getElementById("newTabBtn"),
   balukPanelBtn: document.getElementById("balukPanelBtn"),
   aiPanel: document.getElementById("aiPanel"),
+  closePanelBtn: document.getElementById("closePanelBtn"),
   loginForm: document.getElementById("loginForm"),
   authArea: document.getElementById("authArea"),
   assistantArea: document.getElementById("assistantArea"),
   welcomeText: document.getElementById("welcomeText"),
+  profileMail: document.getElementById("profileMail"),
+  profileAvatar: document.getElementById("profileAvatar"),
   aiForm: document.getElementById("aiForm"),
   aiSoru: document.getElementById("aiSoru"),
-  thinking: document.getElementById("thinking"),
+  thinkingBox: document.getElementById("thinkingBox"),
+  thinkingText: document.getElementById("thinkingText"),
+  spinLogo: document.getElementById("spinLogo"),
   aiCevap: document.getElementById("aiCevap"),
+  plusBtn: document.getElementById("plusBtn"),
+  agentMenu: document.getElementById("agentMenu"),
+  agentModeBtn: document.getElementById("agentModeBtn"),
 };
+
+function escapeHtml(text) {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
 
 function ensureUrl(value) {
   if (!value) return "";
@@ -52,10 +80,140 @@ function renderAuth() {
   if (state.user) {
     el.authArea.classList.add("hidden");
     el.assistantArea.classList.remove("hidden");
-    el.welcomeText.textContent = `Hoş geldin ${state.user.ad} ${state.user.soyad}`;
+    el.welcomeText.textContent = `${state.user.ad} ${state.user.soyad}`;
+    el.profileMail.textContent = state.user.email;
+    el.profileAvatar.src = state.user.profil || "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='70' height='70'%3E%3Crect width='100%25' height='100%25' fill='%23212a57'/%3E%3Ctext x='50%25' y='53%25' text-anchor='middle' fill='%23fff' font-size='22' font-family='Arial' dy='.3em'%3EB%3C/text%3E%3C/svg%3E";
   } else {
     el.authArea.classList.remove("hidden");
     el.assistantArea.classList.add("hidden");
+  }
+}
+
+function createFallbackResults(query) {
+  const safeQuery = encodeURIComponent(query);
+  return [
+    {
+      title: `DuckDuckGo'da "${query}" araması`,
+      href: `https://duckduckgo.com/?q=${safeQuery}`,
+      snippet: "DuckDuckGo sonuç sayfasını açar."
+    },
+    {
+      title: `Wikipedia sonucu: ${query}`,
+      href: `https://tr.wikipedia.org/wiki/Özel:Arama?search=${safeQuery}`,
+      snippet: "Wikipedia üzerinden hızlı kaynak taraması."
+    }
+  ];
+}
+
+async function getSearchResults(query) {
+  const url = `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_redirect=1&no_html=1`;
+  const response = await fetch(url);
+  if (!response.ok) throw new Error("DuckDuckGo API erişimi başarısız.");
+  const data = await response.json();
+
+  const parsed = [];
+
+  if (data.AbstractURL) {
+    parsed.push({
+      title: data.Heading || query,
+      href: data.AbstractURL,
+      snippet: data.AbstractText || "Özet bilgi"
+    });
+  }
+
+  (data.RelatedTopics || []).forEach((item) => {
+    if (item.FirstURL && item.Text) {
+      parsed.push({ title: item.Text.split(" - ")[0], href: item.FirstURL, snippet: item.Text });
+    }
+    if (Array.isArray(item.Topics)) {
+      item.Topics.forEach((sub) => {
+        if (sub.FirstURL && sub.Text) {
+          parsed.push({ title: sub.Text.split(" - ")[0], href: sub.FirstURL, snippet: sub.Text });
+        }
+      });
+    }
+  });
+
+  return parsed.slice(0, 8);
+}
+
+function renderResults(results, query) {
+  if (!results.length) results = createFallbackResults(query);
+  el.sonuclar.innerHTML = "";
+
+  results.forEach((item) => {
+    const card = document.createElement("article");
+    card.className = "result-item";
+    card.innerHTML = `
+      <h3><a href="#">${escapeHtml(item.title)}</a></h3>
+      <p>${escapeHtml(item.snippet || "Açıklama yok")}</p>
+    `;
+    card.querySelector("a").addEventListener("click", (e) => {
+      e.preventDefault();
+      openUrl(item.href);
+    });
+    el.sonuclar.appendChild(card);
+  });
+}
+
+function startThinking() {
+  el.aiCevap.textContent = "";
+  el.thinkingBox.classList.remove("hidden");
+  el.spinLogo.classList.add("active");
+  document.body.classList.add("web-glow");
+
+  let idx = 0;
+  el.thinkingText.textContent = THINKING_LINES[0];
+  state.thinkingTicker = setInterval(() => {
+    idx = (idx + 1) % THINKING_LINES.length;
+    el.thinkingText.textContent = THINKING_LINES[idx];
+  }, 2600);
+}
+
+function stopThinking() {
+  clearInterval(state.thinkingTicker);
+  state.thinkingTicker = null;
+  el.thinkingBox.classList.add("hidden");
+  el.spinLogo.classList.remove("active");
+  document.body.classList.remove("web-glow");
+}
+
+function buildAiAnswer(q) {
+  if (/kaç yılında|ne zaman/i.test(q)) {
+    return "Kuruluş zamanı odaklı analiz: Baluk.ai sayfada tarih/sürüm/hakkında alanlarından kuruluş yılını çıkarmaya çalışır.";
+  }
+  if (/hangi şirket|kim tarafından/i.test(q)) {
+    return "Kurucu/şirket odaklı analiz: Baluk.ai sayfanın footer, about, iletişim ve yasal bölümlerini tarayıp sahiplik bilgisini özetler.";
+  }
+  if (/amacı|ne için/i.test(q)) {
+    return "Amaç odaklı analiz: Baluk.ai ürün açıklamaları ve başlıkları inceleyerek sitenin ana kullanım amacını kısaca anlatır.";
+  }
+
+  const page = el.adresCubugu.value || "açık sayfa";
+  return `${page} için genel analiz: kuruluş zamanı, amacı ve olası şirket bilgisini tek özetten verir.`;
+}
+
+function sendAgentFillInstruction() {
+  const instruction = prompt("Seçtiğin input'a ne yazılsın?");
+  if (!instruction) return;
+
+  try {
+    const doc = el.siteFrame.contentDocument;
+    if (!doc) throw new Error("iframe erişimi yok");
+
+    const target = doc.querySelector("input:focus, textarea:focus") || doc.querySelector("input, textarea");
+    if (!target) {
+      el.aiCevap.textContent = "Agent Mode: Bu sayfada doldurulabilir input bulunamadı.";
+      return;
+    }
+
+    target.focus();
+    target.value = instruction;
+    target.dispatchEvent(new Event("input", { bubbles: true }));
+    target.dispatchEvent(new Event("change", { bubbles: true }));
+    el.aiCevap.textContent = `Agent Mode tamamlandı: Seçilen alana "${instruction}" yazıldı.`;
+  } catch {
+    el.aiCevap.textContent = "Agent Mode güvenlik sınırı: Bu site farklı domain olduğu için doğrudan input doldurma yapılamadı. Aynı domain sayfalarda çalışır.";
   }
 }
 
@@ -66,35 +224,10 @@ el.aramaForm.addEventListener("submit", async (event) => {
 
   el.sonuclar.innerHTML = "Aranıyor...";
   try {
-    const response = await fetch(`https://duckduckgo.com/html/?q=${encodeURIComponent(q)}`);
-    const html = await response.text();
-    const doc = new DOMParser().parseFromString(html, "text/html");
-    const rows = [...doc.querySelectorAll(".result")].slice(0, 7);
-
-    if (!rows.length) {
-      el.sonuclar.innerHTML = "Sonuç bulunamadı.";
-      return;
-    }
-
-    el.sonuclar.innerHTML = "";
-    rows.forEach((row) => {
-      const link = row.querySelector(".result__a");
-      if (!link) return;
-      const title = link.textContent;
-      const href = link.getAttribute("href");
-      const snippet = row.querySelector(".result__snippet")?.textContent || "Açıklama yok.";
-
-      const card = document.createElement("article");
-      card.className = "result-item";
-      card.innerHTML = `<h3><a href="#">${title}</a></h3><p>${snippet}</p>`;
-      card.querySelector("a").addEventListener("click", (e) => {
-        e.preventDefault();
-        openUrl(href);
-      });
-      el.sonuclar.appendChild(card);
-    });
+    const results = await getSearchResults(q);
+    renderResults(results, q);
   } catch {
-    el.sonuclar.innerHTML = "Arama servisine erişilemedi. Tekrar dene.";
+    renderResults(createFallbackResults(q), q);
   }
 });
 
@@ -126,9 +259,8 @@ el.newTabBtn.addEventListener("click", () => {
   el.adresCubugu.value = "";
 });
 
-el.balukPanelBtn.addEventListener("click", () => {
-  el.aiPanel.classList.toggle("hidden");
-});
+el.balukPanelBtn.addEventListener("click", () => el.aiPanel.classList.toggle("hidden"));
+el.closePanelBtn.addEventListener("click", () => el.aiPanel.classList.add("hidden"));
 
 el.loginForm.addEventListener("submit", (e) => {
   e.preventDefault();
@@ -137,6 +269,7 @@ el.loginForm.addEventListener("submit", (e) => {
     ad: document.getElementById("ad").value.trim(),
     soyad: document.getElementById("soyad").value.trim(),
   };
+
   const file = document.getElementById("profil").files[0];
   if (!user.email || !user.ad || !user.soyad) return;
 
@@ -156,30 +289,37 @@ el.loginForm.addEventListener("submit", (e) => {
   }
 });
 
+el.plusBtn.addEventListener("click", () => {
+  el.agentMenu.classList.toggle("hidden");
+});
+
+el.agentModeBtn.addEventListener("click", () => {
+  state.agentMode = true;
+  el.agentMenu.classList.add("hidden");
+  el.aiCevap.textContent = "Agent Mode aktif. Hedef input alanına tıkla, sonra komut verilecek.";
+  sendAgentFillInstruction();
+});
+
 el.aiForm.addEventListener("submit", (e) => {
   e.preventDefault();
   const q = el.aiSoru.value.trim();
   if (!q) return;
 
-  el.aiCevap.textContent = "";
-  el.thinking.classList.remove("hidden");
-  document.body.style.boxShadow = "inset 0 0 80px rgba(141,69,255,0.5)";
+  startThinking();
 
-  setTimeout(() => {
-    el.thinking.classList.add("hidden");
-    document.body.style.boxShadow = "none";
-
-    if (/kaç yılında|ne zaman/i.test(q)) {
-      el.aiCevap.textContent = "Siteyi analiz ederek kuruluş yılına odaklanılmış bir özet hazırlanır.";
-    } else if (/hangi şirket|kim tarafından/i.test(q)) {
-      el.aiCevap.textContent = "Siteyi sahiplik açısından tarayıp şirket / kurucu bilgisini özetler.";
-    } else if (/amacı|ne için/i.test(q)) {
-      el.aiCevap.textContent = "Siteyi kullanım amacı açısından yorumlayıp kısa bir özet verir.";
-    } else {
-      const page = el.adresCubugu.value || "açık bir sayfa";
-      el.aiCevap.textContent = `${page} için genel analiz: kuruluş, amaç ve şirket bilgilerini tek cevapta özetler.`;
-    }
+  clearTimeout(state.thinkingTimer);
+  state.thinkingTimer = setTimeout(() => {
+    stopThinking();
+    el.aiCevap.textContent = buildAiAnswer(q);
+    el.aiSoru.value = "";
   }, 20000);
+});
+
+el.aiSoru.addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && !e.shiftKey) {
+    e.preventDefault();
+    el.aiForm.requestSubmit();
+  }
 });
 
 renderAuth();

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ const state = {
   agentBusy: false,
   selectedTargets: [],
   markMode: false,
+  dragSelecting: false,
 };
 
 const THINKING_LINES = [
@@ -318,18 +319,96 @@ function bindAgentPicker() {
   try {
     const doc = el.siteFrame.contentDocument;
     if (!doc) throw new Error();
-    doc.addEventListener("click", (e) => {
+
+    let box = null;
+    let sx = 0;
+    let sy = 0;
+
+    const clearBox = () => {
+      if (box && box.parentNode) box.parentNode.removeChild(box);
+      box = null;
+      state.dragSelecting = false;
+    };
+
+    doc.addEventListener("mousedown", (e) => {
       if (!state.agentModeActive || !state.markMode) return;
-      const t = e.target;
-      if (!t || t.nodeType !== 1) return;
-      e.preventDefault(); e.stopPropagation();
-      const label = (t.innerText || t.getAttribute("aria-label") || t.placeholder || t.value || t.tagName).trim().slice(0, 28) || t.tagName;
-      state.selectedTargets.push({ el: t, label });
-      t.style.outline = "2px solid #b171ff";
-      renderSelectedTargets();
-      el.aiCevap.innerHTML = `Seçildi: ${highlight(label)}.`;
+      if (e.button !== 0) return;
+      e.preventDefault();
+      e.stopPropagation();
+
+      sx = e.clientX;
+      sy = e.clientY;
+      state.dragSelecting = true;
+
+      clearBox();
+      box = doc.createElement("div");
+      box.style.position = "fixed";
+      box.style.left = `${sx}px`;
+      box.style.top = `${sy}px`;
+      box.style.width = "1px";
+      box.style.height = "1px";
+      box.style.border = "2px dashed #b171ff";
+      box.style.background = "rgba(177,113,255,0.08)";
+      box.style.borderRadius = "2px";
+      box.style.zIndex = "2147483647";
+      box.style.pointerEvents = "none";
+      doc.body.appendChild(box);
     }, { capture: true });
-    el.aiCevap.innerHTML = "Agent Mode 2.0 açık. Kalem (✎) ile işaretleme modunu açıp seçim yapabilirsin.";
+
+    doc.addEventListener("mousemove", (e) => {
+      if (!state.agentModeActive || !state.markMode || !state.dragSelecting || !box) return;
+      e.preventDefault();
+
+      const x = Math.min(sx, e.clientX);
+      const y = Math.min(sy, e.clientY);
+      const w = Math.abs(e.clientX - sx);
+      const h = Math.abs(e.clientY - sy);
+
+      box.style.left = `${x}px`;
+      box.style.top = `${y}px`;
+      box.style.width = `${Math.max(2, w)}px`;
+      box.style.height = `${Math.max(2, h)}px`;
+    }, { capture: true });
+
+    doc.addEventListener("mouseup", (e) => {
+      if (!state.agentModeActive || !state.markMode || !state.dragSelecting) return;
+      e.preventDefault();
+      e.stopPropagation();
+
+      const x1 = Math.min(sx, e.clientX);
+      const y1 = Math.min(sy, e.clientY);
+      const x2 = Math.max(sx, e.clientX);
+      const y2 = Math.max(sy, e.clientY);
+      const width = Math.max(2, x2 - x1);
+      const height = Math.max(2, y2 - y1);
+
+      const cxFrame = x1 + width / 2;
+      const cyFrame = y1 + height / 2;
+
+      const frameRect = el.siteFrame.getBoundingClientRect();
+      const cxViewport = frameRect.left + cxFrame;
+      const cyViewport = frameRect.top + cyFrame;
+
+      const centerEl = doc.elementFromPoint(cxFrame, cyFrame);
+      if (centerEl && centerEl.style) centerEl.style.outline = "2px solid #b171ff";
+
+      const labelBase = centerEl?.getAttribute?.("aria-label") || centerEl?.innerText || centerEl?.placeholder || centerEl?.tagName || "Seçili alan";
+      const label = String(labelBase).trim().slice(0, 28) || "Seçili alan";
+
+      state.selectedTargets.push({
+        mode: "region",
+        label,
+        frameCenter: { x: cxFrame, y: cyFrame },
+        viewportCenter: { x: cxViewport, y: cyViewport },
+        el: centerEl || null,
+      });
+
+      renderSelectedTargets();
+      el.aiCevap.innerHTML = `Düz seçim yapıldı: ${highlight(label)}. Şimdi "buraya tıkla" veya "bu inputa merhaba yaz" diyebilirsin.`;
+      clearBox();
+    }, { capture: true });
+
+    el.aiCevap.innerHTML = "Agent Mode 2.0 açık. Kalem (✎) ile sürükleyerek dikdörtgen alan seçebilirsin.";
   } catch {
     el.aiCevap.innerHTML = "Bu sayfada güvenlik nedeniyle işaretleme yapılamıyor (farklı domain).";
   }
@@ -341,12 +420,12 @@ function toggleMarkMode() {
   state.markMode = !state.markMode;
   el.markToggleBtn?.classList.toggle("active", state.markMode);
   el.aiCevap.innerHTML = state.markMode
-    ? "İşaretleme açık: sayfadan öğelere tıklayıp seçebilirsin."
+    ? "İşaretleme açık: fare/parmak ile sürükleyip düz dikdörtgen alan seçebilirsin."
     : "İşaretleme kapalı.";
 }
 
 function selectedInfo() {
-  if (!state.selectedTargets.length) return "Önce kalemle bir öğe seç.";
+  if (!state.selectedTargets.length) return "Önce kalemle sürükleyerek bir alan seç.";
   const labels = state.selectedTargets.map((t) => t.label).join(", ");
   return `Seçtiğin alan(lar): ${highlight(labels)}. Şimdi "buraya tıkla" veya "bu inputa merhaba yaz" diyebilirsin.`;
 }
@@ -389,22 +468,36 @@ function getElementCenterInViewport(element) {
 }
 
 async function clickMarkedTargetCenter(target) {
-  const { x, y } = getElementCenterInViewport(target.el);
-  moveCursorToPoint(x, y);
+  const center = target.viewportCenter || getElementCenterInViewport(target.el);
+  moveCursorToPoint(center.x, center.y);
   await sleep(220);
 
+  const doc = el.siteFrame.contentDocument;
+  let node = target.el;
+  if ((!node || !node.isConnected) && doc && target.frameCenter) {
+    node = doc.elementFromPoint(target.frameCenter.x, target.frameCenter.y);
+  }
+
+  if (!node) return false;
   try {
     ["pointerdown", "mousedown", "mouseup", "click"].forEach((type) => {
-      target.el.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: target.el.ownerDocument.defaultView }));
+      node.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: node.ownerDocument.defaultView }));
     });
   } catch {
-    target.el.click();
+    node.click();
   }
   await sleep(140);
+  return true;
 }
 
 function writeIntoTarget(target, text) {
-  const node = target.el;
+  const doc = el.siteFrame.contentDocument;
+  let node = target.el;
+  if ((!node || !node.isConnected) && doc && target.frameCenter) {
+    node = doc.elementFromPoint(target.frameCenter.x, target.frameCenter.y);
+  }
+  if (!node) return false;
+
   const isInput = node.matches?.("input, textarea") || node.isContentEditable;
   if (!isInput) return false;
 

--- a/script.js
+++ b/script.js
@@ -1,97 +1,185 @@
-window.onload = () => {
-  const k = localStorage.getItem("kullaniciAdi");
-  const p = localStorage.getItem("profilResmi");
-
-  if (k && p) {
-    document.getElementById("girisEkrani").style.display = "none";
-    document.getElementById("anaEkran").classList.remove("gizli");
-    document.getElementById("kAdi").innerText = k;
-    document.getElementById("profilGorsel").src = p;
-    videolariYukle();
-  }
+const state = {
+  history: [],
+  index: -1,
+  user: JSON.parse(localStorage.getItem("balukUser") || "null"),
 };
 
-function girisYap() {
-  const k = document.getElementById("kullaniciAdi").value.trim();
-  const p = document.getElementById("profilResmi").files[0];
+const el = {
+  aramaForm: document.getElementById("aramaForm"),
+  aramaInput: document.getElementById("aramaInput"),
+  sonuclar: document.getElementById("sonuclar"),
+  homeView: document.getElementById("homeView"),
+  webView: document.getElementById("webView"),
+  siteFrame: document.getElementById("siteFrame"),
+  adresCubugu: document.getElementById("adresCubugu"),
+  geriBtn: document.getElementById("geriBtn"),
+  ileriBtn: document.getElementById("ileriBtn"),
+  yenileBtn: document.getElementById("yenileBtn"),
+  newTabBtn: document.getElementById("newTabBtn"),
+  balukPanelBtn: document.getElementById("balukPanelBtn"),
+  aiPanel: document.getElementById("aiPanel"),
+  loginForm: document.getElementById("loginForm"),
+  authArea: document.getElementById("authArea"),
+  assistantArea: document.getElementById("assistantArea"),
+  welcomeText: document.getElementById("welcomeText"),
+  aiForm: document.getElementById("aiForm"),
+  aiSoru: document.getElementById("aiSoru"),
+  thinking: document.getElementById("thinking"),
+  aiCevap: document.getElementById("aiCevap"),
+};
 
-  if (!k || !p) {
-    alert("Ad ve profil resmi gerekli kaptan!");
-    return;
+function ensureUrl(value) {
+  if (!value) return "";
+  return /^https?:\/\//i.test(value) ? value : `https://${value}`;
+}
+
+function openUrl(url, addToHistory = true) {
+  if (!url) return;
+  const safe = ensureUrl(url);
+  el.siteFrame.src = safe;
+  el.adresCubugu.value = safe;
+  el.homeView.classList.add("hidden");
+  el.webView.classList.remove("hidden");
+
+  if (addToHistory) {
+    state.history = state.history.slice(0, state.index + 1);
+    state.history.push(safe);
+    state.index = state.history.length - 1;
   }
-
-  const reader = new FileReader();
-  reader.onload = () => {
-    localStorage.setItem("kullaniciAdi", k);
-    localStorage.setItem("profilResmi", reader.result);
-    location.reload();
-  };
-  reader.readAsDataURL(p);
 }
 
-function goAnaSayfa() {
-  document.getElementById("hesabim").classList.add("gizli");
-  document.getElementById("anaSayfa").style.display = "block";
-}
-
-function goHesabim() {
-  document.getElementById("anaSayfa").style.display = "none";
-  document.getElementById("hesabim").classList.remove("gizli");
-}
-
-function videoYukle() {
-  const dosya = document.getElementById("videoDosyasi").files[0];
-  const baslik = document.getElementById("videoBaslik").value;
-  const kullanici = localStorage.getItem("kullaniciAdi");
-
-  if (!dosya || !baslik) {
-    alert("Video ve başlık eksik!");
-    return;
+function renderAuth() {
+  if (state.user) {
+    el.authArea.classList.add("hidden");
+    el.assistantArea.classList.remove("hidden");
+    el.welcomeText.textContent = `Hoş geldin ${state.user.ad} ${state.user.soyad}`;
+  } else {
+    el.authArea.classList.remove("hidden");
+    el.assistantArea.classList.add("hidden");
   }
-
-  const videoURL = URL.createObjectURL(dosya);
-  const video = { baslik: baslik, url: videoURL, sahip: kullanici };
-
-  const mevcut = JSON.parse(localStorage.getItem("videolar") || "[]");
-  mevcut.push(video);
-  localStorage.setItem("videolar", JSON.stringify(mevcut));
-  videolariYukle();
-
-  document.getElementById("videoDosyasi").value = "";
-  document.getElementById("videoBaslik").value = "";
 }
 
-function videolariYukle() {
-  const videolar = JSON.parse(localStorage.getItem("videolar") || "[]");
-  const liste = document.getElementById("videoListe");
-  const hesap = document.getElementById("videolar");
-  const kullanici = localStorage.getItem("kullaniciAdi");
+el.aramaForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const q = el.aramaInput.value.trim();
+  if (!q) return;
 
-  liste.innerHTML = "";
-  hesap.innerHTML = "";
+  el.sonuclar.innerHTML = "Aranıyor...";
+  try {
+    const response = await fetch(`https://duckduckgo.com/html/?q=${encodeURIComponent(q)}`);
+    const html = await response.text();
+    const doc = new DOMParser().parseFromString(html, "text/html");
+    const rows = [...doc.querySelectorAll(".result")].slice(0, 7);
 
-  videolar.forEach((v, i) => {
-    const div = document.createElement("div");
-    div.className = "video";
-    div.innerHTML = `
-      <video src="${v.url}" controls></video>
-      <p>${v.baslik}</p>
-    `;
-    // Ana sayfaya herkesin videoları
-    liste.appendChild(div.cloneNode(true));
-
-    // Sadece kendi videolarına silme butonu
-    if (v.sahip === kullanici) {
-      const divHesap = div.cloneNode(true);
-      const silBtn = document.createElement("button");
-      silBtn.innerText = "❌";
-      silBtn.onclick = () => {
-        videolar.splice(i, 1);
-        localStorage.setItem("videolar", JSON.stringify(videolar));
-        videolariYukle();
-      };
-      divHesap.appendChild(silBtn);
-      hesap.appendChild(divHesap);
+    if (!rows.length) {
+      el.sonuclar.innerHTML = "Sonuç bulunamadı.";
+      return;
     }
-  });
-}
+
+    el.sonuclar.innerHTML = "";
+    rows.forEach((row) => {
+      const link = row.querySelector(".result__a");
+      if (!link) return;
+      const title = link.textContent;
+      const href = link.getAttribute("href");
+      const snippet = row.querySelector(".result__snippet")?.textContent || "Açıklama yok.";
+
+      const card = document.createElement("article");
+      card.className = "result-item";
+      card.innerHTML = `<h3><a href="#">${title}</a></h3><p>${snippet}</p>`;
+      card.querySelector("a").addEventListener("click", (e) => {
+        e.preventDefault();
+        openUrl(href);
+      });
+      el.sonuclar.appendChild(card);
+    });
+  } catch {
+    el.sonuclar.innerHTML = "Arama servisine erişilemedi. Tekrar dene.";
+  }
+});
+
+el.adresCubugu.addEventListener("keydown", (e) => {
+  if (e.key === "Enter") openUrl(el.adresCubugu.value);
+});
+
+el.geriBtn.addEventListener("click", () => {
+  if (state.index > 0) {
+    state.index -= 1;
+    openUrl(state.history[state.index], false);
+  }
+});
+
+el.ileriBtn.addEventListener("click", () => {
+  if (state.index < state.history.length - 1) {
+    state.index += 1;
+    openUrl(state.history[state.index], false);
+  }
+});
+
+el.yenileBtn.addEventListener("click", () => {
+  if (el.siteFrame.src) el.siteFrame.src = el.siteFrame.src;
+});
+
+el.newTabBtn.addEventListener("click", () => {
+  el.homeView.classList.remove("hidden");
+  el.webView.classList.add("hidden");
+  el.adresCubugu.value = "";
+});
+
+el.balukPanelBtn.addEventListener("click", () => {
+  el.aiPanel.classList.toggle("hidden");
+});
+
+el.loginForm.addEventListener("submit", (e) => {
+  e.preventDefault();
+  const user = {
+    email: document.getElementById("mail").value.trim(),
+    ad: document.getElementById("ad").value.trim(),
+    soyad: document.getElementById("soyad").value.trim(),
+  };
+  const file = document.getElementById("profil").files[0];
+  if (!user.email || !user.ad || !user.soyad) return;
+
+  if (file) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      user.profil = reader.result;
+      state.user = user;
+      localStorage.setItem("balukUser", JSON.stringify(user));
+      renderAuth();
+    };
+    reader.readAsDataURL(file);
+  } else {
+    state.user = user;
+    localStorage.setItem("balukUser", JSON.stringify(user));
+    renderAuth();
+  }
+});
+
+el.aiForm.addEventListener("submit", (e) => {
+  e.preventDefault();
+  const q = el.aiSoru.value.trim();
+  if (!q) return;
+
+  el.aiCevap.textContent = "";
+  el.thinking.classList.remove("hidden");
+  document.body.style.boxShadow = "inset 0 0 80px rgba(141,69,255,0.5)";
+
+  setTimeout(() => {
+    el.thinking.classList.add("hidden");
+    document.body.style.boxShadow = "none";
+
+    if (/kaç yılında|ne zaman/i.test(q)) {
+      el.aiCevap.textContent = "Siteyi analiz ederek kuruluş yılına odaklanılmış bir özet hazırlanır.";
+    } else if (/hangi şirket|kim tarafından/i.test(q)) {
+      el.aiCevap.textContent = "Siteyi sahiplik açısından tarayıp şirket / kurucu bilgisini özetler.";
+    } else if (/amacı|ne için/i.test(q)) {
+      el.aiCevap.textContent = "Siteyi kullanım amacı açısından yorumlayıp kısa bir özet verir.";
+    } else {
+      const page = el.adresCubugu.value || "açık bir sayfa";
+      el.aiCevap.textContent = `${page} için genel analiz: kuruluş, amaç ve şirket bilgilerini tek cevapta özetler.`;
+    }
+  }, 20000);
+});
+
+renderAuth();

--- a/script.js
+++ b/script.js
@@ -321,7 +321,7 @@ function bindAgentPicker() {
     doc.addEventListener("click", (e) => {
       if (!state.agentModeActive || !state.markMode) return;
       const t = e.target;
-      if (!(t instanceof HTMLElement)) return;
+      if (!t || t.nodeType !== 1) return;
       e.preventDefault(); e.stopPropagation();
       const label = (t.innerText || t.getAttribute("aria-label") || t.placeholder || t.value || t.tagName).trim().slice(0, 28) || t.tagName;
       state.selectedTargets.push({ el: t, label });
@@ -348,7 +348,7 @@ function toggleMarkMode() {
 function selectedInfo() {
   if (!state.selectedTargets.length) return "Önce kalemle bir öğe seç.";
   const labels = state.selectedTargets.map((t) => t.label).join(", ");
-  return `Seçtiğin alan(lar): ${highlight(labels)}.`;
+  return `Seçtiğin alan(lar): ${highlight(labels)}. Şimdi "buraya tıkla" veya "bu inputa merhaba yaz" diyebilirsin.`;
 }
 function parseSearchCommand(q) {
   const t = normalize(q).replace(/^hey baluk\s+/i, "");
@@ -367,6 +367,58 @@ function moveCursorTo(element) {
   agentCursor.style.left = `${rect.left + rect.width / 2}px`;
   agentCursor.style.top = `${rect.top + rect.height / 2}px`;
 }
+function moveCursorToPoint(x, y) {
+  agentCursor.style.opacity = "1";
+  agentCursor.style.left = `${x}px`;
+  agentCursor.style.top = `${y}px`;
+}
+
+function getElementCenterInViewport(element) {
+  const rect = element.getBoundingClientRect();
+  let x = rect.left + rect.width / 2;
+  let y = rect.top + rect.height / 2;
+
+  const doc = element.ownerDocument;
+  const frameEl = doc?.defaultView?.frameElement;
+  if (frameEl) {
+    const fr = frameEl.getBoundingClientRect();
+    x += fr.left;
+    y += fr.top;
+  }
+  return { x, y };
+}
+
+async function clickMarkedTargetCenter(target) {
+  const { x, y } = getElementCenterInViewport(target.el);
+  moveCursorToPoint(x, y);
+  await sleep(220);
+
+  try {
+    ["pointerdown", "mousedown", "mouseup", "click"].forEach((type) => {
+      target.el.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, view: target.el.ownerDocument.defaultView }));
+    });
+  } catch {
+    target.el.click();
+  }
+  await sleep(140);
+}
+
+function writeIntoTarget(target, text) {
+  const node = target.el;
+  const isInput = node.matches?.("input, textarea") || node.isContentEditable;
+  if (!isInput) return false;
+
+  node.focus();
+  if (node.isContentEditable) {
+    node.textContent = text;
+  } else {
+    node.value = text;
+  }
+  node.dispatchEvent(new Event("input", { bubbles: true }));
+  node.dispatchEvent(new Event("change", { bubbles: true }));
+  return true;
+}
+
 
 async function clickElement(element) {
   moveCursorTo(element);
@@ -488,27 +540,23 @@ async function runAgentTask(q) {
     if (state.selectedTargets.length) {
       if (/tıkla/.test(low)) {
         for (const t of state.selectedTargets) {
-          moveCursorTo(t.el);
-          await sleep(180);
-          t.el.click();
-          await sleep(160);
+          await clickMarkedTargetCenter(t);
         }
-        return "Seçtiğin öğelere sırayla tıkladım.";
+        return "Seçtiğin alanların tam ortasına tıkladım.";
       }
 
       const write = q.match(/(?:yaz|değiştir|yap)\s+(.+)/i)?.[1]?.trim();
       if (write) {
+        let wrote = 0;
+        const clean = write.replace(/"/g, "");
         for (const t of state.selectedTargets) {
-          if ("value" in t.el) {
-            moveCursorTo(t.el);
-            await sleep(150);
-            t.el.focus();
-            t.el.value = write.replace(/"/g, "");
-            t.el.dispatchEvent(new Event("input", { bubbles: true }));
-            t.el.dispatchEvent(new Event("change", { bubbles: true }));
-          }
+          const { x, y } = getElementCenterInViewport(t.el);
+          moveCursorToPoint(x, y);
+          await sleep(120);
+          if (writeIntoTarget(t, clean)) wrote += 1;
         }
-        return `Seçili alanlara ${highlight(write)} yazdım.`;
+        if (!wrote) return "İşaretlenen öğelerde yazılabilir input bulunamadı. Input seçip tekrar dene.";
+        return `Seçili input alanlarına ${highlight(clean)} yazdım.`;
       }
     }
 

--- a/script.js
+++ b/script.js
@@ -116,14 +116,31 @@ function escapeHtml(text) {
 function sleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
 function ensureUrl(value) { return /^https?:\/\//i.test(value) ? value : `https://${value}`; }
 
+
+function isLikelyMobileDevice() {
+  return window.matchMedia("(max-width: 980px)").matches || /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
+}
+
+function openExternalUrl(url) {
+  const safe = ensureUrl(url);
+  const popup = window.open(safe, "_blank", "noopener,noreferrer");
+  if (!popup) window.location.href = safe;
+}
+
 function setPanel(open) {
   el.aiPanel.classList.toggle("hidden", !open);
   el.contentGrid.classList.toggle("with-panel", open);
 }
 
-function openUrl(url, addToHistory = true) {
+function openUrl(url, addToHistory = true, forceExternal = false) {
   if (!url) return;
   const safe = ensureUrl(url);
+
+  if (forceExternal || isLikelyMobileDevice()) {
+    openExternalUrl(safe);
+    return;
+  }
+
   el.siteFrame.src = safe;
   el.adresCubugu.value = safe;
   el.homeView.classList.add("hidden");
@@ -232,8 +249,8 @@ function renderResults(results, query) {
         <button type="button" class="ask-link">✦ Baluk.ai'ye Sor</button>
       </div>
     `;
-    card.querySelector("a").addEventListener("click", (e) => { e.preventDefault(); openUrl(item.href); });
-    card.querySelector(".open-link").addEventListener("click", () => openUrl(item.href));
+    card.querySelector("a").addEventListener("click", (e) => { e.preventDefault(); openUrl(item.href, true, isLikelyMobileDevice()); });
+    card.querySelector(".open-link").addEventListener("click", () => openUrl(item.href, true, isLikelyMobileDevice()));
     card.querySelector(".ask-link").addEventListener("click", () => askAboutSite(item.href, `${item.title} sitesi ne işe yarar, kim tarafından kuruldu ve ne zaman kuruldu?`));
     el.sonuclar.appendChild(card);
   });

--- a/script.js
+++ b/script.js
@@ -1,32 +1,25 @@
 const state = {
-  history: [],
-  index: -1,
+  tabs: [{ id: 1, title: "Yeni Sekme", url: "", history: [], index: -1 }],
+  activeTabId: 1,
+  nextTabId: 2,
   user: JSON.parse(localStorage.getItem("balukUser") || "null"),
   thinkingTimer: null,
   thinkingTicker: null,
   agentModeActive: false,
   agentBusy: false,
+  selectedTargets: [],
 };
 
 const THINKING_LINES = [
-  "Baluk.ai düşünüyor...",
-  "Web sayfasına bakıyorum...",
-  "Arama sonuçlarını inceliyorum...",
-  "Kaynaklardan kısa özet çıkarıyorum...",
-  "Cevabı netleştiriyorum..."
+  "Ekranına bakıyorum...",
+  "Kaynakları karşılaştırıyorum...",
+  "Anlamlı parçaları ayırıyorum...",
+  "En doğru özeti hazırlıyorum..."
 ];
 
-const SITE_HINTS = {
-  "youtube.com": { name: "YouTube", purpose: "kullanıcıların video izleyip içerik yüklediği bir video paylaşım platformu", company: "Google / Alphabet", year: "2005", wiki: "YouTube" },
-  "google.com": { name: "Google", purpose: "web araması ve internet servisleri sağlamak", company: "Google / Alphabet", year: "1998", wiki: "Google" },
-  "wikipedia.org": { name: "Wikipedia", purpose: "özgür ansiklopedi içeriği sağlamak", company: "Wikimedia Foundation", year: "2001", wiki: "Wikipedia" },
-  "github.com": { name: "GitHub", purpose: "yazılım projelerini Git tabanlı barındırma ve işbirliği", company: "GitHub (Microsoft)", year: "2008", wiki: "GitHub" },
-  "instagram.com": { name: "Instagram", purpose: "fotoğraf/video paylaşımı ve sosyal etkileşim", company: "Meta", year: "2010", wiki: "Instagram" },
-  "x.com": { name: "X", purpose: "kısa gönderilerle sosyal paylaşım ve haber akışı", company: "X Corp.", year: "2006", wiki: "Twitter" },
-  "twitter.com": { name: "Twitter (X)", purpose: "kısa gönderilerle sosyal paylaşım ve haber akışı", company: "X Corp.", year: "2006", wiki: "Twitter" }
-};
-
 const el = {
+  tabs: document.getElementById("tabs"),
+  addTabBtn: document.getElementById("addTabBtn"),
   contentGrid: document.getElementById("contentGrid"),
   aramaForm: document.getElementById("aramaForm"),
   aramaInput: document.getElementById("aramaInput"),
@@ -57,9 +50,11 @@ const el = {
   plusBtn: document.getElementById("plusBtn"),
   agentMenu: document.getElementById("agentMenu"),
   agentModeBtn: document.getElementById("agentModeBtn"),
+  selectedTargets: document.getElementById("selectedTargets"),
+  agentBadge: document.getElementById("agentBadge"),
+  agentBadgeClose: document.getElementById("agentBadgeClose"),
+  quickPrompts: document.getElementById("quickPrompts"),
   introOverlay: document.getElementById("introOverlay"),
-  introCard: document.getElementById("introCard"),
-  introSubtitle: document.getElementById("introSubtitle"),
   appShell: document.getElementById("appShell"),
 };
 
@@ -68,40 +63,36 @@ agentCursor.id = "agentCursor";
 agentCursor.style.cssText = "position:fixed;width:18px;height:18px;border:2px solid #b78cff;background:radial-gradient(circle,#6b24dd 0%,#141020 75%);border-radius:50%;box-shadow:0 0 18px rgba(141,69,255,.85);z-index:9999;pointer-events:none;opacity:0;transform:translate(-50%,-50%);transition:left .35s ease, top .35s ease, opacity .2s ease;";
 document.body.appendChild(agentCursor);
 
+function currentTab() {
+  return state.tabs.find((t) => t.id === state.activeTabId);
+}
+function escapeHtml(text = "") {
+  return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#039;");
+}
+function ensureUrl(value) { return /^https?:\/\//i.test(value) ? value : `https://${value}`; }
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+function highlight(v) { return `<span class="hl">${escapeHtml(v)}</span>`; }
 
 function playIntroSound() {
   try {
     const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-    const oscillator = audioCtx.createOscillator();
-    const gain = audioCtx.createGain();
-
-    oscillator.type = "triangle";
-    oscillator.frequency.setValueAtTime(180, audioCtx.currentTime);
-    oscillator.frequency.exponentialRampToValueAtTime(520, audioCtx.currentTime + 0.32);
-
-    gain.gain.setValueAtTime(0.0001, audioCtx.currentTime);
-    gain.gain.exponentialRampToValueAtTime(0.2, audioCtx.currentTime + 0.12);
-    gain.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + 0.82);
-
-    oscillator.connect(gain);
-    gain.connect(audioCtx.destination);
-    oscillator.start();
-    oscillator.stop(audioCtx.currentTime + 0.85);
-
-    oscillator.onended = () => audioCtx.close();
-  } catch {
-    // Sessiz geçiş fallback
-  }
+    const o = audioCtx.createOscillator();
+    const g = audioCtx.createGain();
+    o.type = "triangle";
+    o.frequency.setValueAtTime(180, audioCtx.currentTime);
+    o.frequency.exponentialRampToValueAtTime(520, audioCtx.currentTime + 0.32);
+    g.gain.setValueAtTime(0.0001, audioCtx.currentTime);
+    g.gain.exponentialRampToValueAtTime(0.2, audioCtx.currentTime + 0.12);
+    g.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + 0.82);
+    o.connect(g); g.connect(audioCtx.destination); o.start(); o.stop(audioCtx.currentTime + 0.85);
+    o.onended = () => audioCtx.close();
+  } catch {}
 }
-
 function runIntro() {
   const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   const introDuration = reducedMotion ? 2350 : 4800;
-
-  if (!el.introOverlay || !el.appShell) return;
-
   playIntroSound();
-
   setTimeout(() => {
     el.introOverlay.classList.add("hidden");
     el.appShell.classList.remove("app-hidden");
@@ -109,79 +100,312 @@ function runIntro() {
   }, introDuration);
 }
 
-function escapeHtml(text) {
-  return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#039;");
-}
-
-function sleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
-function ensureUrl(value) { return /^https?:\/\//i.test(value) ? value : `https://${value}`; }
-
-
-function isLikelyMobileDevice() {
-  return window.matchMedia("(max-width: 980px)").matches || /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
-}
-
-function openExternalUrl(url) {
-  const safe = ensureUrl(url);
-  const popup = window.open(safe, "_blank", "noopener,noreferrer");
-  if (!popup) window.location.href = safe;
-}
-
 function setPanel(open) {
   el.aiPanel.classList.toggle("hidden", !open);
   el.contentGrid.classList.toggle("with-panel", open);
 }
 
-function openUrl(url, addToHistory = true, forceExternal = false) {
-  if (!url) return;
-  const safe = ensureUrl(url);
+function renderTabs() {
+  el.tabs.innerHTML = "";
+  state.tabs.forEach((tab) => {
+    const b = document.createElement("button");
+    b.className = `tab-item ${tab.id === state.activeTabId ? "active" : ""}`;
+    b.innerHTML = `<span>${escapeHtml(tab.title)}</span><span class="tab-close" data-close="${tab.id}">✕</span>`;
+    b.addEventListener("click", (e) => {
+      const close = e.target.closest(".tab-close");
+      if (close) return closeTab(Number(close.dataset.close));
+      switchTab(tab.id);
+    });
+    el.tabs.appendChild(b);
+  });
+}
 
-  if (forceExternal || isLikelyMobileDevice()) {
-    openExternalUrl(safe);
-    return;
-  }
+function createTab(url = "") {
+  const tab = { id: state.nextTabId++, title: "Yeni Sekme", url: "", history: [], index: -1 };
+  state.tabs.push(tab);
+  state.activeTabId = tab.id;
+  renderTabs();
+  if (url) openUrl(url);
+  else showHome();
+}
 
-  el.siteFrame.src = safe;
-  el.adresCubugu.value = safe;
+function closeTab(id) {
+  if (state.tabs.length === 1) return;
+  state.tabs = state.tabs.filter((t) => t.id !== id);
+  if (!state.tabs.some((t) => t.id === state.activeTabId)) state.activeTabId = state.tabs[0].id;
+  renderTabs();
+  syncTabView();
+}
+
+function switchTab(id) {
+  state.activeTabId = id;
+  renderTabs();
+  syncTabView();
+}
+
+function showHome() {
+  el.homeView.classList.remove("hidden");
+  el.webView.classList.add("hidden");
+  el.adresCubugu.value = "";
+}
+
+function syncTabView() {
+  const tab = currentTab();
+  if (!tab || !tab.url) return showHome();
+  el.adresCubugu.value = tab.url;
+  el.siteFrame.src = tab.url;
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
+}
+
+function openUrl(url, addToHistory = true) {
+  const safe = ensureUrl(url);
+  const tab = currentTab();
+  if (!tab) return;
+
+  tab.url = safe;
+  try { tab.title = new URL(safe).hostname.replace(/^www\./, ""); } catch { tab.title = "Yeni Sekme"; }
 
   if (addToHistory) {
-    state.history = state.history.slice(0, state.index + 1);
-    state.history.push(safe);
-    state.index = state.history.length - 1;
+    tab.history = tab.history.slice(0, tab.index + 1);
+    tab.history.push(safe);
+    tab.index = tab.history.length - 1;
   }
+
+  renderTabs();
+  syncTabView();
 }
 
-function parseSite(urlCandidate) {
-  let url;
-  try { url = new URL(ensureUrl(urlCandidate)); } catch { return null; }
-  const host = url.hostname.replace(/^www\./, "").toLowerCase();
-  const matchKey = Object.keys(SITE_HINTS).find((key) => host.endsWith(key));
-  if (matchKey) return { ...SITE_HINTS[matchKey], host, url: url.href };
-
-  const base = host.split(".")[0] || "web sitesi";
-  return {
-    name: base.charAt(0).toUpperCase() + base.slice(1),
-    purpose: "webde bilgi/hizmet sunmak",
-    company: "kesin şirket bilgisi için site hakkında bölümü gerekir",
-    year: "kuruluş yılı net değil",
-    wiki: base
-  };
+async function getSearchResults(query) {
+  const response = await fetch(`https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_redirect=1&no_html=1`);
+  if (!response.ok) throw new Error("duckduckgo error");
+  const data = await response.json();
+  const parsed = [];
+  if (data.AbstractURL) parsed.push({ title: data.Heading || query, href: data.AbstractURL, snippet: data.AbstractText || "Özet bilgi" });
+  (data.RelatedTopics || []).forEach((item) => {
+    if (item.FirstURL && item.Text) parsed.push({ title: item.Text.split(" - ")[0], href: item.FirstURL, snippet: item.Text });
+    (item.Topics || []).forEach((sub) => {
+      if (sub.FirstURL && sub.Text) parsed.push({ title: sub.Text.split(" - ")[0], href: sub.FirstURL, snippet: sub.Text });
+    });
+  });
+  return parsed.slice(0, 8);
 }
 
-async function fetchWikipediaSnippet(term) {
+function renderResults(results) {
+  el.sonuclar.innerHTML = "";
+  results.forEach((item) => {
+    const card = document.createElement("article");
+    card.className = "result-item";
+    card.innerHTML = `<h3><a href="#">${escapeHtml(item.title)}</a></h3><p>${escapeHtml(item.snippet || "Açıklama yok")}</p><div class="result-actions"><button class="open-link" type="button">Bağlantıyı Aç</button><button class="ask-link" type="button">✦ Baluk.ai'ye Sor</button></div>`;
+    card.querySelector("a").addEventListener("click", (e) => { e.preventDefault(); openUrl(item.href); });
+    card.querySelector(".open-link").addEventListener("click", () => openUrl(item.href));
+    card.querySelector(".ask-link").addEventListener("click", () => {
+      setPanel(true);
+      el.aiSoru.value = `${item.title} web sitesi ne işe yarar?`;
+      el.aiForm.requestSubmit();
+    });
+    el.sonuclar.appendChild(card);
+  });
+}
+
+async function fetchWikipediaSnippet(topic) {
   try {
-    const api = `https://tr.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(term)}`;
-    const res = await fetch(api);
-    if (!res.ok) return "";
-    const data = await res.json();
-    const text = (data.extract || "").trim();
-    if (!text) return "";
-    return text.slice(0, 200);
-  } catch {
-    return "";
+    const r = await fetch(`https://tr.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(topic)}`);
+    if (!r.ok) return "";
+    const data = await r.json();
+    return (data.extract || "").trim().slice(0, 200);
+  } catch { return ""; }
+}
+
+function siteHintFromText(text) {
+  const t = text.toLowerCase();
+  const m = ["youtube", "google", "wikipedia", "github", "instagram", "twitter", "shopify"].find((x) => t.includes(x));
+  return m || "web sitesi";
+}
+
+function startThinking(customLines = THINKING_LINES) {
+  el.aiCevap.innerHTML = "";
+  el.thinkingBox.classList.remove("hidden");
+  el.spinLogo.classList.add("active");
+  document.body.classList.add("web-glow");
+  let idx = 0;
+  el.thinkingText.textContent = customLines[0];
+  clearInterval(state.thinkingTicker);
+  state.thinkingTicker = setInterval(() => {
+    idx = (idx + 1) % customLines.length;
+    el.thinkingText.textContent = customLines[idx];
+  }, 1400);
+}
+function stopThinking() {
+  clearInterval(state.thinkingTicker);
+  el.thinkingBox.classList.add("hidden");
+  el.spinLogo.classList.remove("active");
+  document.body.classList.remove("web-glow");
+}
+
+function setAgentMode(on) {
+  state.agentModeActive = on;
+  el.agentBadge.classList.toggle("hidden", !on);
+  el.agentModeBtn.textContent = on ? "Agent Mode 2.0 (Açık)" : "Agent Mode 2.0";
+  if (!on) {
+    state.selectedTargets = [];
+    renderSelectedTargets();
   }
+}
+
+function renderSelectedTargets() {
+  el.selectedTargets.innerHTML = "";
+  state.selectedTargets.forEach((target, i) => {
+    const chip = document.createElement("div");
+    chip.className = "target-chip";
+    chip.innerHTML = `<span>${escapeHtml(target.label)}</span><button type="button">✕</button>`;
+    chip.querySelector("button").onclick = () => {
+      state.selectedTargets.splice(i, 1);
+      renderSelectedTargets();
+    };
+    el.selectedTargets.appendChild(chip);
+  });
+}
+
+function bindAgentPicker() {
+  try {
+    const doc = el.siteFrame.contentDocument;
+    if (!doc) throw new Error();
+    doc.addEventListener("click", (e) => {
+      if (!state.agentModeActive) return;
+      const t = e.target;
+      if (!(t instanceof HTMLElement)) return;
+      e.preventDefault(); e.stopPropagation();
+      const label = (t.innerText || t.placeholder || t.value || t.tagName).trim().slice(0, 26) || t.tagName;
+      state.selectedTargets.push({ el: t, label });
+      t.style.outline = "2px solid #b171ff";
+      renderSelectedTargets();
+      el.aiCevap.innerHTML = `Seçildi: ${highlight(label)}. Şimdi ne yapılacağını yaz.`;
+    }, { capture: true });
+    el.aiCevap.innerHTML = "Agent Mode 2.0 açık. Sayfadan bir veya birden çok öğe seçebilirsin.";
+  } catch {
+    el.aiCevap.innerHTML = "Bu sayfada güvenlik nedeniyle işaretleme yapılamıyor (farklı domain kısıtı).";
+  }
+}
+
+function parseSearchCommand(q) {
+  const t = q.toLowerCase().trim();
+  const m1 = t.match(/^ara\s+(.+)$/);
+  const m2 = t.match(/^(.+)\s+ara$/);
+  const m3 = t.match(/^(.+)\s+arat$/);
+  const m4 = t.match(/^hey baluk\s+(.+)$/);
+  const query = (m1?.[1] || m2?.[1] || m3?.[1] || m4?.[1] || "").trim();
+  const n = Number((t.match(/(\d+)\.\s*link/) || [])[1] || 1);
+  return { query, linkIndex: Math.max(1, n || 1) };
+}
+
+function moveCursorTo(element) {
+  const rect = element.getBoundingClientRect();
+  agentCursor.style.opacity = "1";
+  agentCursor.style.left = `${rect.left + rect.width / 2}px`;
+  agentCursor.style.top = `${rect.top + rect.height / 2}px`;
+}
+
+async function runAgentTask(q) {
+  startThinking(["Masaüstümü kuruyorum...", "Hedefleri planlıyorum...", "Hazırım, uyguluyorum..."]);
+  await sleep(3000);
+  stopThinking();
+
+  const low = q.toLowerCase();
+  if (low.includes("geri")) { el.geriBtn.click(); return "İstediğin işlem yapıldı: geri gidildi."; }
+  if (low.includes("ileri")) { el.ileriBtn.click(); return "İstediğin işlem yapıldı: ileri gidildi."; }
+  if (low.includes("yenile")) { el.yenileBtn.click(); return "İstediğin işlem yapıldı: sayfa yenilendi."; }
+  if (low.includes("yeni sekme")) { createTab(); return "İstediğin işlem yapıldı: yeni sekme açıldı."; }
+
+  const parsed = parseSearchCommand(q);
+  if (parsed.query) {
+    moveCursorTo(el.aramaInput);
+    await sleep(250);
+    showHome();
+    el.aramaInput.value = parsed.query;
+    el.aramaForm.requestSubmit();
+    await sleep(1200);
+    const cards = [...document.querySelectorAll(".result-item")];
+    const idx = Math.min(parsed.linkIndex - 1, cards.length - 1);
+    const btn = cards[idx]?.querySelector(".open-link");
+    if (btn) {
+      moveCursorTo(btn);
+      await sleep(300);
+      btn.click();
+      return `Şunu istedin: ${escapeHtml(parsed.query)}. Şunu yaptım: ${parsed.linkIndex}. linki açtım.`;
+    }
+    return "Sonuç bulunamadı.";
+  }
+
+  if (state.selectedTargets.length) {
+    if (/tıkla/.test(low)) {
+      for (const t of state.selectedTargets) {
+        t.el.click();
+        await sleep(220);
+      }
+      return "Seçtiğin öğelere sırayla tıkladım.";
+    }
+
+    const write = q.match(/(?:yaz|değiştir|yap)\s+(.+)/i)?.[1]?.trim();
+    if (write) {
+      for (const t of state.selectedTargets) {
+        if ("value" in t.el) {
+          t.el.focus();
+          t.el.value = write.replace(/"/g, "");
+          t.el.dispatchEvent(new Event("input", { bubbles: true }));
+          t.el.dispatchEvent(new Event("change", { bubbles: true }));
+        }
+      }
+      return `Seçili alanlara ${highlight(write)} yazdım.`;
+    }
+  }
+
+  return "Agent Mode 2.0: komutu anlayamadım. Örn: 'youtube arat 2. linke tıkla' veya 'seçili öğelere tıkla'.";
+}
+
+async function answerNormal(q) {
+  const low = q.toLowerCase();
+  if (/(geri|ileri|yenile|yeni sekme)/.test(low)) {
+    return `Bunu ben yapayım dersen ${highlight("Agent Mode 2.0")} açıp tekrar yaz.`;
+  }
+
+  const topic = siteHintFromText(q);
+  const wiki = await fetchWikipediaSnippet(topic);
+
+  if (/kuruluş|kaç yılında|ne zaman/.test(low)) {
+    return `${highlight(topic)} için kuruluş yılı bilgisi: ${highlight(wiki ? "Wikipedia'dan özet bulundu" : "detay için kaynak gerekli")}.`;
+  }
+
+  if (/isim|adı/.test(low)) {
+    return `Web sitesi adı: ${highlight(topic)}.`;
+  }
+
+  if (/amaç|ne işe yarar|hakkında/.test(low)) {
+    const summary = wiki || `${topic} genel olarak bilgi/hizmet sunar.`;
+    return `${highlight(topic)} amacı:\n${escapeHtml(summary)}`;
+  }
+
+  return `${highlight(topic)} hakkında özet:\n${escapeHtml(wiki || "Wikipedia özeti bulunamadı.")}`;
+}
+
+function initPrompts() {
+  const prompts = [
+    { text: "YouTube'un amacı nedir?", agent: false },
+    { text: "shopify arat 1. linke tıkla", agent: true },
+    { text: "Yeni sekme aç", agent: true },
+  ];
+  prompts.forEach((p) => {
+    const b = document.createElement("button");
+    b.type = "button";
+    b.textContent = p.text;
+    b.onclick = () => {
+      setPanel(true);
+      if (p.agent) setAgentMode(true);
+      el.aiSoru.value = p.text;
+      el.aiForm.requestSubmit();
+    };
+    el.quickPrompts.appendChild(b);
+  });
 }
 
 function renderAuth() {
@@ -197,204 +421,48 @@ function renderAuth() {
   }
 }
 
-function createFallbackResults(query) {
-  const q = encodeURIComponent(query);
-  return [
-    { title: `DuckDuckGo: ${query}`, href: `https://duckduckgo.com/?q=${q}`, snippet: "DuckDuckGo sonuç sayfasını açar." },
-    { title: `Wikipedia araması: ${query}`, href: `https://tr.wikipedia.org/wiki/Özel:Arama?search=${q}`, snippet: "Wikipedia üzerinden hızlı kaynak taraması." }
-  ];
-}
-
-async function getSearchResults(query) {
-  const response = await fetch(`https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_redirect=1&no_html=1`);
-  if (!response.ok) throw new Error("duckduckgo error");
-  const data = await response.json();
-  const parsed = [];
-
-  if (data.AbstractURL) parsed.push({ title: data.Heading || query, href: data.AbstractURL, snippet: data.AbstractText || "Özet bilgi" });
-
-  (data.RelatedTopics || []).forEach((item) => {
-    if (item.FirstURL && item.Text) parsed.push({ title: item.Text.split(" - ")[0], href: item.FirstURL, snippet: item.Text });
-    (item.Topics || []).forEach((sub) => {
-      if (sub.FirstURL && sub.Text) parsed.push({ title: sub.Text.split(" - ")[0], href: sub.FirstURL, snippet: sub.Text });
-    });
-  });
-
-  return parsed.slice(0, 8);
-}
-
-function askAboutSite(url, customQuestion = "") {
-  setPanel(true);
-  if (!state.user) {
-    el.aiCevap.textContent = "Bu siteyi analiz etmek için önce giriş yapman gerekiyor.";
-    return;
-  }
-  const q = customQuestion || `Bu web sitesi ne amaçla kurulmuştur? (${url})`;
-  el.aiSoru.value = q;
-  el.aiForm.requestSubmit();
-}
-
-function renderResults(results, query) {
-  if (!results.length) results = createFallbackResults(query);
-  el.sonuclar.innerHTML = "";
-
-  results.forEach((item) => {
-    const card = document.createElement("article");
-    card.className = "result-item";
-    card.innerHTML = `
-      <h3><a href="#">${escapeHtml(item.title)}</a></h3>
-      <p>${escapeHtml(item.snippet || "Açıklama yok")}</p>
-      <div class="result-actions">
-        <button type="button" class="open-link">Bağlantıyı Aç</button>
-        <button type="button" class="ask-link">✦ Baluk.ai'ye Sor</button>
-      </div>
-    `;
-    card.querySelector("a").addEventListener("click", (e) => { e.preventDefault(); openUrl(item.href, true, isLikelyMobileDevice()); });
-    card.querySelector(".open-link").addEventListener("click", () => openUrl(item.href, true, isLikelyMobileDevice()));
-    card.querySelector(".ask-link").addEventListener("click", () => askAboutSite(item.href, `${item.title} sitesi ne işe yarar, kim tarafından kuruldu ve ne zaman kuruldu?`));
-    el.sonuclar.appendChild(card);
-  });
-}
-
-function startThinking() {
-  el.aiCevap.textContent = "";
-  el.thinkingBox.classList.remove("hidden");
-  el.spinLogo.classList.add("active");
-  document.body.classList.add("web-glow");
-
-  let idx = 0;
-  el.thinkingText.textContent = THINKING_LINES[0];
-  state.thinkingTicker = setInterval(() => {
-    idx = (idx + 1) % THINKING_LINES.length;
-    el.thinkingText.textContent = THINKING_LINES[idx];
-  }, 2400);
-}
-
-function stopThinking() {
-  clearInterval(state.thinkingTicker);
-  el.thinkingBox.classList.add("hidden");
-  el.spinLogo.classList.remove("active");
-  document.body.classList.remove("web-glow");
-}
-
-async function buildAiAnswer(q) {
-  const currentUrl = el.adresCubugu.value || q.match(/https?:\/\/\S+/)?.[0] || "";
-  const site = parseSite(currentUrl || "example.com");
-  const siteName = site?.name || "Bu site";
-
-  if (/kaç yılında|ne zaman/i.test(q)) return `${siteName} için bulduğum bilgi: kuruluş yılı ${site.year}.`;
-  if (/hangi şirket|kim tarafından/i.test(q)) return `${siteName} için şirket/kurucu bilgisi: ${site.company}.`;
-
-  if (/youtube|wikipedia|github|instagram|google|twitter|x\.com|web sitesi|site hakkında|hakkında bilgi|amaç/i.test(q)) {
-    const wiki = await fetchWikipediaSnippet(site.wiki || siteName);
-    if (wiki) {
-      return `${siteName}: ${site.purpose}.\n\nWikipedia özeti (ilk 200 karakter): ${wiki}`;
-    }
-    return `${siteName}: ${site.purpose}. Şirket: ${site.company}. Kuruluş: ${site.year}.`;
-  }
-
-  return `${siteName} özeti: ${site.year} yılında kurulduğu biliniyor, ${site.company} tarafından geliştirildi/işletiliyor ve ana amacı ${site.purpose}.`;
-}
-
-function parseAgentCommand(text) {
-  const cleaned = text.toLowerCase().trim();
-  const searchMatch = cleaned.match(/(?:arat|ara)\s*:?\s*(.+?)(?:\s+çıkan|$)/i) || cleaned.match(/(.+?)\s+arat/i);
-  const query = searchMatch ? searchMatch[1].trim() : text.trim();
-
-  const indexMatch = cleaned.match(/(\d+)\.?\s*(link|sonuç)/i);
-  const index = indexMatch ? Math.max(1, Number(indexMatch[1])) : 1;
-
-  return { query, index };
-}
-
-function moveCursorTo(element) {
-  const rect = element.getBoundingClientRect();
-  agentCursor.style.opacity = "1";
-  agentCursor.style.left = `${rect.left + rect.width / 2}px`;
-  agentCursor.style.top = `${rect.top + rect.height / 2}px`;
-}
-
-function hideCursor() {
-  agentCursor.style.opacity = "0";
-}
-
-async function runAgentSearchFlow(commandText) {
-  if (state.agentBusy) return "Agent Mode meşgul, işlem bitmesini bekle.";
-  state.agentBusy = true;
-
-  try {
-    const { query, index } = parseAgentCommand(commandText);
-    if (!query) return "Agent Mode: Aratılacak ifadeyi anlayamadım.";
-
-    el.homeView.classList.remove("hidden");
-    el.webView.classList.add("hidden");
-
-    moveCursorTo(el.aramaInput);
-    await sleep(300);
-    el.aramaInput.focus();
-    el.aramaInput.value = "";
-
-    for (const ch of query) {
-      el.aramaInput.value += ch;
-      await sleep(35);
-    }
-
-    await sleep(240);
-    el.aramaForm.requestSubmit();
-    await sleep(1300);
-
-    const cards = [...document.querySelectorAll(".result-item")];
-    if (!cards.length) return `"${query}" için sonuç bulunamadı.`;
-
-    const targetCard = cards[Math.min(index - 1, cards.length - 1)];
-    const openBtn = targetCard.querySelector(".open-link");
-    if (!openBtn) return "Hedef bağlantı bulunamadı.";
-
-    moveCursorTo(openBtn);
-    await sleep(420);
-    openBtn.click();
-    await sleep(420);
-
-    return `Agent Mode tamamlandı: "${query}" aratıldı ve ${Math.min(index, cards.length)}. link açıldı.`;
-  } finally {
-    hideCursor();
-    state.agentBusy = false;
-    state.agentModeActive = false;
-  }
-}
-
-el.aramaForm.addEventListener("submit", async (event) => {
-  event.preventDefault();
+el.aramaForm.addEventListener("submit", async (e) => {
+  e.preventDefault();
   const q = el.aramaInput.value.trim();
   if (!q) return;
-  el.sonuclar.innerHTML = "Aranıyor...";
-
-  try {
-    const results = await getSearchResults(q);
-    renderResults(results, q);
-  } catch {
-    renderResults(createFallbackResults(q), q);
-  }
+  el.sonuclar.innerHTML = `<span class="searching-status">Ekranında arıyorum...</span>`;
+  try { renderResults(await getSearchResults(q)); }
+  catch { el.sonuclar.innerHTML = "Sonuç alınamadı."; }
 });
 
 el.adresCubugu.addEventListener("keydown", (e) => { if (e.key === "Enter") openUrl(el.adresCubugu.value); });
-el.geriBtn.addEventListener("click", () => { if (state.index > 0) openUrl(state.history[--state.index], false); });
-el.ileriBtn.addEventListener("click", () => { if (state.index < state.history.length - 1) openUrl(state.history[++state.index], false); });
+el.geriBtn.addEventListener("click", () => {
+  const t = currentTab();
+  if (t && t.index > 0) { t.index -= 1; t.url = t.history[t.index]; syncTabView(); renderTabs(); }
+});
+el.ileriBtn.addEventListener("click", () => {
+  const t = currentTab();
+  if (t && t.index < t.history.length - 1) { t.index += 1; t.url = t.history[t.index]; syncTabView(); renderTabs(); }
+});
 el.yenileBtn.addEventListener("click", () => { if (el.siteFrame.src) el.siteFrame.src = el.siteFrame.src; });
-el.newTabBtn.addEventListener("click", () => { el.homeView.classList.remove("hidden"); el.webView.classList.add("hidden"); el.adresCubugu.value = ""; });
+el.newTabBtn.addEventListener("click", () => createTab());
+el.addTabBtn.addEventListener("click", () => createTab());
+
 el.balukPanelBtn.addEventListener("click", () => setPanel(el.aiPanel.classList.contains("hidden")));
 el.closePanelBtn.addEventListener("click", () => setPanel(false));
+el.plusBtn.addEventListener("click", () => el.agentMenu.classList.toggle("hidden"));
+el.agentModeBtn.addEventListener("click", () => {
+  setAgentMode(!state.agentModeActive);
+  el.agentMenu.classList.add("hidden");
+  if (state.agentModeActive) bindAgentPicker();
+});
+el.agentBadgeClose.addEventListener("click", () => setAgentMode(false));
+el.siteFrame.addEventListener("load", () => { if (state.agentModeActive) bindAgentPicker(); });
 
 el.loginForm.addEventListener("submit", (e) => {
   e.preventDefault();
   const user = {
     email: document.getElementById("mail").value.trim(),
     ad: document.getElementById("ad").value.trim(),
-    soyad: document.getElementById("soyad").value.trim()
+    soyad: document.getElementById("soyad").value.trim(),
   };
   const file = document.getElementById("profil").files[0];
   if (!user.email || !user.ad || !user.soyad) return;
-
   if (file) {
     const reader = new FileReader();
     reader.onload = () => {
@@ -411,21 +479,13 @@ el.loginForm.addEventListener("submit", (e) => {
   }
 });
 
-el.plusBtn.addEventListener("click", () => el.agentMenu.classList.toggle("hidden"));
-el.agentModeBtn.addEventListener("click", () => {
-  state.agentModeActive = true;
-  el.agentMenu.classList.add("hidden");
-  el.aiCevap.textContent = "Agent Mode aktif. Komut ver: örn 'youtube arat çıkan 3. linke tıkla'. Link belirtilmezse 1. link açılır.";
-  setPanel(true);
-});
-
 el.aiForm.addEventListener("submit", async (e) => {
   e.preventDefault();
   const q = el.aiSoru.value.trim();
   if (!q) return;
 
   if (state.agentModeActive) {
-    el.aiCevap.textContent = await runAgentSearchFlow(q);
+    el.aiCevap.innerHTML = await runAgentTask(q);
     el.aiSoru.value = "";
     return;
   }
@@ -434,7 +494,7 @@ el.aiForm.addEventListener("submit", async (e) => {
   clearTimeout(state.thinkingTimer);
   state.thinkingTimer = setTimeout(async () => {
     stopThinking();
-    el.aiCevap.textContent = await buildAiAnswer(q);
+    el.aiCevap.innerHTML = await answerNormal(q);
     el.aiSoru.value = "";
   }, 20000);
 });
@@ -446,6 +506,8 @@ el.aiSoru.addEventListener("keydown", (e) => {
   }
 });
 
+renderTabs();
 renderAuth();
+initPrompts();
 setPanel(false);
 runIntro();

--- a/style.css
+++ b/style.css
@@ -208,3 +208,81 @@ body {
   .content-grid, .content-grid.with-panel { grid-template-columns: 1fr; }
   .ai-panel { border-left: none; border-top: 1px solid var(--soft-border); height: auto; }
 }
+
+.app-hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.intro-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 12000;
+  display: grid;
+  place-content: center;
+  gap: 18px;
+  background: radial-gradient(circle at center, rgba(95, 41, 182, 0.42) 0%, rgba(6, 8, 17, 0.96) 62%, #03040a 100%);
+  transition: opacity .7s ease, visibility .7s ease;
+}
+
+.intro-overlay.hidden {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.intro-card {
+  position: relative;
+  min-width: min(860px, 92vw);
+  padding: clamp(18px, 3vw, 30px) clamp(24px, 5vw, 60px);
+  border-radius: 999px;
+  border: 2px solid rgba(180, 140, 255, 0.92);
+  background: linear-gradient(140deg, rgba(90, 37, 176, .95), rgba(23, 20, 72, .94) 56%, rgba(10, 16, 58, .95));
+  box-shadow: 0 0 26px rgba(141,69,255,.9), inset 0 0 22px rgba(236,226,255,.2), 0 0 70px rgba(89, 18, 180, 0.65);
+  transform: scale(.58) translateY(24px);
+  opacity: 0;
+  animation: introZoom .9s cubic-bezier(.15,.8,.22,1) forwards;
+}
+
+.intro-title {
+  position: relative;
+  text-align: center;
+  font-size: clamp(2rem, 5.5vw, 5rem);
+  letter-spacing: .8px;
+  font-weight: 800;
+  color: #eddcff;
+  text-shadow: 0 0 10px rgba(255,255,255,.3), 0 0 24px rgba(176,112,255,.72);
+}
+
+.intro-glow {
+  position: absolute;
+  inset: 4px;
+  border-radius: 999px;
+  pointer-events: none;
+  background: linear-gradient(110deg, rgba(255,255,255,.1), transparent 35%, rgba(255,255,255,.22) 50%, transparent 66%, rgba(255,255,255,.08));
+  filter: blur(1px);
+  animation: introSheen 1.8s ease-in-out .25s 2;
+}
+
+.intro-subtitle {
+  margin: 0;
+  text-align: center;
+  color: #d8c0ff;
+  font-size: clamp(1rem, 2vw, 1.45rem);
+  opacity: 0;
+  transform: translateY(12px);
+  animation: subtitleIn .75s ease .75s forwards;
+}
+
+@keyframes introZoom {
+  to { transform: scale(1) translateY(0); opacity: 1; }
+}
+
+@keyframes introSheen {
+  0% { transform: translateX(-30%); opacity: .2; }
+  45% { transform: translateX(2%); opacity: .75; }
+  100% { transform: translateX(30%); opacity: .2; }
+}
+
+@keyframes subtitleIn {
+  to { opacity: 1; transform: translateY(0); }
+}

--- a/style.css
+++ b/style.css
@@ -1,108 +1,145 @@
+:root {
+  --night: #080b18;
+  --night-soft: #111735;
+  --glow-purple: #8d45ff;
+  --glow-purple-soft: rgba(141, 69, 255, 0.2);
+  --text: #f7f6ff;
+}
+
+* { box-sizing: border-box; }
+
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
-  background-color: #0d0d0d;
-  color: white;
+  font-family: Inter, Arial, sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at top, #241146 0%, var(--night) 45%, #05070f 100%);
+  min-height: 100vh;
 }
 
-.gizli {
-  display: none;
-}
+.app-shell { min-height: 100vh; }
 
-#girisEkrani {
-  text-align: center;
-  padding: 40px;
-}
-
-#girisEkrani input, #girisEkrani button {
-  display: block;
-  margin: 10px auto;
-  padding: 10px;
-  width: 80%;
-}
-
-header {
-  background-color: #1a1a1a;
-  padding: 10px;
-  display: flex;
-  justify-content: space-between;
+.topbar {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  gap: 10px;
   align-items: center;
+  padding: 10px 14px;
+  background: rgba(8, 11, 24, 0.86);
+  border-bottom: 1px solid rgba(141, 69, 255, 0.28);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(6px);
 }
 
-#arama {
-  padding: 8px;
-  border-radius: 5px;
-  border: none;
+.tab { background: #1d2140; border: 1px solid #31386d; color: #ded4ff; border-radius: 10px; padding: 8px 14px; }
+.tab.active { box-shadow: 0 0 14px var(--glow-purple-soft); }
+
+.browser-controls button,
+.baluk-mini,
+.search-box button,
+.stacked-form button {
+  border: 1px solid #4f3b8a;
+  background: #1c2146;
+  color: var(--text);
+  border-radius: 10px;
+  padding: 8px 12px;
+  cursor: pointer;
 }
 
-.video-galeri {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 15px;
-  justify-content: center;
-  padding: 20px;
+#adresCubugu,
+.search-box input,
+.stacked-form input,
+.stacked-form textarea {
+  width: 100%;
+  background: #0f1431;
+  color: var(--text);
+  border: 1px solid #3f4678;
+  border-radius: 10px;
+  padding: 10px;
 }
 
-.video {
-  background: #1a1a1a;
+.content-grid {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  min-height: calc(100vh - 69px);
+}
+
+.search-screen,
+.web-screen {
+  padding: 40px 20px;
+}
+
+.search-screen h1 {
+  text-align: center;
+  margin-top: 60px;
+  font-size: clamp(2rem, 6vw, 3.7rem);
+  letter-spacing: 1px;
+  color: #d8c5ff;
+  text-shadow: 0 0 10px rgba(141, 69, 255, 0.8), 0 0 30px rgba(141, 69, 255, 0.55);
+}
+
+.search-box {
+  max-width: 700px;
+  margin: 16px auto 24px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+}
+
+.results {
+  max-width: 900px;
+  margin: 0 auto;
+  display: grid;
+  gap: 12px;
+}
+
+.result-item {
+  background: rgba(12, 16, 33, 0.9);
+  border: 1px solid rgba(141, 69, 255, 0.32);
+  border-radius: 14px;
+  padding: 14px;
+}
+
+.result-item h3 { margin: 0 0 8px; }
+.result-item p { margin: 0; color: #cfc8e9; }
+.result-item a { color: #cab7ff; text-decoration: none; }
+
+#siteFrame {
+  width: 100%;
+  height: calc(100vh - 150px);
+  border: 1px solid rgba(141, 69, 255, 0.4);
+  border-radius: 14px;
+  background: white;
+}
+
+.ai-panel {
+  border-left: 1px solid rgba(141, 69, 255, 0.32);
+  background: linear-gradient(180deg, rgba(12, 15, 31, 0.95), rgba(7, 10, 18, 0.95));
+  padding: 18px;
+}
+
+.stacked-form { display: grid; gap: 10px; }
+.thinking {
+  margin-top: 10px;
   padding: 10px;
   border-radius: 10px;
-  width: 200px;
-  text-align: center;
-  position: relative;
+  background: rgba(141, 69, 255, 0.12);
+  border: 1px solid rgba(141, 69, 255, 0.6);
+  box-shadow: 0 0 16px rgba(141, 69, 255, 0.55);
+  animation: pulse 1.2s infinite alternate;
 }
 
-.video video {
-  width: 100%;
-  border-radius: 5px;
+.ai-answer { margin-top: 12px; line-height: 1.5; color: #e9e0ff; }
+.hidden { display: none; }
+
+@keyframes pulse {
+  from { opacity: 0.5; }
+  to { opacity: 1; }
 }
 
-.video button {
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  background: red;
-  color: white;
-  border: none;
-  border-radius: 50%;
-  padding: 5px;
-  cursor: pointer;
-}
-
-#profil {
-  text-align: center;
-  margin-top: 20px;
-}
-
-#profil img {
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  object-fit: cover;
-  background-color: white;
-}
-
-#videoDosyasi, #videoBaslik {
-  display: block;
-  margin: 10px auto;
-  padding: 8px;
-  width: 80%;
-}
-
-nav#altMenu {
-  position: fixed;
-  bottom: 0;
-  width: 100%;
-  background: #111;
-  display: flex;
-  justify-content: space-around;
-  padding: 10px 0;
-}
-
-nav button {
-  background: none;
-  border: none;
-  color: white;
-  font-size: 24px;
-  cursor: pointer;
+@media (max-width: 980px) {
+  .topbar { grid-template-columns: 1fr; }
+  .content-grid { grid-template-columns: 1fr; }
+  .ai-panel { border-left: none; border-top: 1px solid rgba(141,69,255,.32); }
 }

--- a/style.css
+++ b/style.css
@@ -149,7 +149,7 @@ body {
 }
 
 .app-hidden { opacity:0; pointer-events:none; }
-.intro-overlay { position:fixed; inset:0; z-index:12000; display:grid; place-content:center; gap:18px; background: radial-gradient(circle at center, rgba(95,41,182,.42) 0%, rgba(6,8,17,.96) 62%, #03040a 100%); transition:opacity .7s ease, visibility .7s ease; }
+.intro-overlay { position:fixed; inset:0; z-index:12000; display:grid; place-content:center; gap:18px; background: radial-gradient(circle at center, rgba(95,41,182,.42) 0%, rgba(6,8,17,.96) 62%, #03040a 100%); transition:opacity .7s ease, visibility .7s ease; animation:introAutoHide 9s ease forwards; }
 .intro-overlay.hidden { opacity:0; visibility:hidden; }
 .intro-card { position:relative; min-width:min(860px,92vw); padding:clamp(18px,3vw,30px) clamp(24px,5vw,60px); border-radius:999px; border:2px solid rgba(180,140,255,.92); background:linear-gradient(140deg, rgba(90,37,176,.95), rgba(23,20,72,.94) 56%, rgba(10,16,58,.95)); box-shadow:0 0 26px rgba(141,69,255,.9), inset 0 0 22px rgba(236,226,255,.2), 0 0 70px rgba(89,18,180,.65); transform:scale(.58) translateY(24px); opacity:0; animation:introZoom .9s cubic-bezier(.15,.8,.22,1) forwards; }
 .intro-title { text-align:center; font-size:clamp(2rem,5.5vw,5rem); font-weight:800; color:#eddcff; text-shadow:0 0 10px rgba(255,255,255,.3),0 0 24px rgba(176,112,255,.72); }
@@ -158,3 +158,8 @@ body {
 @keyframes introZoom { to { transform:scale(1) translateY(0); opacity:1; } }
 @keyframes introSheen { 0%{transform:translateX(-30%);opacity:.2;}45%{transform:translateX(2%);opacity:.75;}100%{transform:translateX(30%);opacity:.2;} }
 @keyframes subtitleIn { to { opacity:1; transform:translateY(0); } }
+
+@keyframes introAutoHide {
+  0%, 82% { opacity: 1; visibility: visible; pointer-events: auto; }
+  100% { opacity: 0; visibility: hidden; pointer-events: none; }
+}

--- a/style.css
+++ b/style.css
@@ -1,24 +1,18 @@
 :root {
   --night: #080b18;
-  --night-soft: #121833;
   --glow-purple: #8d45ff;
-  --glow-hot: #b57dff;
   --text: #f7f6ff;
   --soft-border: rgba(141, 69, 255, 0.32);
 }
-
 * { box-sizing: border-box; }
-
 body {
   margin: 0;
   font-family: Inter, Arial, sans-serif;
   color: var(--text);
-  background: radial-gradient(circle at top, #2a1454 0%, var(--night) 48%, #05070f 100%);
+  background: radial-gradient(circle at top, #2a1454 0%, #0b1130 45%, #05070f 100%);
   min-height: 100vh;
   transition: box-shadow 0.4s ease;
 }
-
-.app-shell { min-height: 100vh; }
 .hidden { display: none !important; }
 
 .topbar {
@@ -34,16 +28,15 @@ body {
   z-index: 10;
   backdrop-filter: blur(6px);
 }
-
 .tab { background: #1d2140; border: 1px solid #31386d; color: #ded4ff; border-radius: 10px; padding: 8px 14px; }
-.tab.active { box-shadow: 0 0 14px rgba(141, 69, 255, 0.35); }
 
 .browser-controls button,
 .search-box button,
 .stacked-form button,
 #sendBtn,
 .agent-menu button,
-.close-panel {
+.close-panel,
+.result-actions button {
   border: 1px solid #5a3fa0;
   background: #1c2146;
   color: var(--text);
@@ -55,7 +48,6 @@ body {
 #adresCubugu,
 .search-box input,
 .stacked-form input,
-.stacked-form textarea,
 #aiSoru {
   width: 100%;
   background: #0f1431;
@@ -67,60 +59,60 @@ body {
 
 .baluk-mini {
   border: 1px solid #8f4bff;
-  background: linear-gradient(135deg, #301460, #5e22bf);
+  background: linear-gradient(135deg, #311062, #6e2ee2);
   color: #fff;
   font-weight: 700;
   border-radius: 12px;
   padding: 10px 14px;
-  cursor: pointer;
-  box-shadow: 0 0 14px rgba(141, 69, 255, 0.6), inset 0 0 8px rgba(255,255,255,0.15);
+  box-shadow: 0 0 20px rgba(141, 69, 255, 0.7), inset 0 0 8px rgba(255,255,255,0.2);
 }
 
 .content-grid {
   display: grid;
-  grid-template-columns: 1fr 340px;
+  grid-template-columns: 1fr;
   min-height: calc(100vh - 69px);
+  transition: grid-template-columns .35s ease;
 }
+.content-grid.with-panel { grid-template-columns: 1fr 350px; }
 
 .search-screen,
-.web-screen {
-  padding: 40px 20px;
-}
-
+.web-screen { padding: 38px 20px; }
 .search-screen h1 {
   text-align: center;
   margin-top: 60px;
   font-size: clamp(2rem, 6vw, 3.8rem);
-  letter-spacing: 1px;
   color: #e1d1ff;
   text-shadow: 0 0 10px rgba(141, 69, 255, 0.8), 0 0 24px rgba(141, 69, 255, 0.6);
 }
 
 .search-box {
-  max-width: 700px;
+  max-width: 760px;
   margin: 16px auto 24px;
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 10px;
 }
-
 .results {
-  max-width: 900px;
+  max-width: 920px;
   margin: 0 auto;
   display: grid;
-  gap: 12px;
+  gap: 14px;
 }
-
 .result-item {
-  background: rgba(12, 16, 33, 0.92);
+  background: linear-gradient(180deg, rgba(19, 23, 49, 0.92), rgba(11, 15, 33, 0.92));
   border: 1px solid var(--soft-border);
-  border-radius: 14px;
+  border-radius: 16px;
   padding: 14px;
 }
-
-.result-item h3 { margin: 0 0 8px; }
-.result-item p { margin: 0; color: #cfc8e9; }
-.result-item a { color: #cab7ff; text-decoration: none; }
+.result-item h3 { margin: 0 0 6px; }
+.result-item p { margin: 0 0 10px; color: #d5ceee; }
+.result-item a { color: #d9c6ff; text-decoration: none; }
+.result-actions { display: flex; gap: 8px; }
+.result-actions button:last-child {
+  background: linear-gradient(135deg, #3d1678, #6d2de2);
+  border-color: #a77eff;
+  box-shadow: 0 0 12px rgba(141,69,255,.45);
+}
 
 #siteFrame {
   width: 100%;
@@ -132,19 +124,15 @@ body {
 
 .ai-panel {
   border-left: 1px solid var(--soft-border);
-  background: linear-gradient(180deg, rgba(14, 16, 38, 0.98), rgba(8, 10, 21, 0.96));
+  background: linear-gradient(180deg, rgba(14, 16, 38, 0.99), rgba(8, 10, 21, 0.98));
   padding: 14px;
+  height: calc(100vh - 69px);
   display: flex;
   flex-direction: column;
-  height: calc(100vh - 69px);
 }
-
-.panel-head {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 8px;
-}
+.panel-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; }
+.logo-head { display: flex; align-items: center; gap: 8px; }
+.baluk-logo-head { width: 42px; height: 18px; object-fit: contain; filter: brightness(2.2) contrast(0.7); }
 
 .profile-card {
   display: flex;
@@ -155,39 +143,22 @@ body {
   padding: 10px;
   background: rgba(141, 69, 255, 0.1);
 }
-
 #profileAvatar {
-  width: 52px;
-  height: 52px;
-  border-radius: 50%;
-  object-fit: cover;
-  border: 2px solid rgba(255,255,255,0.35);
-  background: #1e254e;
+  width: 52px; height: 52px; border-radius: 50%; object-fit: cover;
+  border: 2px solid rgba(255,255,255,0.35); background: #1e254e;
 }
+#profileMail { margin: 2px 0 0; color: #cab9ff; font-size: .85rem; }
 
-#profileMail {
-  margin: 2px 0 0;
-  color: #cab9ff;
-  font-size: 0.85rem;
-}
-
-.assistant-layout {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
+.assistant-layout { height: 100%; display: flex; flex-direction: column; gap: 12px; }
 .ai-answer {
   flex: 1;
   overflow: auto;
-  background: rgba(15, 20, 43, 0.7);
+  background: rgba(15, 20, 43, 0.72);
   border: 1px solid rgba(141,69,255,0.25);
   border-radius: 12px;
   padding: 12px;
   line-height: 1.5;
 }
-
 .thinking-box {
   display: flex;
   align-items: center;
@@ -198,49 +169,20 @@ body {
   background: rgba(141, 69, 255, 0.12);
   box-shadow: 0 0 16px rgba(141, 69, 255, 0.35);
 }
-
-.spin-logo {
-  width: 34px;
-  height: 34px;
-  border-radius: 50%;
-  display: grid;
-  place-items: center;
-  font-weight: 800;
-  background: linear-gradient(135deg, #5920b4, #b87cff);
-  box-shadow: 0 0 12px rgba(141, 69, 255, 0.8);
-}
-
-.spin-logo.active { animation: spin 1.1s linear infinite; }
-
-#thinkingText {
-  margin: 0;
-  position: relative;
-  color: #efe6ff;
-  font-weight: 600;
-}
-
+.spin-logo { width: 42px; height: 42px; object-fit: contain; filter: invert(1) brightness(1.8); }
+.spin-logo.active { animation: spin 1.2s linear infinite; }
+#thinkingText { margin: 0; position: relative; font-weight: 600; }
 #thinkingText::after {
   content: "";
   position: absolute;
   inset: 0;
   background: linear-gradient(120deg, transparent 0%, rgba(255,255,255,.55) 50%, transparent 100%);
   transform: translateX(-130%);
-  animation: shimmer 1.3s infinite;
+  animation: shimmer 1.4s infinite;
 }
 
-.ask-bar {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 8px;
-  align-items: center;
-}
-
-#aiSoru {
-  min-height: 42px;
-  max-height: 90px;
-  resize: vertical;
-}
-
+.ask-bar { display: grid; grid-template-columns: auto 1fr auto; gap: 8px; align-items: center; }
+#aiSoru { min-height: 42px; max-height: 90px; resize: vertical; }
 .plus-btn {
   border-radius: 10px;
   border: 1px solid #7045d8;
@@ -249,25 +191,20 @@ body {
   width: 40px;
   height: 40px;
   font-size: 1.25rem;
-  cursor: pointer;
 }
-
 .agent-menu {
   border: 1px solid var(--soft-border);
   border-radius: 10px;
   padding: 10px;
   background: rgba(17, 22, 45, 0.95);
 }
-
-.web-glow {
-  box-shadow: inset 0 0 110px rgba(141,69,255,0.5), inset 0 0 200px rgba(72,100,255,0.25);
-}
+.web-glow { box-shadow: inset 0 0 110px rgba(141,69,255,0.48), inset 0 0 200px rgba(72,100,255,0.22); }
 
 @keyframes spin { to { transform: rotate(360deg);} }
 @keyframes shimmer { to { transform: translateX(130%);} }
 
 @media (max-width: 980px) {
   .topbar { grid-template-columns: 1fr; }
-  .content-grid { grid-template-columns: 1fr; }
+  .content-grid, .content-grid.with-panel { grid-template-columns: 1fr; }
   .ai-panel { border-left: none; border-top: 1px solid var(--soft-border); height: auto; }
 }

--- a/style.css
+++ b/style.css
@@ -11,24 +11,40 @@ body {
   color: var(--text);
   background: radial-gradient(circle at top, #2a1454 0%, #0b1130 45%, #05070f 100%);
   min-height: 100vh;
-  transition: box-shadow 0.4s ease;
+  transition: box-shadow .4s ease;
 }
 .hidden { display: none !important; }
 
 .topbar {
   display: grid;
-  grid-template-columns: auto auto 1fr auto;
+  grid-template-columns: 1fr auto 1fr auto;
   gap: 10px;
   align-items: center;
-  padding: 10px 14px;
-  background: rgba(8, 11, 24, 0.88);
+  padding: 8px 12px;
+  background: rgba(8, 11, 24, 0.9);
   border-bottom: 1px solid var(--soft-border);
   position: sticky;
   top: 0;
-  z-index: 10;
-  backdrop-filter: blur(6px);
+  z-index: 20;
 }
-.tab { background: #1d2140; border: 1px solid #31386d; color: #ded4ff; border-radius: 10px; padding: 8px 14px; }
+
+.tab-strip { display: flex; align-items: center; gap: 8px; min-width: 260px; }
+.tabs { display: flex; gap: 6px; overflow: auto; max-width: 52vw; }
+.tab-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  min-width: 150px;
+  border-radius: 10px 10px 0 0;
+  border: 1px solid #36406c;
+  background: #202a43;
+  color: #d7dcff;
+  cursor: pointer;
+}
+.tab-item.active { background: #2a3753; border-color: #5870a8; }
+.tab-close { border: none; background: transparent; color: #d7dcff; cursor: pointer; }
+.tab-plus { border: 1px solid #5a3fa0; background: #1c2146; color: #fff; border-radius: 8px; padding: 6px 9px; }
 
 .browser-controls button,
 .search-box button,
@@ -36,11 +52,13 @@ body {
 #sendBtn,
 .agent-menu button,
 .close-panel,
-.result-actions button {
+.result-actions button,
+.quick-prompts button,
+.agent-badge button {
   border: 1px solid #5a3fa0;
   background: #1c2146;
   color: var(--text);
-  border-radius: 10px;
+  border-radius: 8px;
   padding: 8px 12px;
   cursor: pointer;
 }
@@ -53,7 +71,7 @@ body {
   background: #0f1431;
   color: var(--text);
   border: 1px solid #3f4678;
-  border-radius: 10px;
+  border-radius: 8px;
   padding: 10px;
 }
 
@@ -62,227 +80,84 @@ body {
   background: linear-gradient(135deg, #311062, #6e2ee2);
   color: #fff;
   font-weight: 700;
-  border-radius: 12px;
+  border-radius: 10px;
   padding: 10px 14px;
   box-shadow: 0 0 20px rgba(141, 69, 255, 0.7), inset 0 0 8px rgba(255,255,255,0.2);
 }
 
-.content-grid {
-  display: grid;
-  grid-template-columns: 1fr;
-  min-height: calc(100vh - 69px);
-  transition: grid-template-columns .35s ease;
-}
-.content-grid.with-panel { grid-template-columns: 1fr 350px; }
+.content-grid { display: grid; grid-template-columns: 1fr; min-height: calc(100vh - 63px); transition: grid-template-columns .35s ease; }
+.content-grid.with-panel { grid-template-columns: 1fr 420px; }
 
-.search-screen,
-.web-screen { padding: 38px 20px; }
-.search-screen h1 {
-  text-align: center;
-  margin-top: 60px;
-  font-size: clamp(2rem, 6vw, 3.8rem);
-  color: #e1d1ff;
-  text-shadow: 0 0 10px rgba(141, 69, 255, 0.8), 0 0 24px rgba(141, 69, 255, 0.6);
-}
+.search-screen,.web-screen { padding: 30px 20px; }
+.search-screen h1 { text-align: center; margin-top: 50px; font-size: clamp(2rem,6vw,3.8rem); color:#e1d1ff; text-shadow:0 0 10px rgba(141,69,255,.8),0 0 24px rgba(141,69,255,.6); }
+.search-box { max-width: 760px; margin: 16px auto 24px; display:grid; grid-template-columns:1fr auto; gap:10px; }
+.results { max-width: 920px; margin: 0 auto; display: grid; gap: 14px; }
+.result-item { background: linear-gradient(180deg, rgba(19,23,49,.92), rgba(11,15,33,.92)); border:1px solid var(--soft-border); border-radius: 12px; padding:14px; }
+.result-item h3 { margin:0 0 6px; }
+.result-item p { margin:0 0 10px; color:#d5ceee; }
+.result-item a { color:#d9c6ff; text-decoration:none; }
+.result-actions { display:flex; gap:8px; flex-wrap: wrap; }
+.result-actions button:last-child { background: linear-gradient(135deg,#3d1678,#6d2de2); }
+.searching-status { color: #9d9d9d; position: relative; display: inline-block; }
+.searching-status::after { content:""; position:absolute; inset:0; background:linear-gradient(100deg, transparent, rgba(172,117,255,.55), transparent); transform:translateX(-130%); animation: shimmer 1.6s infinite; }
 
-.search-box {
-  max-width: 760px;
-  margin: 16px auto 24px;
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 10px;
-}
-.results {
-  max-width: 920px;
-  margin: 0 auto;
-  display: grid;
-  gap: 14px;
-}
-.result-item {
-  background: linear-gradient(180deg, rgba(19, 23, 49, 0.92), rgba(11, 15, 33, 0.92));
-  border: 1px solid var(--soft-border);
-  border-radius: 16px;
-  padding: 14px;
-}
-.result-item h3 { margin: 0 0 6px; }
-.result-item p { margin: 0 0 10px; color: #d5ceee; }
-.result-item a { color: #d9c6ff; text-decoration: none; }
-.result-actions { display: flex; gap: 8px; }
-.result-actions button:last-child {
-  background: linear-gradient(135deg, #3d1678, #6d2de2);
-  border-color: #a77eff;
-  box-shadow: 0 0 12px rgba(141,69,255,.45);
-}
-
-#siteFrame {
-  width: 100%;
-  height: calc(100vh - 150px);
-  border: 1px solid rgba(141, 69, 255, 0.42);
-  border-radius: 14px;
-  background: white;
-}
+#siteFrame { width:100%; height: calc(100vh - 145px); border:1px solid rgba(141,69,255,.42); border-radius: 10px; background:white; }
 
 .ai-panel {
   border-left: 1px solid var(--soft-border);
-  background: linear-gradient(180deg, rgba(14, 16, 38, 0.99), rgba(8, 10, 21, 0.98));
+  background: linear-gradient(180deg, rgba(16, 18, 44, .99), rgba(9, 11, 26, .98));
+  box-shadow: -6px 0 28px rgba(141,69,255,.18);
   padding: 14px;
-  height: calc(100vh - 69px);
-  display: flex;
+  height: calc(100vh - 63px);
+  display:flex;
   flex-direction: column;
 }
-.panel-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; }
-.logo-head { display: flex; align-items: center; gap: 8px; }
-.baluk-logo-head { width: 42px; height: 18px; object-fit: contain; filter: brightness(2.2) contrast(0.7); }
+.panel-head { display:flex; justify-content:space-between; align-items:center; margin-bottom:10px; }
+.logo-head { display:flex; align-items:center; gap:8px; }
+.baluk-logo-head { width:42px; height:18px; filter: brightness(2.2) contrast(.7); }
+.profile-card { display:flex; align-items:center; gap:10px; border:1px solid var(--soft-border); border-radius:10px; padding:10px; background:rgba(141,69,255,.1); }
+#profileAvatar { width:48px; height:48px; border-radius:50%; object-fit:cover; border:2px solid rgba(255,255,255,.35); }
+#profileMail { margin:2px 0 0; color:#cab9ff; font-size:.85rem; }
+.assistant-layout { height:100%; display:flex; flex-direction:column; gap:10px; }
+.quick-prompts { display:flex; flex-wrap:wrap; gap:8px; }
+.quick-prompts button { background:#222a54; font-size:.82rem; }
 
-.profile-card {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  border: 1px solid var(--soft-border);
-  border-radius: 12px;
-  padding: 10px;
-  background: rgba(141, 69, 255, 0.1);
-}
-#profileAvatar {
-  width: 52px; height: 52px; border-radius: 50%; object-fit: cover;
-  border: 2px solid rgba(255,255,255,0.35); background: #1e254e;
-}
-#profileMail { margin: 2px 0 0; color: #cab9ff; font-size: .85rem; }
-
-.assistant-layout { height: 100%; display: flex; flex-direction: column; gap: 12px; }
-.ai-answer {
-  flex: 1;
-  overflow: auto;
-  background: rgba(15, 20, 43, 0.72);
-  border: 1px solid rgba(141,69,255,0.25);
-  border-radius: 12px;
-  padding: 12px;
-  line-height: 1.5;
-}
-.thinking-box {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  border: 1px solid rgba(141, 69, 255, 0.6);
-  border-radius: 12px;
-  padding: 10px;
-  background: rgba(141, 69, 255, 0.12);
-  box-shadow: 0 0 16px rgba(141, 69, 255, 0.35);
-}
-.spin-logo { width: 42px; height: 42px; object-fit: contain; filter: invert(1) brightness(1.8); }
+.ai-answer { flex:1; overflow:auto; background:rgba(15,20,43,.72); border:1px solid rgba(141,69,255,.25); border-radius:8px; padding:12px; line-height:1.55; }
+.ai-answer .hl { text-decoration: underline 3px #b171ff; font-weight: 700; }
+.thinking-box { display:flex; align-items:center; gap:10px; border:1px solid rgba(141,69,255,.6); border-radius:10px; padding:10px; background:rgba(141,69,255,.12); }
+.spin-logo { width:40px; height:40px; object-fit:contain; filter:invert(1) brightness(1.8); }
 .spin-logo.active { animation: spin 1.2s linear infinite; }
-#thinkingText { margin: 0; position: relative; font-weight: 600; }
-#thinkingText::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(120deg, transparent 0%, rgba(255,255,255,.55) 50%, transparent 100%);
-  transform: translateX(-130%);
-  animation: shimmer 1.4s infinite;
-}
+#thinkingText { margin:0; color:#ddd; position:relative; }
+#thinkingText::after { content:""; position:absolute; inset:0; background:linear-gradient(120deg, transparent, rgba(172,117,255,.52), transparent); transform:translateX(-120%); animation: shimmer 1.4s infinite; }
 
-.ask-bar { display: grid; grid-template-columns: auto 1fr auto; gap: 8px; align-items: center; }
-#aiSoru { min-height: 42px; max-height: 90px; resize: vertical; }
-.plus-btn {
-  border-radius: 10px;
-  border: 1px solid #7045d8;
-  background: #1a1f43;
-  color: #fff;
-  width: 40px;
-  height: 40px;
-  font-size: 1.25rem;
-}
-.agent-menu {
-  border: 1px solid var(--soft-border);
-  border-radius: 10px;
-  padding: 10px;
-  background: rgba(17, 22, 45, 0.95);
-}
-.web-glow { box-shadow: inset 0 0 110px rgba(141,69,255,0.48), inset 0 0 200px rgba(72,100,255,0.22); }
+.agent-badge { display:flex; align-items:center; justify-content:space-between; gap:8px; border:1px solid rgba(141,69,255,.65); background:rgba(72,42,130,.35); padding:8px 10px; border-radius: 8px; }
+.selected-targets { display:flex; flex-wrap: wrap; gap:8px; }
+.target-chip { display:inline-flex; gap:8px; align-items:center; padding:6px 8px; border:1px solid rgba(141,69,255,.55); background:#21163f; border-radius: 999px; font-size: .8rem; }
+.target-chip button { padding:0; width:18px; height:18px; border-radius:50%; }
+
+.ask-bar { display:grid; grid-template-columns:auto 1fr auto; gap:8px; align-items:center; }
+#aiSoru { min-height:40px; max-height:90px; resize:vertical; }
+.plus-btn { border:1px solid #7045d8; background:#1a1f43; color:#fff; width:40px; height:40px; font-size:1.25rem; border-radius:8px; }
+.agent-menu { border:1px solid var(--soft-border); border-radius:8px; padding:10px; background:rgba(17,22,45,.95); }
+.web-glow { box-shadow: inset 0 0 110px rgba(141,69,255,.48), inset 0 0 200px rgba(72,100,255,.22); }
 
 @keyframes spin { to { transform: rotate(360deg);} }
 @keyframes shimmer { to { transform: translateX(130%);} }
 
-@media (max-width: 980px) {
+@media (max-width: 1100px) {
   .topbar { grid-template-columns: 1fr; }
+  .tabs { max-width: 100%; }
   .content-grid, .content-grid.with-panel { grid-template-columns: 1fr; }
-  .ai-panel { border-left: none; border-top: 1px solid var(--soft-border); height: auto; }
+  .ai-panel { border-left:none; border-top:1px solid var(--soft-border); height:auto; min-height: 60vh; }
 }
 
-.app-hidden {
-  opacity: 0;
-  pointer-events: none;
-}
-
-.intro-overlay {
-  position: fixed;
-  inset: 0;
-  z-index: 12000;
-  display: grid;
-  place-content: center;
-  gap: 18px;
-  background: radial-gradient(circle at center, rgba(95, 41, 182, 0.42) 0%, rgba(6, 8, 17, 0.96) 62%, #03040a 100%);
-  transition: opacity .7s ease, visibility .7s ease;
-}
-
-.intro-overlay.hidden {
-  opacity: 0;
-  visibility: hidden;
-}
-
-.intro-card {
-  position: relative;
-  min-width: min(860px, 92vw);
-  padding: clamp(18px, 3vw, 30px) clamp(24px, 5vw, 60px);
-  border-radius: 999px;
-  border: 2px solid rgba(180, 140, 255, 0.92);
-  background: linear-gradient(140deg, rgba(90, 37, 176, .95), rgba(23, 20, 72, .94) 56%, rgba(10, 16, 58, .95));
-  box-shadow: 0 0 26px rgba(141,69,255,.9), inset 0 0 22px rgba(236,226,255,.2), 0 0 70px rgba(89, 18, 180, 0.65);
-  transform: scale(.58) translateY(24px);
-  opacity: 0;
-  animation: introZoom .9s cubic-bezier(.15,.8,.22,1) forwards;
-}
-
-.intro-title {
-  position: relative;
-  text-align: center;
-  font-size: clamp(2rem, 5.5vw, 5rem);
-  letter-spacing: .8px;
-  font-weight: 800;
-  color: #eddcff;
-  text-shadow: 0 0 10px rgba(255,255,255,.3), 0 0 24px rgba(176,112,255,.72);
-}
-
-.intro-glow {
-  position: absolute;
-  inset: 4px;
-  border-radius: 999px;
-  pointer-events: none;
-  background: linear-gradient(110deg, rgba(255,255,255,.1), transparent 35%, rgba(255,255,255,.22) 50%, transparent 66%, rgba(255,255,255,.08));
-  filter: blur(1px);
-  animation: introSheen 1.8s ease-in-out .25s 2;
-}
-
-.intro-subtitle {
-  margin: 0;
-  text-align: center;
-  color: #d8c0ff;
-  font-size: clamp(1rem, 2vw, 1.45rem);
-  opacity: 0;
-  transform: translateY(12px);
-  animation: subtitleIn .75s ease .75s forwards;
-}
-
-@keyframes introZoom {
-  to { transform: scale(1) translateY(0); opacity: 1; }
-}
-
-@keyframes introSheen {
-  0% { transform: translateX(-30%); opacity: .2; }
-  45% { transform: translateX(2%); opacity: .75; }
-  100% { transform: translateX(30%); opacity: .2; }
-}
-
-@keyframes subtitleIn {
-  to { opacity: 1; transform: translateY(0); }
-}
+.app-hidden { opacity:0; pointer-events:none; }
+.intro-overlay { position:fixed; inset:0; z-index:12000; display:grid; place-content:center; gap:18px; background: radial-gradient(circle at center, rgba(95,41,182,.42) 0%, rgba(6,8,17,.96) 62%, #03040a 100%); transition:opacity .7s ease, visibility .7s ease; }
+.intro-overlay.hidden { opacity:0; visibility:hidden; }
+.intro-card { position:relative; min-width:min(860px,92vw); padding:clamp(18px,3vw,30px) clamp(24px,5vw,60px); border-radius:999px; border:2px solid rgba(180,140,255,.92); background:linear-gradient(140deg, rgba(90,37,176,.95), rgba(23,20,72,.94) 56%, rgba(10,16,58,.95)); box-shadow:0 0 26px rgba(141,69,255,.9), inset 0 0 22px rgba(236,226,255,.2), 0 0 70px rgba(89,18,180,.65); transform:scale(.58) translateY(24px); opacity:0; animation:introZoom .9s cubic-bezier(.15,.8,.22,1) forwards; }
+.intro-title { text-align:center; font-size:clamp(2rem,5.5vw,5rem); font-weight:800; color:#eddcff; text-shadow:0 0 10px rgba(255,255,255,.3),0 0 24px rgba(176,112,255,.72); }
+.intro-glow { position:absolute; inset:4px; border-radius:999px; pointer-events:none; background:linear-gradient(110deg, rgba(255,255,255,.1), transparent 35%, rgba(255,255,255,.22) 50%, transparent 66%, rgba(255,255,255,.08)); animation:introSheen 1.8s ease-in-out .25s 2; }
+.intro-subtitle { margin:0; text-align:center; color:#d8c0ff; font-size:clamp(1rem,2vw,1.45rem); opacity:0; transform:translateY(12px); animation:subtitleIn .75s ease .75s forwards; }
+@keyframes introZoom { to { transform:scale(1) translateY(0); opacity:1; } }
+@keyframes introSheen { 0%{transform:translateX(-30%);opacity:.2;}45%{transform:translateX(2%);opacity:.75;}100%{transform:translateX(30%);opacity:.2;} }
+@keyframes subtitleIn { to { opacity:1; transform:translateY(0); } }

--- a/style.css
+++ b/style.css
@@ -102,9 +102,6 @@ body {
 .searching-status::after { content:""; position:absolute; inset:0; background:linear-gradient(100deg, transparent, rgba(172,117,255,.55), transparent); transform:translateX(-130%); animation: shimmer 1.6s infinite; }
 
 #siteFrame { width:100%; height: calc(100vh - 145px); border:1px solid rgba(141,69,255,.42); border-radius: 10px; background:white; }
-
-.ai-panel {
-  border-left: 1px solid var(--soft-border);
   background: linear-gradient(180deg, rgba(16, 18, 44, .99), rgba(9, 11, 26, .98));
   box-shadow: -6px 0 28px rgba(141,69,255,.18);
   padding: 14px;
@@ -133,22 +130,7 @@ body {
 .agent-badge { display:flex; align-items:center; justify-content:space-between; gap:8px; border:1px solid rgba(141,69,255,.65); background:rgba(72,42,130,.35); padding:8px 10px; border-radius: 8px; }
 
 .agent-badge-actions { display:flex; gap:6px; }
-#markToggleBtn {
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  border-radius: 6px;
-  border: 1px solid rgba(141,69,255,.75);
-  background: #251746;
-}
-#markToggleBtn.active {
-  background: linear-gradient(135deg,#5f2dd8,#8b56ff);
-  box-shadow: 0 0 12px rgba(141,69,255,.7);
-}
 
-.selected-targets { display:flex; flex-wrap: wrap; gap:8px; }
-.target-chip { display:inline-flex; gap:8px; align-items:center; padding:6px 8px; border:1px solid rgba(141,69,255,.55); background:#21163f; border-radius: 999px; font-size: .8rem; }
-.target-chip button { padding:0; width:18px; height:18px; border-radius:50%; }
 
 .ask-bar { display:grid; grid-template-columns:auto 1fr auto; gap:8px; align-items:center; }
 #aiSoru { min-height:40px; max-height:90px; resize:vertical; }

--- a/style.css
+++ b/style.css
@@ -131,6 +131,21 @@ body {
 #thinkingText::after { content:""; position:absolute; inset:0; background:linear-gradient(120deg, transparent, rgba(172,117,255,.52), transparent); transform:translateX(-120%); animation: shimmer 1.4s infinite; }
 
 .agent-badge { display:flex; align-items:center; justify-content:space-between; gap:8px; border:1px solid rgba(141,69,255,.65); background:rgba(72,42,130,.35); padding:8px 10px; border-radius: 8px; }
+
+.agent-badge-actions { display:flex; gap:6px; }
+#markToggleBtn {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 6px;
+  border: 1px solid rgba(141,69,255,.75);
+  background: #251746;
+}
+#markToggleBtn.active {
+  background: linear-gradient(135deg,#5f2dd8,#8b56ff);
+  box-shadow: 0 0 12px rgba(141,69,255,.7);
+}
+
 .selected-targets { display:flex; flex-wrap: wrap; gap:8px; }
 .target-chip { display:inline-flex; gap:8px; align-items:center; padding:6px 8px; border:1px solid rgba(141,69,255,.55); background:#21163f; border-radius: 999px; font-size: .8rem; }
 .target-chip button { padding:0; width:18px; height:18px; border-radius:50%; }

--- a/style.css
+++ b/style.css
@@ -1,9 +1,10 @@
 :root {
   --night: #080b18;
-  --night-soft: #111735;
+  --night-soft: #121833;
   --glow-purple: #8d45ff;
-  --glow-purple-soft: rgba(141, 69, 255, 0.2);
+  --glow-hot: #b57dff;
   --text: #f7f6ff;
+  --soft-border: rgba(141, 69, 255, 0.32);
 }
 
 * { box-sizing: border-box; }
@@ -12,11 +13,13 @@ body {
   margin: 0;
   font-family: Inter, Arial, sans-serif;
   color: var(--text);
-  background: radial-gradient(circle at top, #241146 0%, var(--night) 45%, #05070f 100%);
+  background: radial-gradient(circle at top, #2a1454 0%, var(--night) 48%, #05070f 100%);
   min-height: 100vh;
+  transition: box-shadow 0.4s ease;
 }
 
 .app-shell { min-height: 100vh; }
+.hidden { display: none !important; }
 
 .topbar {
   display: grid;
@@ -24,8 +27,8 @@ body {
   gap: 10px;
   align-items: center;
   padding: 10px 14px;
-  background: rgba(8, 11, 24, 0.86);
-  border-bottom: 1px solid rgba(141, 69, 255, 0.28);
+  background: rgba(8, 11, 24, 0.88);
+  border-bottom: 1px solid var(--soft-border);
   position: sticky;
   top: 0;
   z-index: 10;
@@ -33,13 +36,15 @@ body {
 }
 
 .tab { background: #1d2140; border: 1px solid #31386d; color: #ded4ff; border-radius: 10px; padding: 8px 14px; }
-.tab.active { box-shadow: 0 0 14px var(--glow-purple-soft); }
+.tab.active { box-shadow: 0 0 14px rgba(141, 69, 255, 0.35); }
 
 .browser-controls button,
-.baluk-mini,
 .search-box button,
-.stacked-form button {
-  border: 1px solid #4f3b8a;
+.stacked-form button,
+#sendBtn,
+.agent-menu button,
+.close-panel {
+  border: 1px solid #5a3fa0;
   background: #1c2146;
   color: var(--text);
   border-radius: 10px;
@@ -50,7 +55,8 @@ body {
 #adresCubugu,
 .search-box input,
 .stacked-form input,
-.stacked-form textarea {
+.stacked-form textarea,
+#aiSoru {
   width: 100%;
   background: #0f1431;
   color: var(--text);
@@ -59,9 +65,20 @@ body {
   padding: 10px;
 }
 
+.baluk-mini {
+  border: 1px solid #8f4bff;
+  background: linear-gradient(135deg, #301460, #5e22bf);
+  color: #fff;
+  font-weight: 700;
+  border-radius: 12px;
+  padding: 10px 14px;
+  cursor: pointer;
+  box-shadow: 0 0 14px rgba(141, 69, 255, 0.6), inset 0 0 8px rgba(255,255,255,0.15);
+}
+
 .content-grid {
   display: grid;
-  grid-template-columns: 1fr 320px;
+  grid-template-columns: 1fr 340px;
   min-height: calc(100vh - 69px);
 }
 
@@ -73,10 +90,10 @@ body {
 .search-screen h1 {
   text-align: center;
   margin-top: 60px;
-  font-size: clamp(2rem, 6vw, 3.7rem);
+  font-size: clamp(2rem, 6vw, 3.8rem);
   letter-spacing: 1px;
-  color: #d8c5ff;
-  text-shadow: 0 0 10px rgba(141, 69, 255, 0.8), 0 0 30px rgba(141, 69, 255, 0.55);
+  color: #e1d1ff;
+  text-shadow: 0 0 10px rgba(141, 69, 255, 0.8), 0 0 24px rgba(141, 69, 255, 0.6);
 }
 
 .search-box {
@@ -95,8 +112,8 @@ body {
 }
 
 .result-item {
-  background: rgba(12, 16, 33, 0.9);
-  border: 1px solid rgba(141, 69, 255, 0.32);
+  background: rgba(12, 16, 33, 0.92);
+  border: 1px solid var(--soft-border);
   border-radius: 14px;
   padding: 14px;
 }
@@ -108,38 +125,149 @@ body {
 #siteFrame {
   width: 100%;
   height: calc(100vh - 150px);
-  border: 1px solid rgba(141, 69, 255, 0.4);
+  border: 1px solid rgba(141, 69, 255, 0.42);
   border-radius: 14px;
   background: white;
 }
 
 .ai-panel {
-  border-left: 1px solid rgba(141, 69, 255, 0.32);
-  background: linear-gradient(180deg, rgba(12, 15, 31, 0.95), rgba(7, 10, 18, 0.95));
-  padding: 18px;
+  border-left: 1px solid var(--soft-border);
+  background: linear-gradient(180deg, rgba(14, 16, 38, 0.98), rgba(8, 10, 21, 0.96));
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 69px);
 }
 
-.stacked-form { display: grid; gap: 10px; }
-.thinking {
-  margin-top: 10px;
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.profile-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid var(--soft-border);
+  border-radius: 12px;
   padding: 10px;
-  border-radius: 10px;
-  background: rgba(141, 69, 255, 0.12);
+  background: rgba(141, 69, 255, 0.1);
+}
+
+#profileAvatar {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid rgba(255,255,255,0.35);
+  background: #1e254e;
+}
+
+#profileMail {
+  margin: 2px 0 0;
+  color: #cab9ff;
+  font-size: 0.85rem;
+}
+
+.assistant-layout {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ai-answer {
+  flex: 1;
+  overflow: auto;
+  background: rgba(15, 20, 43, 0.7);
+  border: 1px solid rgba(141,69,255,0.25);
+  border-radius: 12px;
+  padding: 12px;
+  line-height: 1.5;
+}
+
+.thinking-box {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   border: 1px solid rgba(141, 69, 255, 0.6);
-  box-shadow: 0 0 16px rgba(141, 69, 255, 0.55);
-  animation: pulse 1.2s infinite alternate;
+  border-radius: 12px;
+  padding: 10px;
+  background: rgba(141, 69, 255, 0.12);
+  box-shadow: 0 0 16px rgba(141, 69, 255, 0.35);
 }
 
-.ai-answer { margin-top: 12px; line-height: 1.5; color: #e9e0ff; }
-.hidden { display: none; }
-
-@keyframes pulse {
-  from { opacity: 0.5; }
-  to { opacity: 1; }
+.spin-logo {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  font-weight: 800;
+  background: linear-gradient(135deg, #5920b4, #b87cff);
+  box-shadow: 0 0 12px rgba(141, 69, 255, 0.8);
 }
+
+.spin-logo.active { animation: spin 1.1s linear infinite; }
+
+#thinkingText {
+  margin: 0;
+  position: relative;
+  color: #efe6ff;
+  font-weight: 600;
+}
+
+#thinkingText::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent 0%, rgba(255,255,255,.55) 50%, transparent 100%);
+  transform: translateX(-130%);
+  animation: shimmer 1.3s infinite;
+}
+
+.ask-bar {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+#aiSoru {
+  min-height: 42px;
+  max-height: 90px;
+  resize: vertical;
+}
+
+.plus-btn {
+  border-radius: 10px;
+  border: 1px solid #7045d8;
+  background: #1a1f43;
+  color: #fff;
+  width: 40px;
+  height: 40px;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
+.agent-menu {
+  border: 1px solid var(--soft-border);
+  border-radius: 10px;
+  padding: 10px;
+  background: rgba(17, 22, 45, 0.95);
+}
+
+.web-glow {
+  box-shadow: inset 0 0 110px rgba(141,69,255,0.5), inset 0 0 200px rgba(72,100,255,0.25);
+}
+
+@keyframes spin { to { transform: rotate(360deg);} }
+@keyframes shimmer { to { transform: translateX(130%);} }
 
 @media (max-width: 980px) {
   .topbar { grid-template-columns: 1fr; }
   .content-grid { grid-template-columns: 1fr; }
-  .ai-panel { border-left: none; border-top: 1px solid rgba(141,69,255,.32); }
+  .ai-panel { border-left: none; border-top: 1px solid var(--soft-border); height: auto; }
 }


### PR DESCRIPTION
### Motivation
- Replace the previous MemTube prototype with a lightweight browser-like interface called **Baluk Screatch** that integrates an AI side panel and search-centered UX. 
- Provide a purple/night visual identity and a simple, non-cluttered UI with basic browser controls and an address bar for in-app navigation. 
- Allow users to sign in (email/name/surname/optional profile image) and persist identity in `localStorage` for personalized AI interactions. 
- Offer an AI-side workflow that can analyze the currently opened page and return intent-specific answers after a simulated thinking period.

### Description
- Replaced the app by updating `index.html`, `style.css`, and `script.js` to implement the Baluk Screatch layout with a sticky topbar, address bar, back/forward/refresh/new-tab buttons, and a central search screen and iframe web viewer. 
- Implemented DuckDuckGo-based result fetching and client-side result rendering that opens clicked links inside an in-app iframe via `openUrl` with a simple history stack. 
- Added the toggleable Baluk.ai side panel with a login form (`email`, `ad`, `soyad`, optional profile image) persisted to `localStorage` and an assistant area where users can ask questions; the assistant shows a `20s` simulated thinking state and produces intent-based responses (year/company/purpose/general). 
- Introduced a purple/night theme, glowing branding effects, responsive CSS, and helper utilities like `ensureUrl` and history management stored in a runtime `state` object. 

### Testing
- Verified `script.js` syntax with `node --check script.js` which completed successfully. 
- Launched a local static server via `python3 -m http.server 4173` and validated the app served without errors. 
- Captured a Playwright screenshot of `http://127.0.0.1:4173` to visually verify the UI render, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2edf5b298832ca74a7142ecf54b41)