### PR TITLE
Add Baluk Screatch UI with AI panel, tabbed browser, and styles

### DIFF
--- a/assets/baluk-logo.svg
+++ b/assets/baluk-logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 150" fill="none">
+  <path d="M40 75C92 22 196 16 270 43C314 59 346 83 380 112" stroke="#101114" stroke-width="9" stroke-linecap="round"/>
+  <path d="M40 75C90 126 191 131 281 97" stroke="#101114" stroke-width="9" stroke-linecap="round"/>
+  <path d="M350 70L388 49L375 83L403 111L364 88" stroke="#101114" stroke-width="9" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="86" cy="74" r="6" fill="#101114"/>
+  <path d="M122 58C132 72 132 91 121 103" stroke="#101114" stroke-width="8" stroke-linecap="round"/>
+  <text x="42" y="144" font-family="Arial, sans-serif" font-size="54" fill="#101114">baluk.ai</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -133,9 +133,9 @@
         <div class="advanced-banner">
           <div>
             <strong>Gelişmiş düzenleme</strong>
-            <p>Yazı kutusu ve başlık yerlerini Agent Mode 3.0 ile düzenle.</p>
+            <p>Düzenleme modunu aç, fareyle sürükleyip boyutlandır.</p>
           </div>
-          <button id="advancedEditBtn" type="button">Başlat</button>
+          <button id="advancedEditBtn" type="button">Düzenleme Modu</button>
         </div>
       </aside>
     </main>

--- a/index.html
+++ b/index.html
@@ -2,49 +2,109 @@
 <html lang="tr">
 <head>
   <meta charset="UTF-8">
-  <title>MemTube</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Baluk Screatch</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
-  <!-- Kayıt Ekranı -->
-  <div id="girisEkrani">
-    <h2>MemTube'e Giriş</h2>
-    <input type="text" id="kullaniciAdi" placeholder="Takma Ad (zorunlu)">
-    <input type="file" id="profilResmi" accept="image/*">
-    <button onclick="girisYap()">Giriş Yap</button>
+  <div id="introOverlay" class="intro-overlay">
+    <div class="intro-card" id="introCard">
+      <div class="intro-glow"></div>
+      <div class="intro-title">✦ Baluk Screatch</div>
+    </div>
+    <p class="intro-subtitle" id="introSubtitle">AI destekli tarayıcı</p>
   </div>
 
-  <!-- Ana Ekran -->
-  <div id="anaEkran" class="gizli">
-    <header>
-      <h1>📺 MemTube</h1>
-      <input type="text" id="arama" placeholder="Ara...">
+  <div class="app-shell" id="appShell">
+    <header class="topbar">
+      <div class="tab-strip">
+        <div id="tabs" class="tabs"></div>
+        <button id="addTabBtn" class="tab-plus" title="Sekme aç">＋</button>
+      </div>
+
+      <div class="browser-controls">
+        <button id="geriBtn" title="Geri">◀</button>
+        <button id="ileriBtn" title="İleri">▶</button>
+        <button id="yenileBtn" title="Yenile">↻</button>
+        <button id="newTabBtn" title="Yeni pencere">＋</button>
+      </div>
+      <input id="adresCubugu" type="text" placeholder="Bağlantı aç (https://...)" />
+      <button id="balukPanelBtn" class="baluk-mini">✦ Baluk.ai</button>
     </header>
 
-    <!-- Ana Sayfa -->
-    <main id="anaSayfa">
-      <div id="videoListe" class="video-galeri"></div>
+    <main class="content-grid" id="contentGrid">
+      <section class="search-screen" id="homeView">
+        <h1>Baluk Screatch</h1>
+        <form id="aramaForm" class="search-box">
+          <input id="aramaInput" type="text" placeholder="Web'de ara..." required>
+          <button type="submit">Ara</button>
+        </form>
+        <div id="sonuclar" class="results"></div>
+      </section>
+
+      <section class="web-screen hidden" id="webView">
+        <iframe id="siteFrame" title="Baluk Screatch görüntüleyici"></iframe>
+      </section>
+
+      <aside class="ai-panel hidden" id="aiPanel">
+        <div class="panel-head">
+          <div class="logo-head">
+            <img src="assets/baluk-logo.svg" alt="Baluk.ai logosu" class="baluk-logo-head">
+            <h2>Baluk.ai</h2>
+          </div>
+          <button id="closePanelBtn" class="close-panel">✕</button>
+        </div>
+
+        <div id="authArea">
+          <p>En iyi cevaplar için oturum açın.</p>
+          <form id="loginForm" class="stacked-form">
+            <input type="email" id="mail" placeholder="Gmail / Email" required>
+            <input type="text" id="ad" placeholder="İsim" required>
+            <input type="text" id="soyad" placeholder="Soyisim" required>
+            <label>Profil resmi (isteğe bağlı)</label>
+            <input type="file" id="profil" accept="image/*">
+            <button type="submit">Oturum Aç</button>
+          </form>
+        </div>
+
+        <div id="assistantArea" class="hidden assistant-layout">
+          <div class="profile-card">
+            <img id="profileAvatar" alt="Profil" src="" />
+            <div>
+              <strong id="welcomeText"></strong>
+              <p id="profileMail"></p>
+            </div>
+          </div>
+
+          <div class="quick-prompts" id="quickPrompts"></div>
+
+          <div class="thinking-box hidden" id="thinkingBox">
+            <img src="assets/baluk-logo.svg" alt="Baluk.ai" class="spin-logo" id="spinLogo">
+            <p id="thinkingText">Baluk.ai düşünüyor...</p>
+          </div>
+
+          <div id="aiCevap" class="ai-answer"></div>
+
+          <div class="agent-badge hidden" id="agentBadge">
+            <span>Agent Mode 2.0 açık</span>
+            <div class="agent-badge-actions">
+              <button id="agentBadgeClose" type="button" title="Agent Mode kapat">✕</button>
+            </div>
+          </div>
+
+
+          <form id="aiForm" class="ask-bar">
+            <button type="button" id="plusBtn" class="plus-btn">＋</button>
+            <textarea id="aiSoru" rows="1" placeholder="Baluk.ai'ye yaz..." required></textarea>
+            <button type="submit" id="sendBtn">Gönder</button>
+          </form>
+
+          <div id="agentMenu" class="agent-menu hidden">
+            <button type="button" id="agentModeBtn">Agent Mode 2.0</button>
+          </div>
+        </div>
+      </aside>
     </main>
-
-    <!-- Hesabım Sayfası -->
-    <section id="hesabim" class="gizli">
-      <div id="profil">
-        <img id="profilGorsel" alt="Profil Resmi">
-        <h3 id="kAdi"></h3>
-      </div>
-      <h4>Videolarım</h4>
-      <input type="file" id="videoDosyasi" accept="video/*">
-      <input type="text" id="videoBaslik" placeholder="Video Başlığı">
-      <button onclick="videoYukle()">+ Yükle</button>
-      <div id="videolar" class="video-galeri"></div>
-    </section>
-
-    <!-- Alt Menü -->
-    <nav id="altMenu">
-      <button onclick="goAnaSayfa()">🏠</button>
-      <button onclick="goHesabim()">👤</button>
-    </nav>
   </div>
 
   <script src="script.js"></script>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
         <button id="newTabBtn" title="Yeni pencere">＋</button>
       </div>
       <input id="adresCubugu" type="text" placeholder="Bağlantı aç (https://...)" />
+      <button id="customizeBtn" class="customize-btn" title="Kişiselleştirme">🖌</button>
       <button id="balukPanelBtn" class="baluk-mini">✦ Baluk.ai</button>
     </header>
 
@@ -86,7 +87,7 @@
           <div id="aiCevap" class="ai-answer"></div>
 
           <div class="agent-badge hidden" id="agentBadge">
-            <span>Agent Mode 2.0 açık</span>
+            <span>Agent Mode 3.0 açık <strong class="new-pill">NEW</strong></span>
             <div class="agent-badge-actions">
               <button id="agentBadgeClose" type="button" title="Agent Mode kapat">✕</button>
             </div>
@@ -100,8 +101,41 @@
           </form>
 
           <div id="agentMenu" class="agent-menu hidden">
-            <button type="button" id="agentModeBtn">Agent Mode 2.0</button>
+            <button type="button" id="agentModeBtn">Agent Mode 3.0 <span class="new-pill">NEW</span></button>
+            <button type="button" id="themeModeBtn">Tema/Kişiselleştirme Modu <span class="new-pill">NEW</span></button>
           </div>
+        </div>
+      </aside>
+
+      <aside id="customizePanel" class="customize-panel hidden">
+        <div class="panel-head">
+          <h3>🖌 Kişiselleştirme</h3>
+          <button id="closeCustomizeBtn" class="close-panel" type="button">✕</button>
+        </div>
+        <label>Tema rengi</label>
+        <select id="themeColorSelect"></select>
+        <label>Yazı stili</label>
+        <select id="fontStyleSelect">
+          <option value="Inter, Arial, sans-serif">Modern (Inter)</option>
+          <option value="'Trebuchet MS', Arial, sans-serif">Dengeli</option>
+          <option value="'Poppins', 'Segoe UI', sans-serif">Poppins</option>
+          <option value="'Georgia', serif">Klasik</option>
+        </select>
+        <label>İmleç şekli</label>
+        <select id="cursorShapeSelect">
+          <option value="circle">Daire</option>
+          <option value="square">Kare</option>
+          <option value="diamond">Elmas</option>
+        </select>
+        <label>İmleç boyutu</label>
+        <input type="range" id="cursorSizeRange" min="14" max="42" value="18">
+        <button id="saveCustomizeBtn" type="button">Ayarları Uygula</button>
+        <div class="advanced-banner">
+          <div>
+            <strong>Gelişmiş düzenleme</strong>
+            <p>Yazı kutusu ve başlık yerlerini Agent Mode 3.0 ile düzenle.</p>
+          </div>
+          <button id="advancedEditBtn" type="button">Başlat</button>
         </div>
       </aside>
     </main>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
   <div class="app-shell" id="appShell">
     <header class="topbar">
       <div class="tab-strip">
-        <div id="tabs" class="tabs"></div>
+        <div id="tabs" class="tabs"><button class="tab-item active" aria-hidden="true"><span>Yeni Sekme</span><span class="tab-close">✕</span></button></div>
         <button id="addTabBtn" class="tab-plus" title="Sekme aç">＋</button>
       </div>
 

--- a/script.js
+++ b/script.js
@@ -381,6 +381,12 @@ function isLikelyFrameDeniedHost(url) {
       'facebook.com',
       'tiktok.com',
       'linkedin.com',
+      'google.com',
+      'duckduckgo.com',
+      'bing.com',
+      'search.yahoo.com',
+      'yahoo.com',
+      'shopify.com',
     ].some((h) => host === h || host.endsWith(`.${h}`));
   } catch {
     return false;
@@ -577,18 +583,16 @@ function showHome() {
 function syncTabView() {
   const tab = currentTab();
   if (!tab || !tab.url) return showHome();
+  const viewUrl = getEmbeddableUrl(tab.url);
   el.adresCubugu.value = tab.url;
+  el.siteFrame.srcdoc = '';
+  el.siteFrame.src = viewUrl;
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
 
-  if (isLikelyFrameDeniedHost(tab.url)) {
-    showOpenHint('Bu site iframe korumalı. Baluk Screatch içinde görüntü modu açıldı.');
-    renderProtectedSiteView(tab.url);
-    return;
+  if (viewUrl !== tab.url) {
+    showOpenHint('Bu site iframe korumalı. Görüntü modu ile açıldı (HTML görünüm).');
   }
-
-  el.siteFrame.srcdoc = '';
-  el.siteFrame.src = tab.url;
 }
 
 function setTabTitle(tab, title) {
@@ -647,11 +651,7 @@ function openUrl(url, addToHistory = true, titleHint = "") {
   if (isIframeBlockedHost(safe)) {
     const handled = tryInternalSearchFromBlockedUrl(safe);
     renderTabs();
-    if (!handled) {
-      showHome();
-      showOpenHint('Bu arama motoru gömülü açılamıyor. Baluk Screatch içinden arama yapmaya devam edebilirsin.');
-    }
-    return;
+    if (handled) return;
   }
 
   renderTabs();

--- a/script.js
+++ b/script.js
@@ -404,6 +404,38 @@ function getEmbeddableUrl(url) {
   return `https://r.jina.ai/http://${stripped}`;
 }
 
+function getYouTubeEmbedUrl(url) {
+  try {
+    const u = new URL(ensureUrl(url));
+    const host = u.hostname.replace(/^www\./, "");
+    const isYoutube = host === "youtube.com" || host === "m.youtube.com" || host === "youtu.be";
+    if (!isYoutube) return "";
+
+    if (host === "youtu.be") {
+      const id = u.pathname.split("/").filter(Boolean)[0];
+      return id ? `https://www.youtube-nocookie.com/embed/${encodeURIComponent(id)}` : "";
+    }
+
+    if (u.pathname === "/watch") {
+      const v = (u.searchParams.get("v") || "").trim();
+      return v ? `https://www.youtube-nocookie.com/embed/${encodeURIComponent(v)}` : "";
+    }
+
+    if (u.pathname.startsWith("/shorts/")) {
+      const id = u.pathname.split("/").filter(Boolean)[1];
+      return id ? `https://www.youtube-nocookie.com/embed/${encodeURIComponent(id)}` : "";
+    }
+
+    if (u.pathname === "/results") {
+      const q = (u.searchParams.get("search_query") || "").trim();
+      return q ? `https://www.youtube-nocookie.com/embed?listType=search&list=${encodeURIComponent(q)}` : "";
+    }
+  } catch {
+    return "";
+  }
+  return "";
+}
+
 function escapeForHtml(str = '') {
   return String(str).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
 }
@@ -483,7 +515,12 @@ async function renderProtectedSiteView(originalUrl) {
     const proxy = `https://r.jina.ai/http://${stripped}`;
     const res = await fetch(proxy);
     if (!res.ok) throw new Error('proxy fail');
-    const text = (await res.text()).replace(/\s+/g, ' ').trim().slice(0, 3500);
+    const textRaw = (await res.text()).replace(/\s+/g, ' ').trim();
+    const text = textRaw
+      .replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, '$1')
+      .replace(/!\[[^\]]*\]\((https?:\/\/[^\s)]+)\)/g, '')
+      .replace(/`{1,3}[^`]*`{1,3}/g, '')
+      .slice(0, 950);
     const body = `${escapeForHtml(text || 'İçerik okunamadı.')}
 
 Orijinal siteyi yeni sekmede açmak için aşağıya tıkla.`;
@@ -709,6 +746,15 @@ function syncTabView() {
   el.adresCubugu.value = tab.url;
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
+
+  const ytEmbed = getYouTubeEmbedUrl(tab.url);
+  if (ytEmbed) {
+    el.siteFrame.srcdoc = '';
+    el.siteFrame.src = ytEmbed;
+    showOpenHint('YouTube Baluk Screatch içinde gömülü modda açıldı.');
+    updateStagedOverlay();
+    return;
+  }
 
   if (/^https?:\/\/(www\.)?duckduckgo\.com\/\?/.test(tab.url)) {
     renderDuckDuckGoInApp(tab.url);

--- a/script.js
+++ b/script.js
@@ -780,7 +780,7 @@ el.aiForm.addEventListener("submit", async (e) => {
     stopThinking();
     el.aiCevap.innerHTML = await answerNormal(q);
     el.aiSoru.value = "";
-  }, 20000);
+  }, 3000);
 });
 
 el.aiSoru.addEventListener("keydown", (e) => {

--- a/script.js
+++ b/script.js
@@ -321,39 +321,43 @@ function renderResults(results, query) {
 
 async function fetchWebResults(query) {
   const url = `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&skip_disambig=1`;
-  const res = await fetch(url);
-  if (!res.ok) throw new Error("Web isteği başarısız");
-  const data = await res.json();
-  const out = [];
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return [];
+    const data = await res.json();
+    const out = [];
 
-  if (data.AbstractURL) {
-    out.push({
-      title: data.Heading || query,
-      description: data.AbstractText || "Öne çıkan sonuç",
-      link: data.AbstractURL,
-    });
-  }
-
-  const pushTopic = (topic) => {
-    if (!topic) return;
-    if (topic.FirstURL && topic.Text) {
-      const title = topic.Text.split(" - ")[0].trim() || topic.Text.slice(0, 64);
-      out.push({ title, description: topic.Text, link: topic.FirstURL });
+    if (data.AbstractURL) {
+      out.push({
+        title: data.Heading || query,
+        description: data.AbstractText || "Öne çıkan sonuç",
+        link: data.AbstractURL,
+      });
     }
-    if (Array.isArray(topic.Topics)) topic.Topics.forEach(pushTopic);
-  };
 
-  (data.RelatedTopics || []).forEach(pushTopic);
+    const pushTopic = (topic) => {
+      if (!topic) return;
+      if (topic.FirstURL && topic.Text) {
+        const title = topic.Text.split(" - ")[0].trim() || topic.Text.slice(0, 64);
+        out.push({ title, description: topic.Text, link: topic.FirstURL });
+      }
+      if (Array.isArray(topic.Topics)) topic.Topics.forEach(pushTopic);
+    };
 
-  const seen = new Set();
-  const uniq = [];
-  for (const item of out) {
-    if (!item?.link || seen.has(item.link)) continue;
-    seen.add(item.link);
-    uniq.push(item);
+    (data.RelatedTopics || []).forEach(pushTopic);
+
+    const seen = new Set();
+    const uniq = [];
+    for (const item of out) {
+      if (!item?.link || seen.has(item.link)) continue;
+      seen.add(item.link);
+      uniq.push(item);
+    }
+
+    return uniq.slice(0, 12);
+  } catch {
+    return [];
   }
-
-  return uniq.slice(0, 12);
 }
 
 function isWikipediaLink(link = "") {
@@ -697,8 +701,14 @@ async function answerNormal(q) {
     return `${highlight("Ben Baluk.ai")}, Baluk Screatch içinde çalışan yardımcı modelim. Web analiz, özetleme ve genel soru-cevap yapabilirim.`;
   }
 
-  const asksCurrentSite = /\bbu\s+web\s*site|\bbu\s+site|ekrandaki\s+site|açık\s+site|şu\s+site/.test(low);
+  const asksCurrentSite = /\bekranımdaki\s+uygulama|\bekrandaki\s+uygulama|\bbu\s+uygulama|\baçık\s+uygulama|\bbu\s+web\s*site|\bbu\s+site|ekrandaki\s+site|açık\s+site|şu\s+site/.test(low);
   const asksGenericWeb = /web\s*site\s*nedir|webin\s+ne\s+oldu|web\s*sitenin\s+amacı\s+ne/.test(low);
+
+  const asksYear = /kuruluş|kurulus|kaç yılında|kac yilinda|ne zaman/.test(low);
+  const asksCompany = /kim tarafından|kim tarafindan|hangi şirket|hangi sirket|kurucu|kim kurdu/.test(low);
+  const asksPurpose = /amaç|amac|amacı|amaci|ne işe yarar|ne ise yarar/.test(low);
+  const asksSummary = /özet|özeti/.test(low);
+  const asksGeneralProfile = /nedir|açıkla|açıklar mısın|anlat|genel bilgi/.test(low) && !asksYear && !asksCompany && !asksPurpose;
 
   if (asksGenericWeb && !asksCurrentSite) {
     return genericWebsiteDefinition();
@@ -716,21 +726,30 @@ async function answerNormal(q) {
   const sourceText = await fetchWebModeAnswer(asksCurrentSite ? (topic?.name || topic?.host || "") : (topic?.name || q));
 
   if (topic) {
-    if (/kuruluş|kaç yılında|ne zaman/.test(low)) {
+    if (asksYear) {
       return `${highlight(topic.name)} kuruluş yılı: ${highlight(topic.year || "bilinmiyor")}.`;
     }
-    if (/kim tarafından|hangi şirket|kurucu/.test(low)) {
+    if (asksCompany) {
       return `${highlight(topic.name)} kurucu/şirket bilgisi:
 ${escapeHtml(topic.company || "bilgi bulunamadı")}`;
     }
-    if (/amaç|ne işe yarar/.test(low)) {
+    if (asksPurpose) {
       return `${highlight(topic.name)} amacı:
 ${escapeHtml(topic.purpose || "bilgi bulunamadı")}`;
     }
-    if (/özet|özeti|nedir|hakkında/.test(low)) {
+    if (asksSummary) {
       const sum = sourceText || topic.summary;
       return `${highlight(topic.name)} özeti:
 ${escapeHtml(sum || "Özet bulunamadı")}`;
+    }
+
+    if (asksGeneralProfile) {
+      const sum = sourceText || topic.summary;
+      return `${highlight(topic.name)} genel bilgi:
+Kuruluş: ${highlight(topic.year || "bilinmiyor")}
+Şirket/Kurucu: ${escapeHtml(topic.company || "bilgi yok")}
+Amaç: ${escapeHtml(topic.purpose || "bilgi yok")}
+Özet: ${escapeHtml(sum || "Özet bulunamadı")}`;
     }
 
     const sum = sourceText || topic.summary;
@@ -742,7 +761,7 @@ Amaç: ${escapeHtml(topic.purpose || "bilgi yok")}
 Web modu özeti: ${escapeHtml(sum || "Özet bulunamadı")}`;
   }
 
-  if (/kuruluş|kaç yılında|ne zaman/.test(low)) {
+  if (asksYear) {
     const known = getKnownSiteFromText(q);
     if (known?.year) return `${highlight(known.name)} kuruluş yılı: ${highlight(known.year)}.`;
     return `${highlight(genericTopic)} kuruluş bilgisi: ${highlight("web kaynaklarından derlendi")}.`;
@@ -750,7 +769,7 @@ Web modu özeti: ${escapeHtml(sum || "Özet bulunamadı")}`;
   if (/isim|adı/.test(low)) {
     return `Site adı: ${highlight(genericTopic)}.`;
   }
-  if (/amaç|ne işe yarar|hakkında|nasıl/.test(low)) {
+  if (asksPurpose || /hakkında|nasıl/.test(low)) {
     return `${highlight("Baluk.ai web modu aktif")}
 ${highlight(genericTopic)} hakkında:
 ${escapeHtml(sourceText || `${genericTopic} hakkında yeterli veri bulunamadı.`)}`;

--- a/script.js
+++ b/script.js
@@ -12,6 +12,7 @@ const state = {
   theme: JSON.parse(localStorage.getItem("balukTheme") || "null"),
   uiEditMode: false,
   editingTarget: null,
+  stagedOpen: null,
 };
 
 const THEME_COLORS = {
@@ -465,6 +466,62 @@ function showOpenHint(message) {
   setTimeout(() => hint.remove(), 4200);
 }
 
+function openResultWithDuckStaging(item, query) {
+  const tab = currentTab();
+  if (!tab) return;
+  const targetUrl = ensureUrl(item?.href || item?.link || '');
+  const ddgUrl = `https://duckduckgo.com/?q=${encodeURIComponent(query || item?.title || '')}`;
+
+  tab.url = ddgUrl;
+  tab.history = tab.history.slice(0, tab.index + 1);
+  tab.history.push(ddgUrl);
+  tab.index = tab.history.length - 1;
+  setTabTitle(tab, query || item?.title || 'Arama');
+
+  state.stagedOpen = {
+    tabId: tab.id,
+    query: query || '',
+    targetUrl,
+    title: item?.title || 'Sonuç',
+  };
+
+  renderTabs();
+  syncTabView();
+}
+
+function renderStagedDuckView(staged) {
+  const safeQuery = escapeForHtml(staged.query || 'Arama sonucu');
+  const safeTitle = escapeForHtml(staged.title || 'Bağlantı');
+  const safeUrl = escapeForHtml(staged.targetUrl || '');
+
+  const html = `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+  body{margin:0;font-family:Inter,Arial,sans-serif;background:#0b0f1f;color:#eef2ff;padding:22px}
+  .head{font-size:28px;font-weight:800;color:#ffb347;margin-bottom:4px}
+  .sub{color:#b8c4ff;margin:0 0 18px}
+  .query{padding:12px 14px;border:1px solid #344b8d;border-radius:12px;background:#121a36;margin-bottom:14px}
+  .card{display:block;text-decoration:none;border:1px solid #4f6bd1;background:#151f44;border-radius:14px;padding:16px;color:#fff}
+  .card strong{display:block;font-size:21px;margin-bottom:8px}
+  .card span{display:block;color:#b6c7ff;word-break:break-all}
+  .hint{margin-top:12px;color:#9fb2ff}
+  </style></head><body>
+  <div class="head">DuckDuckGo</div>
+  <p class="sub">Baluk Screatch içi ara sonuç ekranı</p>
+  <div class="query">Arama: ${safeQuery}</div>
+  <a href="#" class="card" id="goTarget"><strong>${safeTitle}</strong><span>${safeUrl}</span></a>
+  <div class="hint">İlk tık: bu ekran • İkinci tık: gerçek site</div>
+  <script>
+    document.getElementById('goTarget').addEventListener('click', function(e){
+      e.preventDefault();
+      parent.postMessage({type:'baluk-staged-open', url:${JSON.stringify(staged.targetUrl)}, title:${JSON.stringify(staged.title)}}, '*');
+    });
+  </script>
+  </body></html>`;
+
+  el.siteFrame.removeAttribute('src');
+  el.siteFrame.srcdoc = html;
+}
+
 function tryInternalSearchFromBlockedUrl(url) {
   try {
     const u = new URL(url);
@@ -587,12 +644,18 @@ function showHome() {
 function syncTabView() {
   const tab = currentTab();
   if (!tab || !tab.url) return showHome();
-  const viewUrl = getEmbeddableUrl(tab.url);
   el.adresCubugu.value = tab.url;
-  el.siteFrame.srcdoc = '';
-  el.siteFrame.src = viewUrl;
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
+
+  if (state.stagedOpen && state.stagedOpen.tabId === tab.id) {
+    renderStagedDuckView(state.stagedOpen);
+    return;
+  }
+
+  const viewUrl = getEmbeddableUrl(tab.url);
+  el.siteFrame.srcdoc = '';
+  el.siteFrame.src = viewUrl;
 
   if (viewUrl !== tab.url) {
     showOpenHint('Bu site Baluk Screatch içinde güvenli görüntü modunda açıldı.');
@@ -628,6 +691,7 @@ function switchTab(id) {
 }
 
 function openUrl(url, addToHistory = true, titleHint = "") {
+  state.stagedOpen = null;
   const safe = ensureUrl(url);
   const tab = currentTab();
   if (!tab) return;
@@ -695,7 +759,7 @@ function renderResults(results, query) {
     card.className = "result-item";
     card.innerHTML = `<h3><a href="#">${escapeHtml(item.title)}</a></h3><p>${escapeHtml(item.snippet || "Açıklama yok")}</p><div class="result-actions"><button class="open-link" type="button">Bağlantıyı Aç</button><button class="ask-link" type="button">✦ Baluk.ai'ye Sor</button></div>`;
     card.querySelector("a").addEventListener("click", (e) => { e.preventDefault(); openUrl(item.href, true, query); });
-    card.querySelector(".open-link").addEventListener("click", () => openUrl(item.href, true, query));
+    card.querySelector(".open-link").addEventListener("click", () => openResultWithDuckStaging(item, query));
     card.querySelector(".ask-link").addEventListener("click", () => {
       setPanel(true);
       el.aiSoru.value = `${item.title} web sitesi ne işe yarar?`;
@@ -1371,6 +1435,17 @@ el.aiSoru.addEventListener("keydown", (e) => {
     e.preventDefault();
     el.aiForm.requestSubmit();
   }
+});
+
+
+window.addEventListener('message', (event) => {
+  const data = event?.data;
+  if (!data || data.type !== 'baluk-staged-open' || !data.url) return;
+  const staged = state.stagedOpen;
+  if (!staged) return;
+  const tab = currentTab();
+  if (!tab || staged.tabId !== tab.id) return;
+  openUrl(data.url, true, data.title || staged.title || 'Site');
 });
 
 renderTabs();

--- a/script.js
+++ b/script.js
@@ -253,8 +253,8 @@ function beginDragOrResize(target, startEvent) {
   const isResize = startEvent.shiftKey || startEvent.offsetX > rect.width - 24 || startEvent.offsetY > rect.height - 24;
   const startX = startEvent.clientX;
   const startY = startEvent.clientY;
-  const startLeft = parseFloat(node.style.left || '0');
-  const startTop = parseFloat(node.style.top || '0');
+  const startDX = Number(node.dataset.dx || 0);
+  const startDY = Number(node.dataset.dy || 0);
   const startW = rect.width;
   const startH = rect.height;
 
@@ -263,15 +263,23 @@ function beginDragOrResize(target, startEvent) {
       node.style.width = `${Math.max(140, startW + (ev.clientX - startX))}px`;
       node.style.height = `${Math.max(40, startH + (ev.clientY - startY))}px`;
     } else {
-      node.style.left = `${startLeft + (ev.clientX - startX)}px`;
-      node.style.top = `${startTop + (ev.clientY - startY)}px`;
+      const nextDX = startDX + (ev.clientX - startX);
+      const nextDY = startDY + (ev.clientY - startY);
+      node.dataset.dx = String(nextDX);
+      node.dataset.dy = String(nextDY);
+      node.style.transform = `translate(${nextDX}px, ${nextDY}px)`;
     }
   };
   const onUp = () => {
     document.removeEventListener('mousemove', onMove);
     document.removeEventListener('mouseup', onUp);
     const key = `balukEdit:${target.key}`;
-    localStorage.setItem(key, JSON.stringify({ left: node.style.left, top: node.style.top, width: node.style.width, height: node.style.height }));
+    localStorage.setItem(key, JSON.stringify({
+      dx: Number(node.dataset.dx || 0),
+      dy: Number(node.dataset.dy || 0),
+      width: node.style.width,
+      height: node.style.height,
+    }));
   };
 
   document.addEventListener('mousemove', onMove);
@@ -284,11 +292,18 @@ function restoreEditableLayout() {
     if (!saved) return;
     try {
       const d = JSON.parse(saved);
-      target.el.style.position = 'absolute';
-      target.el.style.left = d.left || '0px';
-      target.el.style.top = d.top || '0px';
+      const oldDX = Number.parseFloat(d.left || '0') || 0;
+      const oldDY = Number.parseFloat(d.top || '0') || 0;
+      const dx = Number.isFinite(d.dx) ? d.dx : oldDX;
+      const dy = Number.isFinite(d.dy) ? d.dy : oldDY;
+      target.el.dataset.dx = String(dx);
+      target.el.dataset.dy = String(dy);
+      target.el.style.transform = `translate(${dx}px, ${dy}px)`;
       if (d.width) target.el.style.width = d.width;
       if (d.height) target.el.style.height = d.height;
+      target.el.style.left = '';
+      target.el.style.top = '';
+      target.el.style.position = '';
     } catch {}
   });
 }
@@ -296,14 +311,11 @@ function restoreEditableLayout() {
 function setUiEditMode(on) {
   state.uiEditMode = on;
   el.customizePanel.classList.toggle('editing-active', on);
-  const home = document.getElementById('homeView');
-  if (home) home.style.position = 'relative';
 
   getEditableTargets().forEach((target) => {
     const node = target.el;
     if (on) {
       node.classList.add('editing-mode-target');
-      node.style.position = node.style.position || 'absolute';
       node.onmousedown = (ev) => {
         ev.preventDefault();
         beginDragOrResize(target, ev);

--- a/script.js
+++ b/script.js
@@ -644,15 +644,6 @@ function openUrl(url, addToHistory = true, titleHint = "") {
     tab.index = tab.history.length - 1;
   }
 
-  if (isSearchEngineHost(safe)) {
-    const handled = tryInternalSearchFromBlockedUrl(safe);
-    if (handled) {
-      renderTabs();
-      return;
-    }
-    // query yakalanamadıysa yine uygulama içinde güvenli görüntüye düş
-  }
-
   if (isTouchLikeDevice()) {
     const opened = window.open(safe, '_blank', 'noopener,noreferrer');
     if (!opened) window.location.href = safe;

--- a/script.js
+++ b/script.js
@@ -566,7 +566,7 @@ function openResultWithDuckStaging(item, query) {
   const tab = currentTab();
   if (!tab) return;
   const targetUrl = ensureUrl(item?.href || item?.link || '');
-  const ddgUrl = `https://duckduckgo.com/?q=${encodeURIComponent(query || item?.title || '')}`;
+  const ddgUrl = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query || item?.title || '')}`;
 
   tab.url = ddgUrl;
   tab.history = tab.history.slice(0, tab.index + 1);
@@ -746,12 +746,6 @@ function syncTabView() {
   el.adresCubugu.value = tab.url;
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
-
-  if (/^https?:\/\/(www\.)?duckduckgo\.com\/\?/.test(tab.url)) {
-    renderDuckDuckGoInApp(tab.url);
-    updateStagedOverlay();
-    return;
-  }
 
   // Eski çalışan tarayıcı mantığı: URL'i doğrudan iframe içine aç.
   el.siteFrame.srcdoc = '';

--- a/script.js
+++ b/script.js
@@ -496,7 +496,7 @@ function ensureStagedOverlay() {
   wrap = document.createElement('div');
   wrap.id = 'stagedOverlay';
   wrap.style.cssText = 'position:absolute;left:20px;right:20px;bottom:18px;z-index:35;display:none;';
-  wrap.innerHTML = '<div style="display:flex;gap:10px;align-items:center;justify-content:space-between;background:rgba(10,17,38,.92);border:1px solid rgba(110,142,255,.55);border-radius:12px;padding:10px 12px;color:#eaf0ff;"><span id="stagedLabel" style="font-size:.92rem"></span><button id="stagedOpenBtn" type="button" style="border:1px solid #6e8eff;background:#1d2f66;color:#fff;border-radius:10px;padding:8px 12px;cursor:pointer">DuckDuckGo'daki bağlantıyı aç</button></div>';
+  wrap.innerHTML = `<div style="display:flex;gap:10px;align-items:center;justify-content:space-between;background:rgba(10,17,38,.92);border:1px solid rgba(110,142,255,.55);border-radius:12px;padding:10px 12px;color:#eaf0ff;"><span id="stagedLabel" style="font-size:.92rem"></span><button id="stagedOpenBtn" type="button" style="border:1px solid #6e8eff;background:#1d2f66;color:#fff;border-radius:10px;padding:8px 12px;cursor:pointer">DuckDuckGo'daki bağlantıyı aç</button></div>`;
   el.webView.appendChild(wrap);
   wrap.querySelector('#stagedOpenBtn').addEventListener('click', () => {
     const staged = state.stagedOpen;
@@ -553,11 +553,17 @@ function playIntroSound() {
 }
 
 function runIntro() {
+  if (sessionStorage.getItem('balukIntroSeen') === '1') {
+    forceRevealApp();
+    return;
+  }
+
   let revealed = false;
 
   const revealApp = () => {
     if (revealed) return;
     revealed = true;
+    sessionStorage.setItem('balukIntroSeen', '1');
     forceRevealApp();
   };
 

--- a/script.js
+++ b/script.js
@@ -710,14 +710,6 @@ function openUrl(url, addToHistory = true, titleHint = "") {
     tab.index = tab.history.length - 1;
   }
 
-  if (isTouchLikeDevice()) {
-    const opened = window.open(safe, '_blank', 'noopener,noreferrer');
-    if (!opened) window.location.href = safe;
-    renderTabs();
-    showHome();
-    return;
-  }
-
   renderTabs();
   syncTabView();
   updateStagedOverlay();

--- a/script.js
+++ b/script.js
@@ -190,9 +190,6 @@ function applyTheme(theme) {
   document.documentElement.style.setProperty("--glow-purple", accent);
   document.documentElement.style.setProperty("--soft-border", `${accent}55`);
   document.documentElement.style.setProperty("--theme-font", theme.font || "Inter, Arial, sans-serif");
-  document.documentElement.style.setProperty("--bg-top", shade(accent, -35));
-  document.documentElement.style.setProperty("--bg-mid", shade(accent, -115));
-  document.documentElement.style.setProperty("--bg-bottom", shade(accent, -170));
   document.body.style.cursor = "default";
   setCursorStyle(theme.cursorShape, theme.cursorSize, accent);
 }
@@ -341,15 +338,6 @@ function shade(hex, delta) {
 
 function isTouchLikeDevice() {
   return window.matchMedia('(max-width: 1100px)').matches || /android|iphone|ipad|mobile|tablet/i.test(navigator.userAgent);
-}
-
-function shouldForceExternal(url) {
-  try {
-    const host = new URL(url).hostname.replace(/^www\./, '');
-    return ['duckduckgo.com', 'google.com', 'bing.com', 'search.yahoo.com'].some((h) => host.endsWith(h));
-  } catch {
-    return false;
-  }
 }
 
 function playIntroSound() {
@@ -508,7 +496,7 @@ function openUrl(url, addToHistory = true, titleHint = "") {
     tab.index = tab.history.length - 1;
   }
 
-  if (isTouchLikeDevice() || shouldForceExternal(safe)) {
+  if (isTouchLikeDevice()) {
     const opened = window.open(safe, '_blank', 'noopener,noreferrer');
     if (!opened) window.location.href = safe;
     renderTabs();

--- a/script.js
+++ b/script.js
@@ -10,6 +10,8 @@ const state = {
   customizeMode: false,
   dragTabId: null,
   theme: JSON.parse(localStorage.getItem("balukTheme") || "null"),
+  uiEditMode: false,
+  editingTarget: null,
 };
 
 const THEME_COLORS = {
@@ -188,6 +190,9 @@ function applyTheme(theme) {
   document.documentElement.style.setProperty("--glow-purple", accent);
   document.documentElement.style.setProperty("--soft-border", `${accent}55`);
   document.documentElement.style.setProperty("--theme-font", theme.font || "Inter, Arial, sans-serif");
+  document.documentElement.style.setProperty("--bg-top", shade(accent, -35));
+  document.documentElement.style.setProperty("--bg-mid", shade(accent, -115));
+  document.documentElement.style.setProperty("--bg-bottom", shade(accent, -170));
   document.body.style.cursor = "default";
   setCursorStyle(theme.cursorShape, theme.cursorSize, accent);
 }
@@ -238,12 +243,114 @@ async function runThemeAnimation(colorName) {
   layer.remove();
 }
 
+function getEditableTargets() {
+  return [
+    { key: 'title', el: document.querySelector('#homeView h1') },
+    { key: 'search', el: document.getElementById('aramaForm') },
+  ].filter((t) => t.el);
+}
+
+function beginDragOrResize(target, startEvent) {
+  const node = target.el;
+  const rect = node.getBoundingClientRect();
+  const isResize = startEvent.shiftKey || startEvent.offsetX > rect.width - 24 || startEvent.offsetY > rect.height - 24;
+  const startX = startEvent.clientX;
+  const startY = startEvent.clientY;
+  const startLeft = parseFloat(node.style.left || '0');
+  const startTop = parseFloat(node.style.top || '0');
+  const startW = rect.width;
+  const startH = rect.height;
+
+  const onMove = (ev) => {
+    if (isResize) {
+      node.style.width = `${Math.max(140, startW + (ev.clientX - startX))}px`;
+      node.style.height = `${Math.max(40, startH + (ev.clientY - startY))}px`;
+    } else {
+      node.style.left = `${startLeft + (ev.clientX - startX)}px`;
+      node.style.top = `${startTop + (ev.clientY - startY)}px`;
+    }
+  };
+  const onUp = () => {
+    document.removeEventListener('mousemove', onMove);
+    document.removeEventListener('mouseup', onUp);
+    const key = `balukEdit:${target.key}`;
+    localStorage.setItem(key, JSON.stringify({ left: node.style.left, top: node.style.top, width: node.style.width, height: node.style.height }));
+  };
+
+  document.addEventListener('mousemove', onMove);
+  document.addEventListener('mouseup', onUp, { once: true });
+}
+
+function restoreEditableLayout() {
+  getEditableTargets().forEach((target) => {
+    const saved = localStorage.getItem(`balukEdit:${target.key}`);
+    if (!saved) return;
+    try {
+      const d = JSON.parse(saved);
+      target.el.style.position = 'absolute';
+      target.el.style.left = d.left || '0px';
+      target.el.style.top = d.top || '0px';
+      if (d.width) target.el.style.width = d.width;
+      if (d.height) target.el.style.height = d.height;
+    } catch {}
+  });
+}
+
+function setUiEditMode(on) {
+  state.uiEditMode = on;
+  el.customizePanel.classList.toggle('editing-active', on);
+  const home = document.getElementById('homeView');
+  if (home) home.style.position = 'relative';
+
+  getEditableTargets().forEach((target) => {
+    const node = target.el;
+    if (on) {
+      node.classList.add('editing-mode-target');
+      node.style.position = node.style.position || 'absolute';
+      node.onmousedown = (ev) => {
+        ev.preventDefault();
+        beginDragOrResize(target, ev);
+      };
+    } else {
+      node.classList.remove('editing-mode-target');
+      node.onmousedown = null;
+    }
+  });
+}
+
+
 function currentTab() { return state.tabs.find((t) => t.id === state.activeTabId); }
 function escapeHtml(text = "") { return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#039;"); }
 function ensureUrl(value) { return /^https?:\/\//i.test(value) ? value : `https://${value}`; }
 function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
 function highlight(v) { return `<span class="hl">${escapeHtml(v)}</span>`; }
 function normalize(s = "") { return s.toLowerCase().trim(); }
+
+function hexToRgb(hex) {
+  const v = (hex || '').replace('#', '').trim();
+  const clean = v.length === 3 ? v.split('').map((x) => x + x).join('') : v;
+  const num = Number.parseInt(clean || '000000', 16);
+  return { r: (num >> 16) & 255, g: (num >> 8) & 255, b: num & 255 };
+}
+
+function shade(hex, delta) {
+  const { r, g, b } = hexToRgb(hex);
+  const adj = (n) => Math.max(0, Math.min(255, n + delta));
+  return `rgb(${adj(r)}, ${adj(g)}, ${adj(b)})`;
+}
+
+function isTouchLikeDevice() {
+  return window.matchMedia('(max-width: 1100px)').matches || /android|iphone|ipad|mobile|tablet/i.test(navigator.userAgent);
+}
+
+function shouldForceExternal(url) {
+  try {
+    const host = new URL(url).hostname.replace(/^www\./, '');
+    return ['duckduckgo.com', 'google.com', 'bing.com', 'search.yahoo.com'].some((h) => host.endsWith(h));
+  } catch {
+    return false;
+  }
+}
 
 function playIntroSound() {
   try {
@@ -400,6 +507,15 @@ function openUrl(url, addToHistory = true, titleHint = "") {
     tab.history.push(safe);
     tab.index = tab.history.length - 1;
   }
+
+  if (isTouchLikeDevice() || shouldForceExternal(safe)) {
+    const opened = window.open(safe, '_blank', 'noopener,noreferrer');
+    if (!opened) window.location.href = safe;
+    renderTabs();
+    showHome();
+    return;
+  }
+
   renderTabs();
   syncTabView();
 }
@@ -1063,11 +1179,9 @@ el.saveCustomizeBtn.addEventListener("click", async () => {
   saveThemeFromUi();
 });
 el.advancedEditBtn.addEventListener("click", () => {
-  setAgentMode(true);
-  setCustomizeMode(false);
-  setPanel(true);
-  el.aiSoru.value = "agent mode 3.0 ile gelişmiş düzenleme başlat";
-  el.aiCevap.innerHTML = "Gelişmiş düzenleme için Agent Mode 3.0 açık. Konum/boyut komutu verebilirsin.";
+  const next = !state.uiEditMode;
+  setUiEditMode(next);
+  el.advancedEditBtn.textContent = next ? "Düzenleme Modunu Kapat" : "Düzenleme Modu";
 });
 
 el.loginForm.addEventListener("submit", (e) => {
@@ -1127,5 +1241,6 @@ renderTabs();
 renderAuth();
 initPrompts();
 initThemeOptions();
+restoreEditableLayout();
 setPanel(false);
 runIntro();

--- a/script.js
+++ b/script.js
@@ -393,6 +393,60 @@ function getEmbeddableUrl(url) {
   return `https://r.jina.ai/http://${stripped}`;
 }
 
+function escapeForHtml(str = '') {
+  return String(str).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function setFrameDoc(title, body) {
+  el.siteFrame.removeAttribute('src');
+  el.siteFrame.srcdoc = `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><style>body{margin:0;font-family:Inter,Arial,sans-serif;background:#070b18;color:#e9ecff;padding:26px} .card{max-width:980px;margin:0 auto;background:#0f1634;border:1px solid #2c3f7a;border-radius:14px;padding:18px} h2{margin:0 0 8px} p{line-height:1.55;color:#cfd6ff;white-space:pre-wrap} a{display:inline-block;margin-top:10px;padding:10px 14px;border-radius:10px;text-decoration:none;background:#2a4ea8;color:#fff}</style></head><body><div class="card"><h2>${title}</h2><p>${body}</p></div></body></html>`;
+}
+
+async function renderProtectedSiteView(originalUrl) {
+  const title = 'Bu site iframe korumalı (Baluk Screatch Görüntü Modu)';
+  setFrameDoc(title, `Site: ${escapeForHtml(originalUrl)}
+
+İçeriği getiriyorum...`);
+
+  try {
+    const stripped = originalUrl.replace(/^https?:\/\//i, '');
+    const proxy = `https://r.jina.ai/http://${stripped}`;
+    const res = await fetch(proxy);
+    if (!res.ok) throw new Error('proxy fail');
+    const text = (await res.text()).replace(/\s+/g, ' ').trim().slice(0, 3500);
+    const body = `${escapeForHtml(text || 'İçerik okunamadı.')}
+
+Orijinal siteyi yeni sekmede açmak için aşağıya tıkla.`;
+    setFrameDoc(title, body + `
+
+`);
+    const doc = el.siteFrame.contentDocument;
+    if (doc?.body) {
+      const card = doc.querySelector('.card');
+      const a = doc.createElement('a');
+      a.href = originalUrl;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      a.textContent = 'Orijinal siteyi yeni sekmede aç';
+      card?.appendChild(a);
+    }
+  } catch {
+    setFrameDoc(title, `Site: ${escapeForHtml(originalUrl)}
+
+Bu içeriği gömülü okuyamadım. Orijinal siteyi yeni sekmede açabilirsin.`);
+    const doc = el.siteFrame.contentDocument;
+    if (doc?.body) {
+      const card = doc.querySelector('.card');
+      const a = doc.createElement('a');
+      a.href = originalUrl;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      a.textContent = 'Orijinal siteyi yeni sekmede aç';
+      card?.appendChild(a);
+    }
+  }
+}
+
 function showOpenHint(message) {
   const hint = document.createElement('div');
   hint.className = 'searching-status';
@@ -523,15 +577,18 @@ function showHome() {
 function syncTabView() {
   const tab = currentTab();
   if (!tab || !tab.url) return showHome();
-  const viewUrl = getEmbeddableUrl(tab.url);
   el.adresCubugu.value = tab.url;
-  el.siteFrame.src = viewUrl;
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
 
-  if (viewUrl !== tab.url) {
-    showOpenHint('Bu site iframe korumalı. Baluk Screatch içinde görüntü modu (web özeti) açıldı.');
+  if (isLikelyFrameDeniedHost(tab.url)) {
+    showOpenHint('Bu site iframe korumalı. Baluk Screatch içinde görüntü modu açıldı.');
+    renderProtectedSiteView(tab.url);
+    return;
   }
+
+  el.siteFrame.srcdoc = '';
+  el.siteFrame.src = tab.url;
 }
 
 function setTabTitle(tab, title) {

--- a/script.js
+++ b/script.js
@@ -352,6 +352,29 @@ function isTouchLikeDevice() {
   return window.matchMedia('(max-width: 1100px)').matches || /android|iphone|ipad|mobile|tablet/i.test(navigator.userAgent);
 }
 
+function isIframeBlockedHost(url) {
+  try {
+    const host = new URL(url).hostname.replace(/^www\./, '');
+    return [
+      'duckduckgo.com',
+      'google.com',
+      'bing.com',
+      'search.yahoo.com',
+      'yahoo.com',
+    ].some((h) => host === h || host.endsWith(`.${h}`));
+  } catch {
+    return false;
+  }
+}
+
+function showOpenHint(url) {
+  const hint = document.createElement('div');
+  hint.className = 'searching-status';
+  hint.textContent = `Bu site güvenlik nedeniyle gömülü açılamıyor. Yeni sekmede açıldı: ${url}`;
+  el.sonuclar.prepend(hint);
+  setTimeout(() => hint.remove(), 4200);
+}
+
 function playIntroSound() {
   try {
     const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -508,11 +531,12 @@ function openUrl(url, addToHistory = true, titleHint = "") {
     tab.index = tab.history.length - 1;
   }
 
-  if (isTouchLikeDevice()) {
+  if (isTouchLikeDevice() || isIframeBlockedHost(safe)) {
     const opened = window.open(safe, '_blank', 'noopener,noreferrer');
     if (!opened) window.location.href = safe;
     renderTabs();
     showHome();
+    if (!isTouchLikeDevice()) showOpenHint(safe);
     return;
   }
 

--- a/script.js
+++ b/script.js
@@ -487,39 +487,36 @@ function openResultWithDuckStaging(item, query) {
 
   renderTabs();
   syncTabView();
+  updateStagedOverlay();
 }
 
-function renderStagedDuckView(staged) {
-  const safeQuery = escapeForHtml(staged.query || 'Arama sonucu');
-  const safeTitle = escapeForHtml(staged.title || 'Bağlantı');
-  const safeUrl = escapeForHtml(staged.targetUrl || '');
+function ensureStagedOverlay() {
+  let wrap = document.getElementById('stagedOverlay');
+  if (wrap) return wrap;
+  wrap = document.createElement('div');
+  wrap.id = 'stagedOverlay';
+  wrap.style.cssText = 'position:absolute;left:20px;right:20px;bottom:18px;z-index:35;display:none;';
+  wrap.innerHTML = '<div style="display:flex;gap:10px;align-items:center;justify-content:space-between;background:rgba(10,17,38,.92);border:1px solid rgba(110,142,255,.55);border-radius:12px;padding:10px 12px;color:#eaf0ff;"><span id="stagedLabel" style="font-size:.92rem"></span><button id="stagedOpenBtn" type="button" style="border:1px solid #6e8eff;background:#1d2f66;color:#fff;border-radius:10px;padding:8px 12px;cursor:pointer">DuckDuckGo'daki bağlantıyı aç</button></div>';
+  el.webView.appendChild(wrap);
+  wrap.querySelector('#stagedOpenBtn').addEventListener('click', () => {
+    const staged = state.stagedOpen;
+    if (!staged) return;
+    openUrl(staged.targetUrl, true, staged.title || 'Site');
+  });
+  return wrap;
+}
 
-  const html = `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>
-  body{margin:0;font-family:Inter,Arial,sans-serif;background:#0b0f1f;color:#eef2ff;padding:22px}
-  .head{font-size:28px;font-weight:800;color:#ffb347;margin-bottom:4px}
-  .sub{color:#b8c4ff;margin:0 0 18px}
-  .query{padding:12px 14px;border:1px solid #344b8d;border-radius:12px;background:#121a36;margin-bottom:14px}
-  .card{display:block;text-decoration:none;border:1px solid #4f6bd1;background:#151f44;border-radius:14px;padding:16px;color:#fff}
-  .card strong{display:block;font-size:21px;margin-bottom:8px}
-  .card span{display:block;color:#b6c7ff;word-break:break-all}
-  .hint{margin-top:12px;color:#9fb2ff}
-  </style></head><body>
-  <div class="head">DuckDuckGo</div>
-  <p class="sub">Baluk Screatch içi ara sonuç ekranı</p>
-  <div class="query">Arama: ${safeQuery}</div>
-  <a href="#" class="card" id="goTarget"><strong>${safeTitle}</strong><span>${safeUrl}</span></a>
-  <div class="hint">İlk tık: bu ekran • İkinci tık: gerçek site</div>
-  <script>
-    document.getElementById('goTarget').addEventListener('click', function(e){
-      e.preventDefault();
-      parent.postMessage({type:'baluk-staged-open', url:${JSON.stringify(staged.targetUrl)}, title:${JSON.stringify(staged.title)}}, '*');
-    });
-  </script>
-  </body></html>`;
-
-  el.siteFrame.removeAttribute('src');
-  el.siteFrame.srcdoc = html;
+function updateStagedOverlay() {
+  const wrap = ensureStagedOverlay();
+  const staged = state.stagedOpen;
+  const tab = currentTab();
+  if (!staged || !tab || staged.tabId !== tab.id) {
+    wrap.style.display = 'none';
+    return;
+  }
+  wrap.style.display = 'block';
+  const lbl = wrap.querySelector('#stagedLabel');
+  lbl.textContent = `DuckDuckGo ara ekranı açık: ${staged.query || staged.title || 'sonuç'}. İkinci tıkla asıl siteye geç.`;
 }
 
 function tryInternalSearchFromBlockedUrl(url) {
@@ -648,11 +645,6 @@ function syncTabView() {
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
 
-  if (state.stagedOpen && state.stagedOpen.tabId === tab.id) {
-    renderStagedDuckView(state.stagedOpen);
-    return;
-  }
-
   const viewUrl = getEmbeddableUrl(tab.url);
   el.siteFrame.srcdoc = '';
   el.siteFrame.src = viewUrl;
@@ -660,6 +652,8 @@ function syncTabView() {
   if (viewUrl !== tab.url) {
     showOpenHint('Bu site Baluk Screatch içinde güvenli görüntü modunda açıldı.');
   }
+
+  updateStagedOverlay();
 }
 
 function setTabTitle(tab, title) {
@@ -688,10 +682,12 @@ function switchTab(id) {
   state.activeTabId = id;
   renderTabs();
   syncTabView();
+  updateStagedOverlay();
 }
 
 function openUrl(url, addToHistory = true, titleHint = "") {
   state.stagedOpen = null;
+  updateStagedOverlay();
   const safe = ensureUrl(url);
   const tab = currentTab();
   if (!tab) return;
@@ -718,6 +714,7 @@ function openUrl(url, addToHistory = true, titleHint = "") {
 
   renderTabs();
   syncTabView();
+  updateStagedOverlay();
 }
 
 function buildFallbackResults(query) {
@@ -1437,16 +1434,6 @@ el.aiSoru.addEventListener("keydown", (e) => {
   }
 });
 
-
-window.addEventListener('message', (event) => {
-  const data = event?.data;
-  if (!data || data.type !== 'baluk-staged-open' || !data.url) return;
-  const staged = state.stagedOpen;
-  if (!staged) return;
-  const tab = currentTab();
-  if (!tab || staged.tabId !== tab.id) return;
-  openUrl(data.url, true, data.title || staged.title || 'Site');
-});
 
 renderTabs();
 renderAuth();

--- a/script.js
+++ b/script.js
@@ -457,6 +457,25 @@ function siteHintFromText(text) {
   return ["youtube", "google", "wikipedia", "github", "instagram", "twitter", "shopify"].find((x) => t.includes(x)) || "web sitesi";
 }
 
+function getKnownSiteFromText(text) {
+  const q = normalize(text);
+  for (const [host, info] of Object.entries(SITE_KNOWLEDGE)) {
+    const hostShort = host.replace(/^www\./, "").split(".")[0];
+    const name = normalize(info.name || hostShort);
+    if (q.includes(hostShort) || q.includes(name)) {
+      return {
+        host,
+        name: info.name,
+        year: info.year,
+        company: info.company,
+        purpose: info.purpose,
+        summary: info.summary,
+      };
+    }
+  }
+  return null;
+}
+
 function shouldUseWebModeThinking(query) {
   const q = normalize(query);
   return /(web|site|ekrandaki|bu web|bu site|youtube|shopify|wikipedia|kuruluş|kurucu|şirket|amaç|özet|hakkında|nasıl)/.test(q);
@@ -686,41 +705,46 @@ async function answerNormal(q) {
   }
 
   const current = getCurrentSiteContext();
+  const mentionedSite = getKnownSiteFromText(q);
+
   if (asksCurrentSite && !current) {
     return `Önce bir site aç, sonra ${highlight("bu web sitenin amacı ne")} diye sor; ekrandaki siteyi yorumlayayım.`;
   }
 
-  const topic = asksCurrentSite ? current : null;
+  const topic = asksCurrentSite ? current : mentionedSite;
   const genericTopic = siteHintFromText(q);
-  const sourceText = await fetchWebModeAnswer(asksCurrentSite ? (topic?.name || topic?.host || "") : q);
+  const sourceText = await fetchWebModeAnswer(asksCurrentSite ? (topic?.name || topic?.host || "") : (topic?.name || q));
 
-  if (asksCurrentSite) {
+  if (topic) {
     if (/kuruluş|kaç yılında|ne zaman/.test(low)) {
-      return `${highlight(topic.name)} kuruluş yılı: ${highlight(topic.year)}.`;
+      return `${highlight(topic.name)} kuruluş yılı: ${highlight(topic.year || "bilinmiyor")}.`;
     }
     if (/kim tarafından|hangi şirket|kurucu/.test(low)) {
       return `${highlight(topic.name)} kurucu/şirket bilgisi:
-${escapeHtml(topic.company)}`;
+${escapeHtml(topic.company || "bilgi bulunamadı")}`;
     }
     if (/amaç|ne işe yarar/.test(low)) {
-      return `${highlight("Ekrandaki site")}: ${highlight(topic.name)}
-Amaç: ${escapeHtml(topic.purpose)}`;
+      return `${highlight(topic.name)} amacı:
+${escapeHtml(topic.purpose || "bilgi bulunamadı")}`;
     }
-    if (/özet|özeti|nedir/.test(low)) {
+    if (/özet|özeti|nedir|hakkında/.test(low)) {
       const sum = sourceText || topic.summary;
       return `${highlight(topic.name)} özeti:
-${escapeHtml(sum)}`;
+${escapeHtml(sum || "Özet bulunamadı")}`;
     }
+
     const sum = sourceText || topic.summary;
     return `${highlight("Baluk.ai ağına bağlanıldı")}
 ${highlight(topic.name)} için hızlı analiz:
-Kuruluş: ${highlight(topic.year)}
-Şirket/Kurucu: ${escapeHtml(topic.company)}
-Amaç: ${escapeHtml(topic.purpose)}
-Web modu özeti: ${escapeHtml(sum)}`;
+Kuruluş: ${highlight(topic.year || "bilinmiyor")}
+Şirket/Kurucu: ${escapeHtml(topic.company || "bilgi yok")}
+Amaç: ${escapeHtml(topic.purpose || "bilgi yok")}
+Web modu özeti: ${escapeHtml(sum || "Özet bulunamadı")}`;
   }
 
   if (/kuruluş|kaç yılında|ne zaman/.test(low)) {
+    const known = getKnownSiteFromText(q);
+    if (known?.year) return `${highlight(known.name)} kuruluş yılı: ${highlight(known.year)}.`;
     return `${highlight(genericTopic)} kuruluş bilgisi: ${highlight("web kaynaklarından derlendi")}.`;
   }
   if (/isim|adı/.test(low)) {

--- a/script.js
+++ b/script.js
@@ -367,12 +367,29 @@ function isIframeBlockedHost(url) {
   }
 }
 
-function showOpenHint(url) {
+function showOpenHint(message) {
   const hint = document.createElement('div');
   hint.className = 'searching-status';
-  hint.textContent = `Bu site güvenlik nedeniyle gömülü açılamıyor. Yeni sekmede açıldı: ${url}`;
+  hint.textContent = message;
   el.sonuclar.prepend(hint);
   setTimeout(() => hint.remove(), 4200);
+}
+
+function tryInternalSearchFromBlockedUrl(url) {
+  try {
+    const u = new URL(url);
+    const params = u.searchParams;
+    const q = (params.get('q') || params.get('p') || params.get('query') || '').trim();
+    if (!q) return false;
+    const tab = currentTab();
+    if (tab) setTabTitle(tab, q);
+    showHome();
+    el.aramaInput.value = q;
+    el.aramaForm.requestSubmit();
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function playIntroSound() {
@@ -531,12 +548,21 @@ function openUrl(url, addToHistory = true, titleHint = "") {
     tab.index = tab.history.length - 1;
   }
 
-  if (isTouchLikeDevice() || isIframeBlockedHost(safe)) {
+  if (isTouchLikeDevice()) {
     const opened = window.open(safe, '_blank', 'noopener,noreferrer');
     if (!opened) window.location.href = safe;
     renderTabs();
     showHome();
-    if (!isTouchLikeDevice()) showOpenHint(safe);
+    return;
+  }
+
+  if (isIframeBlockedHost(safe)) {
+    const handled = tryInternalSearchFromBlockedUrl(safe);
+    renderTabs();
+    if (!handled) {
+      showHome();
+      showOpenHint('Bu arama motoru gömülü açılamıyor. Baluk Screatch içinden arama yapmaya devam edebilirsin.');
+    }
     return;
   }
 
@@ -547,9 +573,9 @@ function openUrl(url, addToHistory = true, titleHint = "") {
 function buildFallbackResults(query) {
   const q = encodeURIComponent(query);
   return [
-    { title: `${query} - DuckDuckGo`, href: `https://duckduckgo.com/?q=${q}`, snippet: "DuckDuckGo sonuç sayfasını aç." },
     { title: `${query} - Wikipedia araması`, href: `https://tr.wikipedia.org/wiki/Özel:Arama?search=${q}`, snippet: "Wikipedia içinde ara." },
-    { title: `${query} - Google araması`, href: `https://www.google.com/search?q=${q}`, snippet: "Google sonuç sayfasını aç." },
+    { title: `${query} - YouTube araması`, href: `https://www.youtube.com/results?search_query=${q}`, snippet: "YouTube içinde ara." },
+    { title: `${query} - GitHub araması`, href: `https://github.com/search?q=${q}`, snippet: "GitHub içinde ara." },
   ];
 }
 

--- a/script.js
+++ b/script.js
@@ -10,10 +10,17 @@ const state = {
 };
 
 const THINKING_LINES = [
-  "Baluk.ai ağına bağlanılıyor...",
-  "Ekranındaki sayfayı satır satır tarıyorum...",
-  "Web + Wikipedia kaynaklarını birleştiriyorum...",
-  "Doğrulayıp net cevabı hazırlıyorum..."
+  "Baluk.ai düşünüyor...",
+  "Sorunu anlamlandırıyorum...",
+  "En doğru cevabı hazırlıyorum...",
+  "Cevap hazır, son kontrol yapıyorum..."
+];
+
+const WEB_MODE_THINKING_LINES = [
+  "Baluk.ai uygulamasına bağlanıyorum...",
+  "Web modu özelliğini alıyorum...",
+  "DuckDuckGo sonuçlarını çekiyorum...",
+  "Wikipedia metnini süzüp 400 harfe indiriyorum..."
 ];
 const SITE_KNOWLEDGE = {
   "youtube.com": {
@@ -312,40 +319,104 @@ function renderResults(results, query) {
   });
 }
 
-async function fetchWikipediaSnippet(topic) {
-  try {
-    const r = await fetch(`https://tr.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(topic)}`);
-    if (!r.ok) return "";
-    const data = await r.json();
-    return (data.extract || "").trim().slice(0, 200);
-  } catch { return ""; }
+async function fetchWebResults(query) {
+  const url = `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&skip_disambig=1`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error("Web isteği başarısız");
+  const data = await res.json();
+  const out = [];
+
+  if (data.AbstractURL) {
+    out.push({
+      title: data.Heading || query,
+      description: data.AbstractText || "Öne çıkan sonuç",
+      link: data.AbstractURL,
+    });
+  }
+
+  const pushTopic = (topic) => {
+    if (!topic) return;
+    if (topic.FirstURL && topic.Text) {
+      const title = topic.Text.split(" - ")[0].trim() || topic.Text.slice(0, 64);
+      out.push({ title, description: topic.Text, link: topic.FirstURL });
+    }
+    if (Array.isArray(topic.Topics)) topic.Topics.forEach(pushTopic);
+  };
+
+  (data.RelatedTopics || []).forEach(pushTopic);
+
+  const seen = new Set();
+  const uniq = [];
+  for (const item of out) {
+    if (!item?.link || seen.has(item.link)) continue;
+    seen.add(item.link);
+    uniq.push(item);
+  }
+
+  return uniq.slice(0, 12);
 }
 
+function isWikipediaLink(link = "") {
+  return /https?:\/\/(?:[a-z]{2}\.)?wikipedia\.org\/wiki\//i.test(link);
+}
 
+function extractWikiTitleFromLink(link = "") {
+  try {
+    const u = new URL(link);
+    if (!u.pathname.startsWith("/wiki/")) return "";
+    return decodeURIComponent(u.pathname.replace("/wiki/", "")).replace(/_/g, " ").trim();
+  } catch {
+    return "";
+  }
+}
+
+async function fetchWikipediaLongExcerpt(link) {
+  if (!isWikipediaLink(link)) return null;
+  const title = extractWikiTitleFromLink(link);
+  if (!title) return null;
+
+  const endpoints = [
+    `https://tr.wikipedia.org/w/api.php?action=query&prop=extracts&explaintext=1&exsectionformat=plain&titles=${encodeURIComponent(title)}&format=json&origin=*`,
+    `https://en.wikipedia.org/w/api.php?action=query&prop=extracts&explaintext=1&exsectionformat=plain&titles=${encodeURIComponent(title)}&format=json&origin=*`,
+  ];
+
+  for (const ep of endpoints) {
+    try {
+      const res = await fetch(ep);
+      if (!res.ok) continue;
+      const data = await res.json();
+      const pages = data?.query?.pages || {};
+      const page = Object.values(pages)[0];
+      const raw = (page?.extract || "").replace(/\s+/g, " ").trim();
+      if (raw) return raw.slice(0, 400);
+    } catch {}
+  }
+  return null;
+}
 
 async function fetchWebModeAnswer(query) {
   const cleaned = query.trim();
   if (!cleaned) return "";
 
-  const parts = [];
   try {
-    const ddgResp = await fetch(`https://api.duckduckgo.com/?q=${encodeURIComponent(cleaned)}&format=json&no_redirect=1&no_html=1`);
-    if (ddgResp.ok) {
-      const ddg = await ddgResp.json();
-      if (ddg.AbstractText) parts.push(ddg.AbstractText);
-      const related = (ddg.RelatedTopics || [])
-        .flatMap((item) => item.Topics || [item])
-        .map((item) => item?.Text)
-        .filter(Boolean);
-      if (related.length) parts.push(related.slice(0, 2).join(" "));
+    const results = await fetchWebResults(cleaned);
+    if (!results.length) return "";
+
+    const primary = results[0];
+    let text = (primary.description || primary.title || "").trim();
+
+    for (const item of results) {
+      const wikiExcerpt = await fetchWikipediaLongExcerpt(item.link);
+      if (wikiExcerpt) {
+        text = `${text} ${wikiExcerpt}`.trim();
+        break;
+      }
     }
-  } catch {}
 
-  const wiki = await fetchWikipediaSnippet(cleaned);
-  if (wiki) parts.push(wiki);
-
-  const merged = parts.join(" ").replace(/\s+/g, " ").trim();
-  return merged.slice(0, 450);
+    return text.replace(/\s+/g, " ").trim().slice(0, 400);
+  } catch {
+    return "";
+  }
 }
 
 function getCurrentSiteContext() {
@@ -384,6 +455,11 @@ function genericWebsiteDefinition() {
 function siteHintFromText(text) {
   const t = normalize(text);
   return ["youtube", "google", "wikipedia", "github", "instagram", "twitter", "shopify"].find((x) => t.includes(x)) || "web sitesi";
+}
+
+function shouldUseWebModeThinking(query) {
+  const q = normalize(query);
+  return /(web|site|ekrandaki|bu web|bu site|youtube|shopify|wikipedia|kuruluş|kurucu|şirket|amaç|özet|hakkında|nasıl)/.test(q);
 }
 
 function startThinking(customLines = THINKING_LINES) {
@@ -774,7 +850,7 @@ el.aiForm.addEventListener("submit", async (e) => {
     return;
   }
 
-  startThinking();
+  startThinking(shouldUseWebModeThinking(q) ? WEB_MODE_THINKING_LINES : THINKING_LINES);
   clearTimeout(state.thinkingTimer);
   state.thinkingTimer = setTimeout(async () => {
     stopThinking();

--- a/script.js
+++ b/script.js
@@ -747,35 +747,15 @@ function syncTabView() {
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
 
-  const ytEmbed = getYouTubeEmbedUrl(tab.url);
-  if (ytEmbed) {
-    el.siteFrame.srcdoc = '';
-    el.siteFrame.src = ytEmbed;
-    showOpenHint('YouTube Baluk Screatch içinde gömülü modda açıldı.');
-    updateStagedOverlay();
-    return;
-  }
-
   if (/^https?:\/\/(www\.)?duckduckgo\.com\/\?/.test(tab.url)) {
     renderDuckDuckGoInApp(tab.url);
     updateStagedOverlay();
     return;
   }
 
-  if (isLikelyFrameDeniedHost(tab.url)) {
-    renderProtectedSiteView(tab.url);
-    showOpenHint('Bu site Baluk Screatch içinde güvenli görüntü modunda açıldı.');
-    updateStagedOverlay();
-    return;
-  }
-
-  const viewUrl = getEmbeddableUrl(tab.url);
+  // Eski çalışan tarayıcı mantığı: URL'i doğrudan iframe içine aç.
   el.siteFrame.srcdoc = '';
-  el.siteFrame.src = viewUrl;
-
-  if (viewUrl !== tab.url) {
-    showOpenHint('Bu site Baluk Screatch içinde güvenli görüntü modunda açıldı.');
-  }
+  el.siteFrame.src = tab.url;
 
   updateStagedOverlay();
 }

--- a/script.js
+++ b/script.js
@@ -651,6 +651,13 @@ function syncTabView() {
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
 
+  if (isLikelyFrameDeniedHost(tab.url)) {
+    renderProtectedSiteView(tab.url);
+    showOpenHint('Bu site Baluk Screatch içinde güvenli görüntü modunda açıldı.');
+    updateStagedOverlay();
+    return;
+  }
+
   const viewUrl = getEmbeddableUrl(tab.url);
   el.siteFrame.srcdoc = '';
   el.siteFrame.src = viewUrl;

--- a/script.js
+++ b/script.js
@@ -367,6 +367,10 @@ function isIframeBlockedHost(url) {
   }
 }
 
+function isSearchEngineHost(url) {
+  return isIframeBlockedHost(url);
+}
+
 function isLikelyFrameDeniedHost(url) {
   try {
     const host = new URL(url).hostname.replace(/^www\./, '');
@@ -635,6 +639,16 @@ function openUrl(url, addToHistory = true, titleHint = "") {
     tab.index = tab.history.length - 1;
   }
 
+  if (isSearchEngineHost(safe)) {
+    const handled = tryInternalSearchFromBlockedUrl(safe);
+    renderTabs();
+    if (!handled) {
+      showHome();
+      showOpenHint('Arama motoru bağlantısı içe aktarılamadı. Lütfen Baluk Screatch arama kutusuna sorguyu yaz.');
+    }
+    return;
+  }
+
   if (isTouchLikeDevice()) {
     const opened = window.open(safe, '_blank', 'noopener,noreferrer');
     if (!opened) window.location.href = safe;
@@ -643,14 +657,11 @@ function openUrl(url, addToHistory = true, titleHint = "") {
     return;
   }
 
-  if (isIframeBlockedHost(safe) || isLikelyFrameDeniedHost(safe)) {
-    const handled = isIframeBlockedHost(safe) ? tryInternalSearchFromBlockedUrl(safe) : false;
-    if (!handled) {
-      const opened = window.open(safe, '_blank', 'noopener,noreferrer');
-      if (!opened) window.location.href = safe;
-      showOpenHint('Bu site güvenlik nedeniyle gömülü açılamıyor. Yeni sekmede açıldı.');
-      showHome();
-    }
+  if (isLikelyFrameDeniedHost(safe)) {
+    const opened = window.open(safe, '_blank', 'noopener,noreferrer');
+    if (!opened) window.location.href = safe;
+    showOpenHint('Bu site güvenlik nedeniyle gömülü açılamıyor. Yeni sekmede açıldı.');
+    showHome();
     renderTabs();
     return;
   }

--- a/script.js
+++ b/script.js
@@ -7,6 +7,22 @@ const state = {
   thinkingTicker: null,
   agentModeActive: false,
   agentBusy: false,
+  customizeMode: false,
+  dragTabId: null,
+  theme: JSON.parse(localStorage.getItem("balukTheme") || "null"),
+};
+
+const THEME_COLORS = {
+  "mavi": "#3498ff", "kırmızı": "#ff3b4f", "yesil": "#29b35f", "yeşil": "#29b35f", "sarı": "#ffd84c", "turuncu": "#ff8b2b", "mor": "#8d45ff", "pembe": "#ff6bc9", "siyah": "#0b0b10", "beyaz": "#f5f7ff", "gri": "#8f96a8", "lacivert": "#1a2f7a", "bordo": "#6c1d31", "kahverengi": "#6a4935", "bej": "#d8c3a5", "krem": "#f4e9d4",
+  "bebek mavisi": "#9fd7ff", "gök mavisi": "#65b8ff", "buz mavisi": "#b7e6ff", "deniz mavisi": "#2e8bbd", "okyanus mavisi": "#245f99", "saks mavisi": "#2f52d6", "kobalt mavisi": "#3d59d8", "çelik mavisi": "#5b7a9b", "petrol mavisi": "#0f4f63", "turkuaz": "#23c5c8", "camgöbeği": "#00b7b7", "akuamarin": "#6ad5c2", "buzul mavisi": "#8fd6f1", "gece mavisi": "#1a2a5e", "kraliyet mavisi": "#3553d8", "indigo": "#3f2f9a",
+  "mint yeşili": "#9ff7cb", "nane yeşili": "#89e3b3", "çağla yeşili": "#b8d67a", "fıstık yeşili": "#95c867", "zümrüt yeşili": "#13a86b", "orman yeşili": "#17663a", "çam yeşili": "#1f5b3d", "zeytin yeşili": "#687c39", "haki": "#7a7b47", "avokado yeşili": "#70a95d", "su yeşili": "#5ecab6", "deniz köpüğü": "#9ee8d5", "yeşim yeşili": "#00a86b", "nefti": "#4f7942", "çimen yeşili": "#5ab84d",
+  "lila": "#b38cff", "leylak": "#c8a7ff", "lavanta": "#c3b1ff", "menekşe": "#8f5add", "eflatun": "#c154c1", "erguvan": "#9d3f7a", "mürdüm": "#6d1f68", "patlıcan moru": "#4b2042", "ametist": "#9966cc", "orkide moru": "#b86fd9", "fuşya": "#d946ef", "magenta": "#ff00aa", "gece moru": "#2d184f", "dumanlı mor": "#6f5e82",
+  "pudra pembesi": "#f4c7d5", "şeker pembesi": "#ff8ecf", "gül pembesi": "#f07aaf", "bebe pembe": "#ffb7d8", "pastel pembe": "#f7b8cf", "somon pembe": "#ff8b82", "nar pembesi": "#d95a80", "toz pembe": "#d9a0b3", "gül kurusu": "#b76e79",
+  "nar çiçeği": "#f04a4a", "gül kırmızısı": "#c72c48", "karmen": "#9f1d35", "yakut kırmızısı": "#9b111e", "ateş kırmızısı": "#ff3f34", "vişne çürüğü": "#5c1a2e", "şarap kırmızısı": "#722f37", "kiremit": "#b24f3e", "tuğla kırmızısı": "#aa4a44", "mercan": "#ff6f61",
+  "şeftali": "#ffb58a", "kayısı rengi": "#f4a460", "mandalina": "#ff9f1a", "yavruağzı": "#ffad8a", "balkabağı": "#ff7518", "bakır turuncu": "#b87333", "pas turuncusu": "#c5683a", "gün batımı turuncusu": "#ff7e48", "altın turuncu": "#ffb347", "mercan turuncusu": "#ff7f50",
+  "limon sarısı": "#fff44f", "altın sarısı": "#ffcf33", "bal sarısı": "#f5b942", "hardal sarısı": "#d9a520", "safran": "#f4c430", "kanarya sarısı": "#ffe94d", "pastel sarı": "#fff4a3", "kum sarısı": "#e4c57a", "güneş sarısı": "#ffd447", "kehribar": "#ffbf00",
+  "fildişi": "#fffff0", "ekru": "#f3ecd3", "kum beji": "#d8c8a5", "taş rengi": "#b7a899", "vizon": "#9c8b75", "camel": "#c19a6b", "sütlü kahve": "#a67c52", "karamel": "#b97745", "gümüş gri": "#c0c0c0", "antrasit": "#32343c", "füme": "#6b6f76", "kömür grisi": "#3b3f46", "duman grisi": "#9ca3af", "inci beyazı": "#f8f6f0",
+  "ay ışığı": "#dde7ff", "derin deniz": "#123f63", "kutup mavisi": "#84d1ff", "buz kristali": "#d7f3ff", "lavanta sisi": "#c8b6ff", "dumanlı gül": "#c08a95", "kum fırtınası": "#c7b089", "çöl beji": "#d9bf8f", "zeytin taşı": "#7d7f54", "orman sisi": "#5f7b64", "ay taşı": "#d6d6e8", "inci gri": "#d9dde4", "gölgeli lila": "#9e8bb8", "bulut grisi": "#cfd4db", "gün doğumu pembesi": "#ffc3c8", "kuzey ışığı yeşili": "#58e6a9"
 };
 
 const THINKING_LINES = [
@@ -101,11 +117,21 @@ const el = {
   plusBtn: document.getElementById("plusBtn"),
   agentMenu: document.getElementById("agentMenu"),
   agentModeBtn: document.getElementById("agentModeBtn"),
+  themeModeBtn: document.getElementById("themeModeBtn"),
   agentBadge: document.getElementById("agentBadge"),
   agentBadgeClose: document.getElementById("agentBadgeClose"),
   quickPrompts: document.getElementById("quickPrompts"),
   introOverlay: document.getElementById("introOverlay"),
   appShell: document.getElementById("appShell"),
+  customizeBtn: document.getElementById("customizeBtn"),
+  customizePanel: document.getElementById("customizePanel"),
+  closeCustomizeBtn: document.getElementById("closeCustomizeBtn"),
+  themeColorSelect: document.getElementById("themeColorSelect"),
+  fontStyleSelect: document.getElementById("fontStyleSelect"),
+  cursorShapeSelect: document.getElementById("cursorShapeSelect"),
+  cursorSizeRange: document.getElementById("cursorSizeRange"),
+  saveCustomizeBtn: document.getElementById("saveCustomizeBtn"),
+  advancedEditBtn: document.getElementById("advancedEditBtn"),
 };
 
 
@@ -127,6 +153,90 @@ const agentCursor = document.createElement("div");
 agentCursor.id = "agentCursor";
 agentCursor.style.cssText = "position:fixed;width:18px;height:18px;border:2px solid #b78cff;background:radial-gradient(circle,#6b24dd 0%,#141020 75%);border-radius:50%;box-shadow:0 0 18px rgba(141,69,255,.85);z-index:9999;pointer-events:none;opacity:0;transform:translate(-50%,-50%);transition:left .25s ease, top .25s ease, opacity .15s ease;";
 document.body.appendChild(agentCursor);
+
+function getAccentForTheme(themeName = "mor") {
+  const key = normalize(themeName);
+  return THEME_COLORS[key] || "#8d45ff";
+}
+
+function setCursorStyle(shape = "circle", size = 18, color = "#8d45ff") {
+  const px = `${Math.max(14, Math.min(42, Number(size) || 18))}px`;
+  agentCursor.style.width = px;
+  agentCursor.style.height = px;
+  agentCursor.style.borderColor = color;
+  agentCursor.style.boxShadow = `0 0 18px ${color}`;
+  if (shape === "square") {
+    agentCursor.style.borderRadius = "4px";
+    agentCursor.style.transform = "translate(-50%,-50%)";
+  } else if (shape === "diamond") {
+    agentCursor.style.borderRadius = "2px";
+    agentCursor.style.transform = "translate(-50%,-50%) rotate(45deg)";
+  } else {
+    agentCursor.style.borderRadius = "50%";
+    agentCursor.style.transform = "translate(-50%,-50%)";
+  }
+}
+
+function setCustomizeMode(open) {
+  state.customizeMode = open;
+  el.customizePanel.classList.toggle("hidden", !open);
+}
+
+function applyTheme(theme) {
+  if (!theme) return;
+  const accent = getAccentForTheme(theme.colorName);
+  document.documentElement.style.setProperty("--glow-purple", accent);
+  document.documentElement.style.setProperty("--soft-border", `${accent}55`);
+  document.documentElement.style.setProperty("--theme-font", theme.font || "Inter, Arial, sans-serif");
+  document.body.style.cursor = "default";
+  setCursorStyle(theme.cursorShape, theme.cursorSize, accent);
+}
+
+function initThemeOptions() {
+  if (!el.themeColorSelect) return;
+  const names = Object.keys(THEME_COLORS).sort((a, b) => a.localeCompare(b, "tr"));
+  el.themeColorSelect.innerHTML = names.map((n) => `<option value="${escapeHtml(n)}">${escapeHtml(n)}</option>`).join("");
+
+  const existing = state.theme || { colorName: "mor", font: "Inter, Arial, sans-serif", cursorShape: "circle", cursorSize: 18 };
+  state.theme = existing;
+  el.themeColorSelect.value = existing.colorName;
+  el.fontStyleSelect.value = existing.font;
+  el.cursorShapeSelect.value = existing.cursorShape;
+  el.cursorSizeRange.value = String(existing.cursorSize);
+  applyTheme(existing);
+}
+
+async function runThemeAnimation(colorName) {
+  const accent = getAccentForTheme(colorName);
+  const layer = document.createElement("div");
+  layer.className = "theme-anim-layer";
+  const status = document.createElement("div");
+  status.className = "theme-anim-status";
+  status.textContent = "Baluk.ai: Kişiselleştirme moduna bağlanıyorum...";
+  layer.appendChild(status);
+
+  for (let i = 0; i < 16; i += 1) {
+    const b = document.createElement("span");
+    b.className = "theme-ball";
+    b.style.setProperty("--c", accent);
+    b.style.left = `${Math.random() * 90 + 5}%`;
+    b.style.top = `${Math.random() * 90 + 5}%`;
+    b.style.animationDelay = `${Math.random() * 1.8}s`;
+    layer.appendChild(b);
+  }
+
+  document.body.appendChild(layer);
+  startThinking([
+    "Baluk.ai uygulamasına bağlanıyorum...",
+    "Tema motorunu hazırlıyorum...",
+    `${colorName} rengini enerji kürelerinde birleştiriyorum...`,
+    "Animasyon tamamlanıyor, tema ayarlanıyor...",
+  ]);
+
+  await sleep(5500);
+  stopThinking();
+  layer.remove();
+}
 
 function currentTab() { return state.tabs.find((t) => t.id === state.activeTabId); }
 function escapeHtml(text = "") { return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#039;"); }
@@ -196,6 +306,7 @@ function renderTabs() {
   state.tabs.forEach((tab) => {
     const b = document.createElement("button");
     b.className = `tab-item ${tab.id === state.activeTabId ? "active" : ""}`;
+    b.draggable = true;
     b.dataset.tabId = String(tab.id);
     b.innerHTML = `<span>${escapeHtml(tab.title)}</span><span class="tab-close" data-close="${tab.id}">✕</span>`;
     b.addEventListener("click", (e) => {
@@ -203,8 +314,31 @@ function renderTabs() {
       if (close) return closeTab(Number(close.dataset.close));
       switchTab(tab.id);
     });
+    b.addEventListener("dragstart", () => {
+      state.dragTabId = tab.id;
+      b.classList.add("dragging");
+    });
+    b.addEventListener("dragend", () => {
+      state.dragTabId = null;
+      b.classList.remove("dragging");
+    });
+    b.addEventListener("dragover", (e) => e.preventDefault());
+    b.addEventListener("drop", (e) => {
+      e.preventDefault();
+      reorderTab(state.dragTabId, tab.id);
+    });
     el.tabs.appendChild(b);
   });
+}
+
+function reorderTab(fromId, toId) {
+  if (!fromId || !toId || fromId === toId) return;
+  const fromIdx = state.tabs.findIndex((t) => t.id === fromId);
+  const toIdx = state.tabs.findIndex((t) => t.id === toId);
+  if (fromIdx < 0 || toIdx < 0) return;
+  const [moved] = state.tabs.splice(fromIdx, 1);
+  state.tabs.splice(toIdx, 0, moved);
+  renderTabs();
 }
 
 function showHome() {
@@ -509,7 +643,7 @@ function stopThinking() {
 function setAgentMode(on) {
   state.agentModeActive = on;
   el.agentBadge.classList.toggle("hidden", !on);
-  el.agentModeBtn.textContent = on ? "Agent Mode 2.0 (Açık)" : "Agent Mode 2.0";
+  el.agentModeBtn.innerHTML = on ? 'Agent Mode 3.0 (Açık) <span class="new-pill">NEW</span>' : 'Agent Mode 3.0 <span class="new-pill">NEW</span>';
 }
 
 function parseSearchCommand(q) {
@@ -521,6 +655,30 @@ function parseSearchCommand(q) {
   const query = (m4?.[1] || m1?.[1] || m2?.[1] || m3?.[1] || "").trim();
   const n = Number((t.match(/(\d+)\.?\s*link/) || [])[1] || m4?.[2] || 1);
   return { query, linkIndex: Math.max(1, n || 1) };
+}
+
+function detectThemeColorFromText(text) {
+  const q = normalize(text);
+  let found = null;
+  for (const name of Object.keys(THEME_COLORS)) {
+    if (q.includes(normalize(name))) {
+      if (!found || name.length > found.length) found = name;
+    }
+  }
+  return found;
+}
+
+function saveThemeFromUi() {
+  const theme = {
+    colorName: el.themeColorSelect.value,
+    font: el.fontStyleSelect.value,
+    cursorShape: el.cursorShapeSelect.value,
+    cursorSize: Number(el.cursorSizeRange.value || 18),
+  };
+  state.theme = theme;
+  localStorage.setItem("balukTheme", JSON.stringify(theme));
+  applyTheme(theme);
+  return theme;
 }
 
 function moveCursorTo(element) {
@@ -613,6 +771,39 @@ async function runAgentTask(q) {
   try {
     const low = normalize(q);
 
+    const themeColor = detectThemeColorFromText(q);
+    if ((/tema|renk|rengi|kişiselleştir|kisisellestir|tarayıcı rengimi|tarayici rengimi/.test(low)) && themeColor) {
+      await runThemeAnimation(themeColor);
+      if (el.themeColorSelect) el.themeColorSelect.value = themeColor;
+      const theme = saveThemeFromUi();
+      return `Şunu istedin: tema ${highlight(themeColor)}. Şunu yaptım: tema rengini ${highlight(theme.colorName)} olarak ayarladım.`;
+    }
+
+    if (/yazı stili|font/.test(low)) {
+      if (low.includes("klasik")) el.fontStyleSelect.value = "'Georgia', serif";
+      else if (low.includes("poppins")) el.fontStyleSelect.value = "'Poppins', 'Segoe UI', sans-serif";
+      else if (low.includes("dengeli")) el.fontStyleSelect.value = "'Trebuchet MS', Arial, sans-serif";
+      else el.fontStyleSelect.value = "Inter, Arial, sans-serif";
+      const theme = saveThemeFromUi();
+      return `Yazı stilini güncelledim: ${highlight(theme.font)}.`;
+    }
+
+    if (/imlec|cursor/.test(low)) {
+      if (low.includes("kare")) el.cursorShapeSelect.value = "square";
+      else if (low.includes("elmas")) el.cursorShapeSelect.value = "diamond";
+      else el.cursorShapeSelect.value = "circle";
+      const sizeMatch = low.match(/(\d{2})/);
+      if (sizeMatch) el.cursorSizeRange.value = String(Math.max(14, Math.min(42, Number(sizeMatch[1]))));
+      saveThemeFromUi();
+      return "İmleç şeklini/boyutunu güncelledim.";
+    }
+
+    if (/sekmeleri soldan saga diz|sekmeleri soldan sağa diz|sekmeleri ters cevir|sekmeleri ters çevir/.test(low)) {
+      state.tabs.reverse();
+      renderTabs();
+      return "Sekmelerin sırasını değiştirdim.";
+    }
+
     if (low.includes("geri")) { await clickElement(el.geriBtn); return "Şunu istedin: geri. Şunu yaptım: geri gittim."; }
     if (low.includes("ileri")) { await clickElement(el.ileriBtn); return "Şunu istedin: ileri. Şunu yaptım: ileri gittim."; }
     if (low.includes("yenile")) { await clickElement(el.yenileBtn); return "Şunu istedin: yenile. Şunu yaptım: sayfayı yeniledim."; }
@@ -676,7 +867,7 @@ async function runAgentTask(q) {
       return `Şunu istedin: ${escapeHtml(parsed.query)}. Şunu yaptım: ${parsed.linkIndex}. linke girdim.`;
     }
 
-    return "Agent Mode 2.0 komutu anlaşılamadı.";
+    return "Agent Mode 3.0 komutu anlaşılamadı.";
   } finally {
     state.agentBusy = false;
     agentCursor.style.opacity = "0";
@@ -685,8 +876,12 @@ async function runAgentTask(q) {
 
 async function answerNormal(q) {
   const low = normalize(q);
+  const themeColor = detectThemeColorFromText(q);
+  if (themeColor && /(tema|renk|tarayıcı|tarayici|kişiselleştir|kisisellestir)/.test(low)) {
+    return `Bunu direkt yapmam için ${highlight("Agent Mode 3.0")} açabilirsin veya 🖌 kişiselleştirme butonundan ${highlight(themeColor)} seçebilirsin.`;
+  }
   if (/(geri|ileri|yenile|yeni sekme|kapat)/.test(low)) {
-    return `Bunu otomatik yapmam için ${highlight("Agent Mode 2.0")} aç.`;
+    return `Bunu otomatik yapmam için ${highlight("Agent Mode 3.0")} aç.`;
   }
 
   if (/(merhaba|selam|hey|günaydın|iyi akşamlar)/.test(low)) {
@@ -794,6 +989,7 @@ function initPrompts() {
     { text: "YouTube'un amacı nedir?", agent: false },
     { text: "shopify arat 1. linke tıkla", agent: true },
     { text: "10 yeni sekme aç", agent: true },
+    { text: "tarayıcı temamı gece mavisi yap", agent: true },
   ];
 
   prompts.forEach((p) => {
@@ -854,7 +1050,25 @@ el.agentModeBtn.addEventListener("click", () => {
   setAgentMode(!state.agentModeActive);
   el.agentMenu.classList.add("hidden");
 });
+el.themeModeBtn.addEventListener("click", () => {
+  setCustomizeMode(true);
+  el.agentMenu.classList.add("hidden");
+});
 el.agentBadgeClose.addEventListener("click", () => setAgentMode(false));
+el.customizeBtn.addEventListener("click", () => setCustomizeMode(!state.customizeMode));
+el.closeCustomizeBtn.addEventListener("click", () => setCustomizeMode(false));
+el.saveCustomizeBtn.addEventListener("click", async () => {
+  const selectedColor = el.themeColorSelect.value;
+  await runThemeAnimation(selectedColor);
+  saveThemeFromUi();
+});
+el.advancedEditBtn.addEventListener("click", () => {
+  setAgentMode(true);
+  setCustomizeMode(false);
+  setPanel(true);
+  el.aiSoru.value = "agent mode 3.0 ile gelişmiş düzenleme başlat";
+  el.aiCevap.innerHTML = "Gelişmiş düzenleme için Agent Mode 3.0 açık. Konum/boyut komutu verebilirsin.";
+});
 
 el.loginForm.addEventListener("submit", (e) => {
   e.preventDefault();
@@ -912,5 +1126,6 @@ el.aiSoru.addEventListener("keydown", (e) => {
 renderTabs();
 renderAuth();
 initPrompts();
+initThemeOptions();
 setPanel(false);
 runIntro();

--- a/script.js
+++ b/script.js
@@ -367,6 +367,32 @@ function isIframeBlockedHost(url) {
   }
 }
 
+function isLikelyFrameDeniedHost(url) {
+  try {
+    const host = new URL(url).hostname.replace(/^www\./, '');
+    return [
+      'youtube.com',
+      'youtu.be',
+      'shopify.com',
+      'accounts.google.com',
+      'instagram.com',
+      'x.com',
+      'twitter.com',
+      'facebook.com',
+      'tiktok.com',
+      'linkedin.com',
+    ].some((h) => host === h || host.endsWith(`.${h}`));
+  } catch {
+    return false;
+  }
+}
+
+function getEmbeddableUrl(url) {
+  if (!isLikelyFrameDeniedHost(url)) return url;
+  const stripped = url.replace(/^https?:\/\//i, '');
+  return `https://r.jina.ai/http://${stripped}`;
+}
+
 function showOpenHint(message) {
   const hint = document.createElement('div');
   hint.className = 'searching-status';
@@ -497,10 +523,15 @@ function showHome() {
 function syncTabView() {
   const tab = currentTab();
   if (!tab || !tab.url) return showHome();
+  const viewUrl = getEmbeddableUrl(tab.url);
   el.adresCubugu.value = tab.url;
-  el.siteFrame.src = tab.url;
+  el.siteFrame.src = viewUrl;
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
+
+  if (viewUrl !== tab.url) {
+    showOpenHint('Bu site iframe korumalı. Baluk Screatch içinde görüntü modu (web özeti) açıldı.');
+  }
 }
 
 function setTabTitle(tab, title) {

--- a/script.js
+++ b/script.js
@@ -587,11 +587,16 @@ function showHome() {
 function syncTabView() {
   const tab = currentTab();
   if (!tab || !tab.url) return showHome();
+  const viewUrl = getEmbeddableUrl(tab.url);
   el.adresCubugu.value = tab.url;
   el.siteFrame.srcdoc = '';
-  el.siteFrame.src = tab.url;
+  el.siteFrame.src = viewUrl;
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
+
+  if (viewUrl !== tab.url) {
+    showOpenHint('Bu site Baluk Screatch içinde güvenli görüntü modunda açıldı.');
+  }
 }
 
 function setTabTitle(tab, title) {
@@ -641,12 +646,11 @@ function openUrl(url, addToHistory = true, titleHint = "") {
 
   if (isSearchEngineHost(safe)) {
     const handled = tryInternalSearchFromBlockedUrl(safe);
-    renderTabs();
-    if (!handled) {
-      showHome();
-      showOpenHint('Arama motoru bağlantısı içe aktarılamadı. Lütfen Baluk Screatch arama kutusuna sorguyu yaz.');
+    if (handled) {
+      renderTabs();
+      return;
     }
-    return;
+    // query yakalanamadıysa yine uygulama içinde güvenli görüntüye düş
   }
 
   if (isTouchLikeDevice()) {
@@ -654,15 +658,6 @@ function openUrl(url, addToHistory = true, titleHint = "") {
     if (!opened) window.location.href = safe;
     renderTabs();
     showHome();
-    return;
-  }
-
-  if (isLikelyFrameDeniedHost(safe)) {
-    const opened = window.open(safe, '_blank', 'noopener,noreferrer');
-    if (!opened) window.location.href = safe;
-    showOpenHint('Bu site güvenlik nedeniyle gömülü açılamıyor. Yeni sekmede açıldı.');
-    showHome();
-    renderTabs();
     return;
   }
 

--- a/script.js
+++ b/script.js
@@ -413,6 +413,65 @@ function setFrameDoc(title, body) {
   el.siteFrame.srcdoc = `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><style>body{margin:0;font-family:Inter,Arial,sans-serif;background:#070b18;color:#e9ecff;padding:26px} .card{max-width:980px;margin:0 auto;background:#0f1634;border:1px solid #2c3f7a;border-radius:14px;padding:18px} h2{margin:0 0 8px} p{line-height:1.55;color:#cfd6ff;white-space:pre-wrap} a{display:inline-block;margin-top:10px;padding:10px 14px;border-radius:10px;text-decoration:none;background:#2a4ea8;color:#fff}</style></head><body><div class="card"><h2>${title}</h2><p>${body}</p></div></body></html>`;
 }
 
+async function renderDuckDuckGoInApp(duckUrl) {
+  let query = "";
+  try {
+    const u = new URL(duckUrl);
+    query = (u.searchParams.get("q") || "").trim();
+  } catch {
+    query = "";
+  }
+
+  const staged = state.stagedOpen;
+  const results = query ? await getSearchResults(query) : [];
+  const safeResults = results.length ? results : buildFallbackResults(query || "arama");
+  const target = staged?.targetUrl || "";
+
+  const listHtml = safeResults.slice(0, 10).map((item, i) => {
+    const title = escapeForHtml(item.title || `Sonuç ${i + 1}`);
+    const link = ensureUrl(item.href || item.link || "");
+    const snippet = escapeForHtml(item.snippet || item.description || "Açıklama yok");
+    const highlighted = target && link === target;
+    return `<article class="res ${highlighted ? "hl" : ""}">
+      <a class="res-link" href="#" data-url="${escapeForHtml(link)}" data-title="${title}">${title}</a>
+      <p>${snippet}</p>
+      <small>${escapeForHtml(link)}</small>
+    </article>`;
+  }).join("");
+
+  el.siteFrame.removeAttribute("src");
+  el.siteFrame.srcdoc = `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><style>
+  body{margin:0;background:#070b18;color:#eaf0ff;font-family:Inter,Arial,sans-serif;padding:20px}
+  .wrap{max-width:1080px;margin:0 auto}
+  .head{padding:14px 16px;border:1px solid #2f4cc8;background:linear-gradient(135deg,#122258,#0b1440);border-radius:12px;margin-bottom:12px}
+  .head h2{margin:0;font-size:1.2rem}
+  .head p{margin:.45rem 0 0;color:#c8d5ff}
+  .res{border:1px solid #283a75;background:#0c1433;border-radius:12px;padding:12px 14px;margin:10px 0}
+  .res.hl{border-color:#7aa2ff;box-shadow:0 0 0 1px rgba(122,162,255,.55) inset}
+  .res-link{color:#9ec2ff;font-weight:700;text-decoration:none}
+  .res-link:hover{text-decoration:underline}
+  .res p{margin:.5rem 0;color:#d6e1ff;line-height:1.45}
+  .res small{color:#95a9df;word-break:break-all}
+  </style></head><body><div class="wrap">
+  <div class="head"><h2>DuckDuckGo — Baluk Screatch içinde</h2><p>Arama: ${escapeForHtml(query || "—")} · Sonuçlardan birine tıkla, site yine Baluk Screatch içinde açılsın.</p></div>
+  ${listHtml}
+  </div></body></html>`;
+
+  const bindClicks = () => {
+    const doc = el.siteFrame.contentDocument;
+    if (!doc) return;
+    doc.querySelectorAll(".res-link").forEach((a) => {
+      a.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        const href = a.getAttribute("data-url") || "";
+        const title = a.getAttribute("data-title") || "";
+        openUrl(href, true, title);
+      });
+    });
+  };
+  setTimeout(bindClicks, 40);
+}
+
 async function renderProtectedSiteView(originalUrl) {
   const title = 'Bu site iframe korumalı (Baluk Screatch Görüntü Modu)';
   setFrameDoc(title, `Site: ${escapeForHtml(originalUrl)}
@@ -650,6 +709,12 @@ function syncTabView() {
   el.adresCubugu.value = tab.url;
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
+
+  if (/^https?:\/\/(www\.)?duckduckgo\.com\/\?/.test(tab.url)) {
+    renderDuckDuckGoInApp(tab.url);
+    updateStagedOverlay();
+    return;
+  }
 
   if (isLikelyFrameDeniedHost(tab.url)) {
     renderProtectedSiteView(tab.url);

--- a/script.js
+++ b/script.js
@@ -1,97 +1,797 @@
-window.onload = () => {
-  const k = localStorage.getItem("kullaniciAdi");
-  const p = localStorage.getItem("profilResmi");
+const state = {
+  tabs: [{ id: 1, title: "Yeni Sekme", url: "", history: [], index: -1 }],
+  activeTabId: 1,
+  nextTabId: 2,
+  user: JSON.parse(localStorage.getItem("balukUser") || "null"),
+  thinkingTimer: null,
+  thinkingTicker: null,
+  agentModeActive: false,
+  agentBusy: false,
+};
 
-  if (k && p) {
-    document.getElementById("girisEkrani").style.display = "none";
-    document.getElementById("anaEkran").classList.remove("gizli");
-    document.getElementById("kAdi").innerText = k;
-    document.getElementById("profilGorsel").src = p;
-    videolariYukle();
+const THINKING_LINES = [
+  "Baluk.ai ağına bağlanılıyor...",
+  "Ekranındaki sayfayı satır satır tarıyorum...",
+  "Web + Wikipedia kaynaklarını birleştiriyorum...",
+  "Doğrulayıp net cevabı hazırlıyorum..."
+];
+const SITE_KNOWLEDGE = {
+  "youtube.com": {
+    name: "YouTube",
+    year: "2005",
+    company: "Jawed Karim, Steve Chen ve Chad Hurley tarafından kuruldu; daha sonra Google (Alphabet) tarafından satın alındı.",
+    purpose: "Video izleme, paylaşma ve içerik üreticilerinin yayın yapması için tasarlanmış bir platformdur.",
+    summary: "YouTube, kullanıcıların video yükleyip izleyebildiği, canlı yayın yapabildiği ve içerik ekosistemi oluşturabildiği küresel bir video platformudur."
+  },
+  "google.com": {
+    name: "Google",
+    year: "1998",
+    company: "Larry Page ve Sergey Brin tarafından kuruldu.",
+    purpose: "Web üzerinde bilgiye hızlı erişim sağlayan arama motoru ve internet servisleri sunmak.",
+    summary: "Google, arama motoru merkezli başlayan ve e-posta, haritalar, bulut, reklam gibi alanlarda büyüyen bir teknoloji platformudur."
+  },
+  "wikipedia.org": {
+    name: "Wikipedia",
+    year: "2001",
+    company: "Jimmy Wales ve Larry Sanger tarafından başlatıldı; Wikimedia Foundation tarafından yönetilir.",
+    purpose: "Özgür ve ortaklaşa düzenlenen ansiklopedi içeriği sunmak.",
+    summary: "Wikipedia, gönüllüler tarafından düzenlenen çok dilli, açık lisanslı bir çevrimiçi ansiklopedidir."
+  },
+  "github.com": {
+    name: "GitHub",
+    year: "2008",
+    company: "Tom Preston-Werner, Chris Wanstrath, PJ Hyett ve Scott Chacon tarafından kuruldu; Microsoft bünyesindedir.",
+    purpose: "Yazılım projeleri için Git tabanlı kod barındırma ve iş birliği sağlamak.",
+    summary: "GitHub, geliştiricilerin kod depoladığı, sürüm takip ettiği ve ekip olarak yazılım geliştirdiği bir platformdur."
+  },
+  "instagram.com": {
+    name: "Instagram",
+    year: "2010",
+    company: "Kevin Systrom ve Mike Krieger tarafından kuruldu; Meta bünyesindedir.",
+    purpose: "Fotoğraf ve video paylaşımı ile sosyal etkileşim sağlamak.",
+    summary: "Instagram, görsel odaklı paylaşım, hikaye/reels formatları ve sosyal etkileşim özellikleri sunan bir platformdur."
+  },
+  "shopify.com": {
+    name: "Shopify",
+    year: "2006",
+    company: "Tobias Lütke, Daniel Weinand ve Scott Lake tarafından kuruldu.",
+    purpose: "İşletmelerin çevrimiçi mağaza kurup yönetmesini sağlamak.",
+    summary: "Shopify, e-ticaret sitesi kurma, ödeme alma ve sipariş yönetimi gibi süreçleri tek panelde sunan bir altyapıdır."
   }
 };
 
-function girisYap() {
-  const k = document.getElementById("kullaniciAdi").value.trim();
-  const p = document.getElementById("profilResmi").files[0];
 
-  if (!k || !p) {
-    alert("Ad ve profil resmi gerekli kaptan!");
-    return;
+const el = {
+  tabs: document.getElementById("tabs"),
+  addTabBtn: document.getElementById("addTabBtn"),
+  contentGrid: document.getElementById("contentGrid"),
+  aramaForm: document.getElementById("aramaForm"),
+  aramaInput: document.getElementById("aramaInput"),
+  sonuclar: document.getElementById("sonuclar"),
+  homeView: document.getElementById("homeView"),
+  webView: document.getElementById("webView"),
+  siteFrame: document.getElementById("siteFrame"),
+  adresCubugu: document.getElementById("adresCubugu"),
+  geriBtn: document.getElementById("geriBtn"),
+  ileriBtn: document.getElementById("ileriBtn"),
+  yenileBtn: document.getElementById("yenileBtn"),
+  newTabBtn: document.getElementById("newTabBtn"),
+  balukPanelBtn: document.getElementById("balukPanelBtn"),
+  aiPanel: document.getElementById("aiPanel"),
+  closePanelBtn: document.getElementById("closePanelBtn"),
+  loginForm: document.getElementById("loginForm"),
+  authArea: document.getElementById("authArea"),
+  assistantArea: document.getElementById("assistantArea"),
+  welcomeText: document.getElementById("welcomeText"),
+  profileMail: document.getElementById("profileMail"),
+  profileAvatar: document.getElementById("profileAvatar"),
+  aiForm: document.getElementById("aiForm"),
+  aiSoru: document.getElementById("aiSoru"),
+  thinkingBox: document.getElementById("thinkingBox"),
+  thinkingText: document.getElementById("thinkingText"),
+  spinLogo: document.getElementById("spinLogo"),
+  aiCevap: document.getElementById("aiCevap"),
+  plusBtn: document.getElementById("plusBtn"),
+  agentMenu: document.getElementById("agentMenu"),
+  agentModeBtn: document.getElementById("agentModeBtn"),
+  agentBadge: document.getElementById("agentBadge"),
+  agentBadgeClose: document.getElementById("agentBadgeClose"),
+  quickPrompts: document.getElementById("quickPrompts"),
+  introOverlay: document.getElementById("introOverlay"),
+  appShell: document.getElementById("appShell"),
+};
+
+
+
+function forceRevealApp() {
+  if (el.introOverlay) el.introOverlay.classList.add("hidden");
+  if (el.appShell) {
+    el.appShell.classList.remove("app-hidden");
+    el.appShell.style.pointerEvents = "auto";
   }
+}
 
-  const reader = new FileReader();
-  reader.onload = () => {
-    localStorage.setItem("kullaniciAdi", k);
-    localStorage.setItem("profilResmi", reader.result);
-    location.reload();
+window.addEventListener("load", () => {
+  setTimeout(forceRevealApp, 1200);
+});
+setTimeout(forceRevealApp, 9000);
+
+const agentCursor = document.createElement("div");
+agentCursor.id = "agentCursor";
+agentCursor.style.cssText = "position:fixed;width:18px;height:18px;border:2px solid #b78cff;background:radial-gradient(circle,#6b24dd 0%,#141020 75%);border-radius:50%;box-shadow:0 0 18px rgba(141,69,255,.85);z-index:9999;pointer-events:none;opacity:0;transform:translate(-50%,-50%);transition:left .25s ease, top .25s ease, opacity .15s ease;";
+document.body.appendChild(agentCursor);
+
+function currentTab() { return state.tabs.find((t) => t.id === state.activeTabId); }
+function escapeHtml(text = "") { return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#039;"); }
+function ensureUrl(value) { return /^https?:\/\//i.test(value) ? value : `https://${value}`; }
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+function highlight(v) { return `<span class="hl">${escapeHtml(v)}</span>`; }
+function normalize(s = "") { return s.toLowerCase().trim(); }
+
+function playIntroSound() {
+  try {
+    const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    const o = audioCtx.createOscillator();
+    const g = audioCtx.createGain();
+    o.type = "triangle";
+    o.frequency.setValueAtTime(180, audioCtx.currentTime);
+    o.frequency.exponentialRampToValueAtTime(520, audioCtx.currentTime + 0.32);
+    g.gain.setValueAtTime(0.0001, audioCtx.currentTime);
+    g.gain.exponentialRampToValueAtTime(0.2, audioCtx.currentTime + 0.12);
+    g.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + 0.82);
+    o.connect(g); g.connect(audioCtx.destination); o.start(); o.stop(audioCtx.currentTime + 0.85);
+    o.onended = () => audioCtx.close();
+  } catch {}
+}
+
+function runIntro() {
+  let revealed = false;
+
+  const revealApp = () => {
+    if (revealed) return;
+    revealed = true;
+    forceRevealApp();
   };
-  reader.readAsDataURL(p);
-}
 
-function goAnaSayfa() {
-  document.getElementById("hesabim").classList.add("gizli");
-  document.getElementById("anaSayfa").style.display = "block";
-}
-
-function goHesabim() {
-  document.getElementById("anaSayfa").style.display = "none";
-  document.getElementById("hesabim").classList.remove("gizli");
-}
-
-function videoYukle() {
-  const dosya = document.getElementById("videoDosyasi").files[0];
-  const baslik = document.getElementById("videoBaslik").value;
-  const kullanici = localStorage.getItem("kullaniciAdi");
-
-  if (!dosya || !baslik) {
-    alert("Video ve başlık eksik!");
+  if (!el.appShell || !el.introOverlay) {
+    revealApp();
     return;
   }
 
-  const videoURL = URL.createObjectURL(dosya);
-  const video = { baslik: baslik, url: videoURL, sahip: kullanici };
+  const reducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches;
+  const introDuration = reducedMotion ? 2350 : 4800;
 
-  const mevcut = JSON.parse(localStorage.getItem("videolar") || "[]");
-  mevcut.push(video);
-  localStorage.setItem("videolar", JSON.stringify(mevcut));
-  videolariYukle();
+  playIntroSound();
 
-  document.getElementById("videoDosyasi").value = "";
-  document.getElementById("videoBaslik").value = "";
+  const finishTimer = setTimeout(revealApp, introDuration);
+  const hardFailSafeTimer = setTimeout(revealApp, introDuration + 2500);
+
+  const skipIntro = () => {
+    clearTimeout(finishTimer);
+    clearTimeout(hardFailSafeTimer);
+    revealApp();
+    window.removeEventListener("keydown", skipIntro);
+    window.removeEventListener("pointerdown", skipIntro);
+  };
+
+  window.addEventListener("keydown", skipIntro, { once: true });
+  window.addEventListener("pointerdown", skipIntro, { once: true });
 }
 
-function videolariYukle() {
-  const videolar = JSON.parse(localStorage.getItem("videolar") || "[]");
-  const liste = document.getElementById("videoListe");
-  const hesap = document.getElementById("videolar");
-  const kullanici = localStorage.getItem("kullaniciAdi");
 
-  liste.innerHTML = "";
-  hesap.innerHTML = "";
+function setPanel(open) {
+  el.aiPanel.classList.toggle("hidden", !open);
+  el.contentGrid.classList.toggle("with-panel", open);
+}
 
-  videolar.forEach((v, i) => {
-    const div = document.createElement("div");
-    div.className = "video";
-    div.innerHTML = `
-      <video src="${v.url}" controls></video>
-      <p>${v.baslik}</p>
-    `;
-    // Ana sayfaya herkesin videoları
-    liste.appendChild(div.cloneNode(true));
-
-    // Sadece kendi videolarına silme butonu
-    if (v.sahip === kullanici) {
-      const divHesap = div.cloneNode(true);
-      const silBtn = document.createElement("button");
-      silBtn.innerText = "❌";
-      silBtn.onclick = () => {
-        videolar.splice(i, 1);
-        localStorage.setItem("videolar", JSON.stringify(videolar));
-        videolariYukle();
-      };
-      divHesap.appendChild(silBtn);
-      hesap.appendChild(divHesap);
-    }
+function renderTabs() {
+  el.tabs.innerHTML = "";
+  state.tabs.forEach((tab) => {
+    const b = document.createElement("button");
+    b.className = `tab-item ${tab.id === state.activeTabId ? "active" : ""}`;
+    b.dataset.tabId = String(tab.id);
+    b.innerHTML = `<span>${escapeHtml(tab.title)}</span><span class="tab-close" data-close="${tab.id}">✕</span>`;
+    b.addEventListener("click", (e) => {
+      const close = e.target.closest(".tab-close");
+      if (close) return closeTab(Number(close.dataset.close));
+      switchTab(tab.id);
+    });
+    el.tabs.appendChild(b);
   });
 }
+
+function showHome() {
+  el.homeView.classList.remove("hidden");
+  el.webView.classList.add("hidden");
+  el.adresCubugu.value = "";
+}
+
+function syncTabView() {
+  const tab = currentTab();
+  if (!tab || !tab.url) return showHome();
+  el.adresCubugu.value = tab.url;
+  el.siteFrame.src = tab.url;
+  el.homeView.classList.add("hidden");
+  el.webView.classList.remove("hidden");
+}
+
+function setTabTitle(tab, title) {
+  tab.title = (title || "Yeni Sekme").slice(0, 22);
+}
+
+function createTab(url = "") {
+  const tab = { id: state.nextTabId++, title: "Yeni Sekme", url: "", history: [], index: -1 };
+  state.tabs.push(tab);
+  state.activeTabId = tab.id;
+  renderTabs();
+  if (url) openUrl(url);
+  else showHome();
+}
+
+function closeTab(id) {
+  if (state.tabs.length === 1) return false;
+  state.tabs = state.tabs.filter((t) => t.id !== id);
+  if (!state.tabs.some((t) => t.id === state.activeTabId)) state.activeTabId = state.tabs[0].id;
+  renderTabs();
+  syncTabView();
+  return true;
+}
+
+function switchTab(id) {
+  state.activeTabId = id;
+  renderTabs();
+  syncTabView();
+}
+
+function openUrl(url, addToHistory = true, titleHint = "") {
+  const safe = ensureUrl(url);
+  const tab = currentTab();
+  if (!tab) return;
+  tab.url = safe;
+  if (titleHint) {
+    setTabTitle(tab, titleHint);
+  } else {
+    try { setTabTitle(tab, new URL(safe).hostname.replace(/^www\./, "")); } catch { setTabTitle(tab, "Yeni Sekme"); }
+  }
+
+  if (addToHistory) {
+    tab.history = tab.history.slice(0, tab.index + 1);
+    tab.history.push(safe);
+    tab.index = tab.history.length - 1;
+  }
+  renderTabs();
+  syncTabView();
+}
+
+function buildFallbackResults(query) {
+  const q = encodeURIComponent(query);
+  return [
+    { title: `${query} - DuckDuckGo`, href: `https://duckduckgo.com/?q=${q}`, snippet: "DuckDuckGo sonuç sayfasını aç." },
+    { title: `${query} - Wikipedia araması`, href: `https://tr.wikipedia.org/wiki/Özel:Arama?search=${q}`, snippet: "Wikipedia içinde ara." },
+    { title: `${query} - Google araması`, href: `https://www.google.com/search?q=${q}`, snippet: "Google sonuç sayfasını aç." },
+  ];
+}
+
+async function getSearchResults(query) {
+  try {
+    const response = await fetch(`https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_redirect=1&no_html=1`);
+    if (!response.ok) return buildFallbackResults(query);
+    const data = await response.json();
+    const parsed = [];
+
+    if (data.AbstractURL) parsed.push({ title: data.Heading || query, href: data.AbstractURL, snippet: data.AbstractText || "Özet bilgi" });
+    (data.RelatedTopics || []).forEach((item) => {
+      if (item.FirstURL && item.Text) parsed.push({ title: item.Text.split(" - ")[0], href: item.FirstURL, snippet: item.Text });
+      (item.Topics || []).forEach((sub) => {
+        if (sub.FirstURL && sub.Text) parsed.push({ title: sub.Text.split(" - ")[0], href: sub.FirstURL, snippet: sub.Text });
+      });
+    });
+
+    return parsed.length ? parsed.slice(0, 8) : buildFallbackResults(query);
+  } catch {
+    return buildFallbackResults(query);
+  }
+}
+
+function renderResults(results, query) {
+  el.sonuclar.innerHTML = "";
+  const safeResults = results.length ? results : buildFallbackResults(query);
+
+  safeResults.forEach((item) => {
+    const card = document.createElement("article");
+    card.className = "result-item";
+    card.innerHTML = `<h3><a href="#">${escapeHtml(item.title)}</a></h3><p>${escapeHtml(item.snippet || "Açıklama yok")}</p><div class="result-actions"><button class="open-link" type="button">Bağlantıyı Aç</button><button class="ask-link" type="button">✦ Baluk.ai'ye Sor</button></div>`;
+    card.querySelector("a").addEventListener("click", (e) => { e.preventDefault(); openUrl(item.href, true, query); });
+    card.querySelector(".open-link").addEventListener("click", () => openUrl(item.href, true, query));
+    card.querySelector(".ask-link").addEventListener("click", () => {
+      setPanel(true);
+      el.aiSoru.value = `${item.title} web sitesi ne işe yarar?`;
+      el.aiForm.requestSubmit();
+    });
+    el.sonuclar.appendChild(card);
+  });
+}
+
+async function fetchWikipediaSnippet(topic) {
+  try {
+    const r = await fetch(`https://tr.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(topic)}`);
+    if (!r.ok) return "";
+    const data = await r.json();
+    return (data.extract || "").trim().slice(0, 200);
+  } catch { return ""; }
+}
+
+
+
+async function fetchWebModeAnswer(query) {
+  const cleaned = query.trim();
+  if (!cleaned) return "";
+
+  const parts = [];
+  try {
+    const ddgResp = await fetch(`https://api.duckduckgo.com/?q=${encodeURIComponent(cleaned)}&format=json&no_redirect=1&no_html=1`);
+    if (ddgResp.ok) {
+      const ddg = await ddgResp.json();
+      if (ddg.AbstractText) parts.push(ddg.AbstractText);
+      const related = (ddg.RelatedTopics || [])
+        .flatMap((item) => item.Topics || [item])
+        .map((item) => item?.Text)
+        .filter(Boolean);
+      if (related.length) parts.push(related.slice(0, 2).join(" "));
+    }
+  } catch {}
+
+  const wiki = await fetchWikipediaSnippet(cleaned);
+  if (wiki) parts.push(wiki);
+
+  const merged = parts.join(" ").replace(/\s+/g, " ").trim();
+  return merged.slice(0, 450);
+}
+
+function getCurrentSiteContext() {
+  const tab = currentTab();
+  const raw = tab?.url || el.adresCubugu.value || "";
+  if (!raw) return null;
+  try {
+    const u = new URL(raw);
+    const host = u.hostname.replace(/^www\./, "");
+    const name = host.split(".")[0] || host;
+    const key = Object.keys(SITE_KNOWLEDGE).find((k) => host.endsWith(k));
+    const known = key ? SITE_KNOWLEDGE[key] : null;
+    return {
+      host,
+      name: known?.name || (name.charAt(0).toUpperCase() + name.slice(1)),
+      url: u.href,
+      year: known?.year || "kesin yıl bilgisi bulunamadı",
+      company: known?.company || "kurucu/şirket bilgisi için resmi Hakkında sayfasına bakılmalı",
+      purpose: known?.purpose || "kullanıcıya bilgi/hizmet sunmak için tasarlanmış bir web platformu",
+      summary: known?.summary || `${name.charAt(0).toUpperCase() + name.slice(1)} için özet bilgi çıkarıldı; detay için resmi kaynaklar incelenmeli.`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getCurrentHost() {
+  const c = getCurrentSiteContext();
+  return c?.host || "";
+}
+
+function genericWebsiteDefinition() {
+  return `${highlight("Web sitesi")}, internet üzerinde çalışan sayfalardan oluşan bir bilgi/hizmet alanıdır. Genelde amacı içerik sunmak, işlem yaptırmak veya kullanıcıyı bir hizmete ulaştırmaktır.`;
+}
+
+function siteHintFromText(text) {
+  const t = normalize(text);
+  return ["youtube", "google", "wikipedia", "github", "instagram", "twitter", "shopify"].find((x) => t.includes(x)) || "web sitesi";
+}
+
+function startThinking(customLines = THINKING_LINES) {
+  el.aiCevap.innerHTML = "";
+  el.thinkingBox.classList.remove("hidden");
+  el.spinLogo.classList.add("active");
+  document.body.classList.add("web-glow");
+  let idx = 0;
+  el.thinkingText.textContent = customLines[0];
+  clearInterval(state.thinkingTicker);
+  state.thinkingTicker = setInterval(() => {
+    idx = (idx + 1) % customLines.length;
+    el.thinkingText.textContent = customLines[idx];
+  }, 1400);
+}
+
+function stopThinking() {
+  clearInterval(state.thinkingTicker);
+  el.thinkingBox.classList.add("hidden");
+  el.spinLogo.classList.remove("active");
+  document.body.classList.remove("web-glow");
+}
+
+function setAgentMode(on) {
+  state.agentModeActive = on;
+  el.agentBadge.classList.toggle("hidden", !on);
+  el.agentModeBtn.textContent = on ? "Agent Mode 2.0 (Açık)" : "Agent Mode 2.0";
+}
+
+function parseSearchCommand(q) {
+  const t = normalize(q).replace(/^hey baluk\s+/i, "");
+  const m1 = t.match(/^ara\s+(.+)$/i);
+  const m2 = t.match(/^(.+)\s+ara$/i);
+  const m3 = t.match(/^(.+)\s+arat$/i);
+  const m4 = t.match(/^(.+)\s+arat\s+çıkan\s+(\d+)\.?\s+link/i);
+  const query = (m4?.[1] || m1?.[1] || m2?.[1] || m3?.[1] || "").trim();
+  const n = Number((t.match(/(\d+)\.?\s*link/) || [])[1] || m4?.[2] || 1);
+  return { query, linkIndex: Math.max(1, n || 1) };
+}
+
+function moveCursorTo(element) {
+  const rect = element.getBoundingClientRect();
+  agentCursor.style.opacity = "1";
+  agentCursor.style.left = `${rect.left + rect.width / 2}px`;
+  agentCursor.style.top = `${rect.top + rect.height / 2}px`;
+}
+function moveCursorToPoint(x, y) {
+  agentCursor.style.opacity = "1";
+  agentCursor.style.left = `${x}px`;
+  agentCursor.style.top = `${y}px`;
+}
+
+function clickByViewportPoint(x, y) {
+  const under = document.elementFromPoint(x, y);
+  if (!under) return false;
+  try {
+    ["pointerdown", "mousedown", "mouseup", "click"].forEach((type) => {
+      under.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, clientX: x, clientY: y, view: window }));
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getElementCenterInViewport(element) {
+  const rect = element.getBoundingClientRect();
+  let x = rect.left + rect.width / 2;
+  let y = rect.top + rect.height / 2;
+
+  const doc = element.ownerDocument;
+  const frameEl = doc?.defaultView?.frameElement;
+  if (frameEl) {
+    const fr = frameEl.getBoundingClientRect();
+    x += fr.left;
+    y += fr.top;
+  }
+  return { x, y };
+}
+
+async function clickElement(element) {
+  moveCursorTo(element);
+  await sleep(280);
+  element.click();
+  await sleep(160);
+}
+
+function findTabByName(name) {
+  const q = normalize(name);
+  return state.tabs.find((t) => normalize(t.title).includes(q));
+}
+
+function parseCloseNames(text) {
+  const quoted = [...text.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+  if (quoted.length) return quoted;
+  const single = text.match(/(.+?)\s+isimli\s+sekmeyi\s+kapat/i);
+  return single ? [single[1].trim()] : [];
+}
+
+async function closeTabViaCursor(tabId) {
+  const closeBtn = document.querySelector(`.tab-item [data-close="${tabId}"]`);
+  if (!closeBtn) return false;
+  await clickElement(closeBtn);
+  return true;
+}
+
+async function closeMany(order, count) {
+  let tabs = [...state.tabs];
+  if (tabs.length <= 1) return "Kapatılacak sekme yok.";
+  if (order === "right") tabs = tabs.reverse();
+
+  let done = 0;
+  for (const tab of tabs) {
+    if (state.tabs.length <= 1 || done >= count) break;
+    const ok = await closeTabViaCursor(tab.id);
+    if (ok) done += 1;
+  }
+  return `${done} sekme kapatıldı.`;
+}
+
+async function runAgentTask(q) {
+  if (state.agentBusy) return "Agent Mode meşgul, bekle.";
+  state.agentBusy = true;
+  startThinking(["Masaüstümü kuruyorum...", "Hedefleri planlıyorum...", "Hazırım, uyguluyorum..."]);
+  await sleep(3000);
+  stopThinking();
+
+  try {
+    const low = normalize(q);
+
+    if (low.includes("geri")) { await clickElement(el.geriBtn); return "Şunu istedin: geri. Şunu yaptım: geri gittim."; }
+    if (low.includes("ileri")) { await clickElement(el.ileriBtn); return "Şunu istedin: ileri. Şunu yaptım: ileri gittim."; }
+    if (low.includes("yenile")) { await clickElement(el.yenileBtn); return "Şunu istedin: yenile. Şunu yaptım: sayfayı yeniledim."; }
+
+    if (/\d+\s+yeni\s+sekme\s+aç/.test(low)) {
+      const n = Number(low.match(/(\d+)\s+yeni\s+sekme\s+aç/)?.[1] || 1);
+      for (let i = 0; i < n; i += 1) await clickElement(el.addTabBtn);
+      return `${n} yeni sekme açtım.`;
+    }
+    if (low.includes("yeni sekme")) { await clickElement(el.addTabBtn); return "Yeni sekme açtım."; }
+
+    if (low.includes("tüm sekmeleri kapat")) {
+      while (state.tabs.length > 1) {
+        await closeTabViaCursor(state.tabs[state.tabs.length - 1].id);
+      }
+      return "Tüm sekmeleri kapattım (en az 1 sekme kaldı).";
+    }
+
+    if (/soldan\s+sağa\s+\d+\s+sekme\s+kapat/.test(low)) {
+      const n = Number(low.match(/soldan\s+sağa\s+(\d+)\s+sekme\s+kapat/)?.[1] || 1);
+      return closeMany("left", n);
+    }
+    if (/sağdan\s+sola\s+\d+\s+sekme\s+kapat/.test(low)) {
+      const n = Number(low.match(/sağdan\s+sola\s+(\d+)\s+sekme\s+kapat/)?.[1] || 1);
+      return closeMany("right", n);
+    }
+
+    if (low.includes("isimli sekmeyi kapat") || /"[^"]+"/.test(q)) {
+      const names = parseCloseNames(q);
+      if (!names.length) return "Sekme adı anlayamadım.";
+      let closed = 0;
+      for (const name of names) {
+        const tab = findTabByName(name);
+        if (tab && state.tabs.length > 1) {
+          await closeTabViaCursor(tab.id);
+          closed += 1;
+        }
+      }
+      return `${closed} isimli sekme kapatıldı.`;
+    }
+
+    const parsed = parseSearchCommand(q);
+    if (parsed.query) {
+      await clickElement(el.newTabBtn);
+      moveCursorTo(el.aramaInput);
+      await sleep(220);
+      const tab = currentTab();
+      if (tab) setTabTitle(tab, parsed.query);
+      el.aramaInput.value = "";
+      for (const ch of parsed.query) {
+        el.aramaInput.value += ch;
+        await sleep(26);
+      }
+      el.aramaForm.requestSubmit();
+      await sleep(1200);
+      const cards = [...document.querySelectorAll(".result-item")];
+      const idx = Math.min(parsed.linkIndex - 1, cards.length - 1);
+      const btn = cards[idx]?.querySelector(".open-link");
+      if (!btn) return "Sonuç bulunamadı.";
+      await clickElement(btn);
+      return `Şunu istedin: ${escapeHtml(parsed.query)}. Şunu yaptım: ${parsed.linkIndex}. linke girdim.`;
+    }
+
+    return "Agent Mode 2.0 komutu anlaşılamadı.";
+  } finally {
+    state.agentBusy = false;
+    agentCursor.style.opacity = "0";
+  }
+}
+
+async function answerNormal(q) {
+  const low = normalize(q);
+  if (/(geri|ileri|yenile|yeni sekme|kapat)/.test(low)) {
+    return `Bunu otomatik yapmam için ${highlight("Agent Mode 2.0")} aç.`;
+  }
+
+  if (/(merhaba|selam|hey|günaydın|iyi akşamlar)/.test(low)) {
+    return `${highlight("Merhaba!")} İyiyim, hazırım ✦ İstersen web araştırması, istersen normal sohbet yapabiliriz.`;
+  }
+
+  if (/(nasılsın|naber|iyi misin)/.test(low)) {
+    return `Gayet iyiyim 🙌 ${highlight("Baluk.ai")} olarak hem web tarafında hem de genel konularda yardımcı olabilirim.`;
+  }
+
+  if (/(sen kimsin|nesin|kimsin)/.test(low)) {
+    return `${highlight("Ben Baluk.ai")}, Baluk Screatch içinde çalışan yardımcı modelim. Web analiz, özetleme ve genel soru-cevap yapabilirim.`;
+  }
+
+  const asksCurrentSite = /\bbu\s+web\s*site|\bbu\s+site|ekrandaki\s+site|açık\s+site|şu\s+site/.test(low);
+  const asksGenericWeb = /web\s*site\s*nedir|webin\s+ne\s+oldu|web\s*sitenin\s+amacı\s+ne/.test(low);
+
+  if (asksGenericWeb && !asksCurrentSite) {
+    return genericWebsiteDefinition();
+  }
+
+  const current = getCurrentSiteContext();
+  if (asksCurrentSite && !current) {
+    return `Önce bir site aç, sonra ${highlight("bu web sitenin amacı ne")} diye sor; ekrandaki siteyi yorumlayayım.`;
+  }
+
+  const topic = asksCurrentSite ? current : null;
+  const genericTopic = siteHintFromText(q);
+  const sourceText = await fetchWebModeAnswer(asksCurrentSite ? (topic?.name || topic?.host || "") : q);
+
+  if (asksCurrentSite) {
+    if (/kuruluş|kaç yılında|ne zaman/.test(low)) {
+      return `${highlight(topic.name)} kuruluş yılı: ${highlight(topic.year)}.`;
+    }
+    if (/kim tarafından|hangi şirket|kurucu/.test(low)) {
+      return `${highlight(topic.name)} kurucu/şirket bilgisi:
+${escapeHtml(topic.company)}`;
+    }
+    if (/amaç|ne işe yarar/.test(low)) {
+      return `${highlight("Ekrandaki site")}: ${highlight(topic.name)}
+Amaç: ${escapeHtml(topic.purpose)}`;
+    }
+    if (/özet|özeti|nedir/.test(low)) {
+      const sum = sourceText || topic.summary;
+      return `${highlight(topic.name)} özeti:
+${escapeHtml(sum)}`;
+    }
+    const sum = sourceText || topic.summary;
+    return `${highlight("Baluk.ai ağına bağlanıldı")}
+${highlight(topic.name)} için hızlı analiz:
+Kuruluş: ${highlight(topic.year)}
+Şirket/Kurucu: ${escapeHtml(topic.company)}
+Amaç: ${escapeHtml(topic.purpose)}
+Web modu özeti: ${escapeHtml(sum)}`;
+  }
+
+  if (/kuruluş|kaç yılında|ne zaman/.test(low)) {
+    return `${highlight(genericTopic)} kuruluş bilgisi: ${highlight("web kaynaklarından derlendi")}.`;
+  }
+  if (/isim|adı/.test(low)) {
+    return `Site adı: ${highlight(genericTopic)}.`;
+  }
+  if (/amaç|ne işe yarar|hakkında|nasıl/.test(low)) {
+    return `${highlight("Baluk.ai web modu aktif")}
+${highlight(genericTopic)} hakkında:
+${escapeHtml(sourceText || `${genericTopic} hakkında yeterli veri bulunamadı.`)}`;
+  }
+
+  if (!asksCurrentSite && !asksGenericWeb) {
+    const general = await fetchWebModeAnswer(q);
+    if (general) {
+      return `${highlight("Baluk.ai genel mod")}
+${escapeHtml(general)}`;
+    }
+    return `${highlight("Baluk.ai genel mod")}
+Bu konuda sohbet edebiliriz. Daha net istersen sorunu biraz detaylandır.`;
+  }
+
+  return `${highlight(genericTopic)} özeti:
+${escapeHtml(sourceText || "Özet bulunamadı")}`;
+}
+
+function initPrompts() {
+  const prompts = [
+    { text: "YouTube'un amacı nedir?", agent: false },
+    { text: "shopify arat 1. linke tıkla", agent: true },
+    { text: "10 yeni sekme aç", agent: true },
+  ];
+
+  prompts.forEach((p) => {
+    const b = document.createElement("button");
+    b.type = "button";
+    b.textContent = p.text;
+    b.onclick = () => {
+      setPanel(true);
+      if (p.agent) setAgentMode(true);
+      el.aiSoru.value = p.text;
+      el.aiForm.requestSubmit();
+    };
+    el.quickPrompts.appendChild(b);
+  });
+}
+
+function renderAuth() {
+  if (state.user) {
+    el.authArea.classList.add("hidden");
+    el.assistantArea.classList.remove("hidden");
+    el.welcomeText.textContent = `${state.user.ad} ${state.user.soyad}`;
+    el.profileMail.textContent = state.user.email;
+    el.profileAvatar.src = state.user.profil || "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='70' height='70'%3E%3Crect width='100%25' height='100%25' fill='%23212a57'/%3E%3Ctext x='50%25' y='53%25' text-anchor='middle' fill='%23fff' font-size='22' font-family='Arial' dy='.3em'%3EB%3C/text%3E%3C/svg%3E";
+  } else {
+    el.authArea.classList.remove("hidden");
+    el.assistantArea.classList.add("hidden");
+  }
+}
+
+el.aramaForm.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const q = el.aramaInput.value.trim();
+  if (!q) return;
+  const tab = currentTab();
+  if (tab) { setTabTitle(tab, q); renderTabs(); }
+  el.sonuclar.innerHTML = `<span class="searching-status">Ekranında arıyorum...</span>`;
+  const results = await getSearchResults(q);
+  renderResults(results, q);
+});
+
+el.adresCubugu.addEventListener("keydown", (e) => { if (e.key === "Enter") openUrl(el.adresCubugu.value); });
+el.geriBtn.addEventListener("click", () => {
+  const t = currentTab();
+  if (t && t.index > 0) { t.index -= 1; t.url = t.history[t.index]; syncTabView(); }
+});
+el.ileriBtn.addEventListener("click", () => {
+  const t = currentTab();
+  if (t && t.index < t.history.length - 1) { t.index += 1; t.url = t.history[t.index]; syncTabView(); }
+});
+el.yenileBtn.addEventListener("click", () => { if (el.siteFrame.src) el.siteFrame.src = el.siteFrame.src; });
+el.newTabBtn.addEventListener("click", () => createTab());
+el.addTabBtn.addEventListener("click", () => createTab());
+
+el.balukPanelBtn.addEventListener("click", () => setPanel(el.aiPanel.classList.contains("hidden")));
+el.closePanelBtn.addEventListener("click", () => setPanel(false));
+el.plusBtn.addEventListener("click", () => el.agentMenu.classList.toggle("hidden"));
+el.agentModeBtn.addEventListener("click", () => {
+  setAgentMode(!state.agentModeActive);
+  el.agentMenu.classList.add("hidden");
+});
+el.agentBadgeClose.addEventListener("click", () => setAgentMode(false));
+
+el.loginForm.addEventListener("submit", (e) => {
+  e.preventDefault();
+  const user = {
+    email: document.getElementById("mail").value.trim(),
+    ad: document.getElementById("ad").value.trim(),
+    soyad: document.getElementById("soyad").value.trim(),
+  };
+  const file = document.getElementById("profil").files[0];
+  if (!user.email || !user.ad || !user.soyad) return;
+
+  if (file) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      user.profil = reader.result;
+      state.user = user;
+      localStorage.setItem("balukUser", JSON.stringify(user));
+      renderAuth();
+    };
+    reader.readAsDataURL(file);
+  } else {
+    state.user = user;
+    localStorage.setItem("balukUser", JSON.stringify(user));
+    renderAuth();
+  }
+});
+
+el.aiForm.addEventListener("submit", async (e) => {
+  e.preventDefault();
+  const q = el.aiSoru.value.trim();
+  if (!q) return;
+
+  if (state.agentModeActive) {
+    el.aiCevap.innerHTML = await runAgentTask(q);
+    el.aiSoru.value = "";
+    return;
+  }
+
+  startThinking();
+  clearTimeout(state.thinkingTimer);
+  state.thinkingTimer = setTimeout(async () => {
+    stopThinking();
+    el.aiCevap.innerHTML = await answerNormal(q);
+    el.aiSoru.value = "";
+  }, 20000);
+});
+
+el.aiSoru.addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && !e.shiftKey) {
+    e.preventDefault();
+    el.aiForm.requestSubmit();
+  }
+});
+
+renderTabs();
+renderAuth();
+initPrompts();
+setPanel(false);
+runIntro();

--- a/script.js
+++ b/script.js
@@ -583,16 +583,11 @@ function showHome() {
 function syncTabView() {
   const tab = currentTab();
   if (!tab || !tab.url) return showHome();
-  const viewUrl = getEmbeddableUrl(tab.url);
   el.adresCubugu.value = tab.url;
   el.siteFrame.srcdoc = '';
-  el.siteFrame.src = viewUrl;
+  el.siteFrame.src = tab.url;
   el.homeView.classList.add("hidden");
   el.webView.classList.remove("hidden");
-
-  if (viewUrl !== tab.url) {
-    showOpenHint('Bu site iframe korumalı. Görüntü modu ile açıldı (HTML görünüm).');
-  }
 }
 
 function setTabTitle(tab, title) {
@@ -648,10 +643,16 @@ function openUrl(url, addToHistory = true, titleHint = "") {
     return;
   }
 
-  if (isIframeBlockedHost(safe)) {
-    const handled = tryInternalSearchFromBlockedUrl(safe);
+  if (isIframeBlockedHost(safe) || isLikelyFrameDeniedHost(safe)) {
+    const handled = isIframeBlockedHost(safe) ? tryInternalSearchFromBlockedUrl(safe) : false;
+    if (!handled) {
+      const opened = window.open(safe, '_blank', 'noopener,noreferrer');
+      if (!opened) window.location.href = safe;
+      showOpenHint('Bu site güvenlik nedeniyle gömülü açılamıyor. Yeni sekmede açıldı.');
+      showHome();
+    }
     renderTabs();
-    if (handled) return;
+    return;
   }
 
   renderTabs();

--- a/style.css
+++ b/style.css
@@ -1,108 +1,169 @@
+:root {
+  --night: #080b18;
+  --glow-purple: #8d45ff;
+  --text: #f7f6ff;
+  --soft-border: rgba(141, 69, 255, 0.32);
+}
+* { box-sizing: border-box; }
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
-  background-color: #0d0d0d;
-  color: white;
+  font-family: Inter, Arial, sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at top, #2a1454 0%, #0b1130 45%, #05070f 100%);
+  min-height: 100vh;
+  transition: box-shadow .4s ease;
 }
+.hidden { display: none !important; }
 
-.gizli {
-  display: none;
-}
-
-#girisEkrani {
-  text-align: center;
-  padding: 40px;
-}
-
-#girisEkrani input, #girisEkrani button {
-  display: block;
-  margin: 10px auto;
-  padding: 10px;
-  width: 80%;
-}
-
-header {
-  background-color: #1a1a1a;
-  padding: 10px;
-  display: flex;
-  justify-content: space-between;
+.topbar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr auto;
+  gap: 10px;
   align-items: center;
+  padding: 8px 12px;
+  background: rgba(8, 11, 24, 0.9);
+  border-bottom: 1px solid var(--soft-border);
+  position: sticky;
+  top: 0;
+  z-index: 20;
 }
 
-#arama {
-  padding: 8px;
-  border-radius: 5px;
-  border: none;
+.tab-strip { display: flex; align-items: center; gap: 8px; min-width: 260px; }
+.tabs { display: flex; gap: 6px; overflow: auto; max-width: 52vw; }
+.tab-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  min-width: 150px;
+  border-radius: 10px 10px 0 0;
+  border: 1px solid #36406c;
+  background: #202a43;
+  color: #d7dcff;
+  cursor: pointer;
+}
+.tab-item.active { background: #2a3753; border-color: #5870a8; }
+.tab-close { border: none; background: transparent; color: #d7dcff; cursor: pointer; }
+.tab-plus { border: 1px solid #5a3fa0; background: #1c2146; color: #fff; border-radius: 8px; padding: 6px 9px; }
+
+.browser-controls button,
+.search-box button,
+.stacked-form button,
+#sendBtn,
+.agent-menu button,
+.close-panel,
+.result-actions button,
+.quick-prompts button,
+.agent-badge button {
+  border: 1px solid #5a3fa0;
+  background: #1c2146;
+  color: var(--text);
+  border-radius: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
 }
 
-.video-galeri {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 15px;
-  justify-content: center;
-  padding: 20px;
-}
-
-.video {
-  background: #1a1a1a;
+#adresCubugu,
+.search-box input,
+.stacked-form input,
+#aiSoru {
+  width: 100%;
+  background: #0f1431;
+  color: var(--text);
+  border: 1px solid #3f4678;
+  border-radius: 8px;
   padding: 10px;
+}
+
+.baluk-mini {
+  border: 1px solid #8f4bff;
+  background: linear-gradient(135deg, #311062, #6e2ee2);
+  color: #fff;
+  font-weight: 700;
   border-radius: 10px;
-  width: 200px;
-  text-align: center;
-  position: relative;
+  padding: 10px 14px;
+  box-shadow: 0 0 20px rgba(141, 69, 255, 0.7), inset 0 0 8px rgba(255,255,255,0.2);
 }
 
-.video video {
-  width: 100%;
-  border-radius: 5px;
+.content-grid { display: grid; grid-template-columns: 1fr; min-height: calc(100vh - 63px); transition: grid-template-columns .35s ease; }
+.content-grid.with-panel { grid-template-columns: 1fr 420px; }
+
+.search-screen,.web-screen { padding: 30px 20px; }
+.search-screen h1 { text-align: center; margin-top: 50px; font-size: clamp(2rem,6vw,3.8rem); color:#e1d1ff; text-shadow:0 0 10px rgba(141,69,255,.8),0 0 24px rgba(141,69,255,.6); }
+.search-box { max-width: 760px; margin: 16px auto 24px; display:grid; grid-template-columns:1fr auto; gap:10px; }
+.results { max-width: 920px; margin: 0 auto; display: grid; gap: 14px; }
+.result-item { background: linear-gradient(180deg, rgba(19,23,49,.92), rgba(11,15,33,.92)); border:1px solid var(--soft-border); border-radius: 12px; padding:14px; }
+.result-item h3 { margin:0 0 6px; }
+.result-item p { margin:0 0 10px; color:#d5ceee; }
+.result-item a { color:#d9c6ff; text-decoration:none; }
+.result-actions { display:flex; gap:8px; flex-wrap: wrap; }
+.result-actions button:last-child { background: linear-gradient(135deg,#3d1678,#6d2de2); }
+.searching-status { color: #9d9d9d; position: relative; display: inline-block; }
+.searching-status::after { content:""; position:absolute; inset:0; background:linear-gradient(100deg, transparent, rgba(172,117,255,.55), transparent); transform:translateX(-130%); animation: shimmer 1.6s infinite; }
+
+#siteFrame { width:100%; height: calc(100vh - 145px); border:1px solid rgba(141,69,255,.42); border-radius: 10px; background:white; }
+.web-screen { position: relative; }
+
+.ai-panel {
+  border-left: 1px solid var(--soft-border);
+  background: linear-gradient(180deg, rgba(16, 18, 44, .99), rgba(9, 11, 26, .98));
+  box-shadow: -6px 0 28px rgba(141,69,255,.18);
+  padding: 14px;
+  height: calc(100vh - 63px);
+  display:flex;
+  flex-direction: column;
+}
+.panel-head { display:flex; justify-content:space-between; align-items:center; margin-bottom:10px; }
+.logo-head { display:flex; align-items:center; gap:8px; }
+.baluk-logo-head { width:42px; height:18px; filter: brightness(2.2) contrast(.7); }
+.profile-card { display:flex; align-items:center; gap:10px; border:1px solid var(--soft-border); border-radius:10px; padding:10px; background:rgba(141,69,255,.1); }
+#profileAvatar { width:48px; height:48px; border-radius:50%; object-fit:cover; border:2px solid rgba(255,255,255,.35); }
+#profileMail { margin:2px 0 0; color:#cab9ff; font-size:.85rem; }
+.assistant-layout { height:100%; display:flex; flex-direction:column; gap:10px; }
+.quick-prompts { display:flex; flex-wrap:wrap; gap:8px; }
+.quick-prompts button { background:#222a54; font-size:.82rem; }
+
+.ai-answer { flex:1; overflow:auto; background:rgba(15,20,43,.72); border:1px solid rgba(141,69,255,.25); border-radius:8px; padding:12px; line-height:1.55; }
+.ai-answer .hl { text-decoration: underline 3px #b171ff; font-weight: 700; }
+.thinking-box { display:flex; align-items:center; gap:10px; border:1px solid rgba(141,69,255,.6); border-radius:10px; padding:10px; background:rgba(141,69,255,.12); }
+.spin-logo { width:40px; height:40px; object-fit:contain; filter:invert(1) brightness(1.8); }
+.spin-logo.active { animation: spin 1.2s linear infinite; }
+#thinkingText { margin:0; color:#ddd; position:relative; }
+#thinkingText::after { content:""; position:absolute; inset:0; background:linear-gradient(120deg, transparent, rgba(172,117,255,.52), transparent); transform:translateX(-120%); animation: shimmer 1.4s infinite; }
+
+.agent-badge { display:flex; align-items:center; justify-content:space-between; gap:8px; border:1px solid rgba(141,69,255,.65); background:rgba(72,42,130,.35); padding:8px 10px; border-radius: 8px; }
+
+.agent-badge-actions { display:flex; gap:6px; }
+
+
+.ask-bar { display:grid; grid-template-columns:auto 1fr auto; gap:8px; align-items:center; }
+#aiSoru { min-height:40px; max-height:90px; resize:vertical; }
+.plus-btn { border:1px solid #7045d8; background:#1a1f43; color:#fff; width:40px; height:40px; font-size:1.25rem; border-radius:8px; }
+.agent-menu { border:1px solid var(--soft-border); border-radius:8px; padding:10px; background:rgba(17,22,45,.95); }
+.web-glow { box-shadow: inset 0 0 110px rgba(141,69,255,.48), inset 0 0 200px rgba(72,100,255,.22); }
+
+@keyframes spin { to { transform: rotate(360deg);} }
+@keyframes shimmer { to { transform: translateX(130%);} }
+
+@media (max-width: 1100px) {
+  .topbar { grid-template-columns: 1fr; }
+  .tabs { max-width: 100%; }
+  .content-grid, .content-grid.with-panel { grid-template-columns: 1fr; }
+  .ai-panel { border-left:none; border-top:1px solid var(--soft-border); height:auto; min-height: 60vh; }
 }
 
-.video button {
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  background: red;
-  color: white;
-  border: none;
-  border-radius: 50%;
-  padding: 5px;
-  cursor: pointer;
-}
+.app-hidden { opacity:0; pointer-events:none; }
+.intro-overlay { position:fixed; inset:0; z-index:12000; display:grid; place-content:center; gap:18px; background: radial-gradient(circle at center, rgba(95,41,182,.42) 0%, rgba(6,8,17,.96) 62%, #03040a 100%); transition:opacity .7s ease, visibility .7s ease; animation:introAutoHide 9s ease forwards; }
+.intro-overlay.hidden { opacity:0; visibility:hidden; }
+.intro-card { position:relative; min-width:min(860px,92vw); padding:clamp(18px,3vw,30px) clamp(24px,5vw,60px); border-radius:999px; border:2px solid rgba(180,140,255,.92); background:linear-gradient(140deg, rgba(90,37,176,.95), rgba(23,20,72,.94) 56%, rgba(10,16,58,.95)); box-shadow:0 0 26px rgba(141,69,255,.9), inset 0 0 22px rgba(236,226,255,.2), 0 0 70px rgba(89,18,180,.65); transform:scale(.58) translateY(24px); opacity:0; animation:introZoom .9s cubic-bezier(.15,.8,.22,1) forwards; }
+.intro-title { text-align:center; font-size:clamp(2rem,5.5vw,5rem); font-weight:800; color:#eddcff; text-shadow:0 0 10px rgba(255,255,255,.3),0 0 24px rgba(176,112,255,.72); }
+.intro-glow { position:absolute; inset:4px; border-radius:999px; pointer-events:none; background:linear-gradient(110deg, rgba(255,255,255,.1), transparent 35%, rgba(255,255,255,.22) 50%, transparent 66%, rgba(255,255,255,.08)); animation:introSheen 1.8s ease-in-out .25s 2; }
+.intro-subtitle { margin:0; text-align:center; color:#d8c0ff; font-size:clamp(1rem,2vw,1.45rem); opacity:0; transform:translateY(12px); animation:subtitleIn .75s ease .75s forwards; }
+@keyframes introZoom { to { transform:scale(1) translateY(0); opacity:1; } }
+@keyframes introSheen { 0%{transform:translateX(-30%);opacity:.2;}45%{transform:translateX(2%);opacity:.75;}100%{transform:translateX(30%);opacity:.2;} }
+@keyframes subtitleIn { to { opacity:1; transform:translateY(0); } }
 
-#profil {
-  text-align: center;
-  margin-top: 20px;
-}
-
-#profil img {
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  object-fit: cover;
-  background-color: white;
-}
-
-#videoDosyasi, #videoBaslik {
-  display: block;
-  margin: 10px auto;
-  padding: 8px;
-  width: 80%;
-}
-
-nav#altMenu {
-  position: fixed;
-  bottom: 0;
-  width: 100%;
-  background: #111;
-  display: flex;
-  justify-content: space-around;
-  padding: 10px 0;
-}
-
-nav button {
-  background: none;
-  border: none;
-  color: white;
-  font-size: 24px;
-  cursor: pointer;
+@keyframes introAutoHide {
+  0%, 82% { opacity: 1; visibility: visible; pointer-events: auto; }
+  100% { opacity: 0; visibility: hidden; pointer-events: none; }
 }

--- a/style.css
+++ b/style.css
@@ -4,21 +4,24 @@
   --text: #f7f6ff;
   --soft-border: rgba(141, 69, 255, 0.32);
   --theme-font: Inter, Arial, sans-serif;
+  --bg-top: #2a1454;
+  --bg-mid: #0b1130;
+  --bg-bottom: #05070f;
 }
 * { box-sizing: border-box; }
 body {
   margin: 0;
   font-family: var(--theme-font);
   color: var(--text);
-  background: radial-gradient(circle at top, #2a1454 0%, #0b1130 45%, #05070f 100%);
+  background: radial-gradient(circle at top, var(--bg-top) 0%, var(--bg-mid) 45%, var(--bg-bottom) 100%);
   min-height: 100vh;
-  transition: box-shadow .4s ease;
+  transition: box-shadow .4s ease, background .45s ease;
 }
 .hidden { display: none !important; }
 
 .topbar {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr auto;
+  display: flex;
+  flex-wrap: wrap;
   gap: 10px;
   align-items: center;
   padding: 8px 12px;
@@ -29,8 +32,8 @@ body {
   z-index: 20;
 }
 
-.tab-strip { display: flex; align-items: center; gap: 8px; min-width: 260px; }
-.tabs { display: flex; gap: 6px; overflow: auto; max-width: 52vw; }
+.tab-strip { display: flex; align-items: center; gap: 8px; min-width: 220px; flex: 1 1 320px; }
+.tabs { display: flex; gap: 6px; overflow: auto; max-width: min(52vw, 680px); }
 .tab-item {
   display: inline-flex;
   align-items: center;
@@ -46,6 +49,9 @@ body {
 .tab-item.active { background: #2a3753; border-color: #5870a8; }
 .tab-close { border: none; background: transparent; color: #d7dcff; cursor: pointer; }
 .tab-plus { border: 1px solid #5a3fa0; background: #1c2146; color: #fff; border-radius: 8px; padding: 6px 9px; }
+.browser-controls { display:flex; gap:8px; flex: 0 0 auto; }
+#adresCubugu { flex: 1 1 260px; min-width: 220px; }
+
 
 .browser-controls button,
 .search-box button,
@@ -81,17 +87,21 @@ body {
   background: linear-gradient(135deg, #311062, #6e2ee2);
   color: #fff;
   font-weight: 700;
-  border-radius: 10px;
-  padding: 10px 14px;
+  border-radius: 8px;
+  padding: 7px 10px;
+  font-size: .88rem;
+  white-space: nowrap;
   box-shadow: 0 0 20px color-mix(in srgb, var(--glow-purple) 70%, transparent), inset 0 0 8px rgba(255,255,255,0.2);
 }
 .customize-btn {
   border: 1px solid var(--soft-border);
   background: #161b3e;
   color: var(--text);
-  border-radius: 10px;
-  padding: 10px 12px;
-  font-size: 1.1rem;
+  border-radius: 8px;
+  padding: 7px 10px;
+  font-size: .95rem;
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .content-grid { display: grid; grid-template-columns: 1fr; min-height: calc(100vh - 63px); transition: grid-template-columns .35s ease; }
@@ -202,6 +212,30 @@ body {
   border-radius: 999px;
 }
 
+
+.customize-panel.editing-active { outline: 1px solid color-mix(in srgb, var(--glow-purple) 70%, transparent); }
+.editing-mode-target {
+  position: absolute !important;
+  z-index: 22;
+  cursor: move !important;
+  border: 1px dashed color-mix(in srgb, var(--glow-purple) 72%, #fff 10%);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--glow-purple) 30%, transparent);
+}
+.editing-mode-target::after {
+  content: "↘";
+  position: absolute;
+  right: -10px;
+  bottom: -10px;
+  width: 20px;
+  height: 20px;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--glow-purple) 75%, #fff 10%);
+  color: #fff;
+  font-size: 12px;
+}
+
 @keyframes spin { to { transform: rotate(360deg);} }
 @keyframes shimmer { to { transform: translateX(130%);} }
 @keyframes ballMerge {
@@ -211,7 +245,10 @@ body {
 }
 
 @media (max-width: 1100px) {
-  .topbar { grid-template-columns: 1fr; }
+   .topbar { padding: 8px; gap: 8px; }
+  .browser-controls { order: 2; }
+  #adresCubugu { order: 3; min-width: 100%; }
+  #customizeBtn, #balukPanelBtn { order: 4; }
   .tabs { max-width: 100%; }
   .content-grid, .content-grid.with-panel { grid-template-columns: 1fr; }
   .ai-panel { border-left:none; border-top:1px solid var(--soft-border); height:auto; min-height: 60vh; }

--- a/style.css
+++ b/style.css
@@ -4,16 +4,13 @@
   --text: #f7f6ff;
   --soft-border: rgba(141, 69, 255, 0.32);
   --theme-font: Inter, Arial, sans-serif;
-  --bg-top: #2a1454;
-  --bg-mid: #0b1130;
-  --bg-bottom: #05070f;
 }
 * { box-sizing: border-box; }
 body {
   margin: 0;
   font-family: var(--theme-font);
   color: var(--text);
-  background: radial-gradient(circle at top, var(--bg-top) 0%, var(--bg-mid) 45%, var(--bg-bottom) 100%);
+  background: radial-gradient(circle at top, color-mix(in srgb, var(--glow-purple) 18%, #0b1022) 0%, #0b1130 45%, #05070f 100%);
   min-height: 100vh;
   transition: box-shadow .4s ease, background .45s ease;
 }
@@ -41,14 +38,14 @@ body {
   padding: 7px 10px;
   min-width: 150px;
   border-radius: 10px 10px 0 0;
-  border: 1px solid #36406c;
-  background: #202a43;
+  border: 1px solid color-mix(in srgb, var(--glow-purple) 34%, #36406c);
+  background: color-mix(in srgb, var(--glow-purple) 12%, #202a43);
   color: #d7dcff;
   cursor: pointer;
 }
-.tab-item.active { background: #2a3753; border-color: #5870a8; }
+.tab-item.active { background: color-mix(in srgb, var(--glow-purple) 18%, #2a3753); border-color: color-mix(in srgb, var(--glow-purple) 45%, #5870a8); box-shadow: inset 0 0 16px color-mix(in srgb, var(--glow-purple) 35%, transparent); }
 .tab-close { border: none; background: transparent; color: #d7dcff; cursor: pointer; }
-.tab-plus { border: 1px solid #5a3fa0; background: #1c2146; color: #fff; border-radius: 8px; padding: 6px 9px; }
+.tab-plus { border: 1px solid color-mix(in srgb, var(--glow-purple) 55%, #5a3fa0); background: color-mix(in srgb, var(--glow-purple) 16%, #1c2146); color: #fff; border-radius: 8px; padding: 6px 9px; box-shadow: 0 0 12px color-mix(in srgb, var(--glow-purple) 40%, transparent); }
 .browser-controls { display:flex; gap:8px; flex: 0 0 auto; }
 #adresCubugu { flex: 1 1 260px; min-width: 220px; }
 
@@ -62,8 +59,8 @@ body {
 .result-actions button,
 .quick-prompts button,
 .agent-badge button {
-  border: 1px solid #5a3fa0;
-  background: #1c2146;
+  border: 1px solid color-mix(in srgb, var(--glow-purple) 55%, #5a3fa0);
+  background: color-mix(in srgb, var(--glow-purple) 12%, #1c2146);
   color: var(--text);
   border-radius: 8px;
   padding: 8px 12px;
@@ -77,14 +74,14 @@ body {
   width: 100%;
   background: #0f1431;
   color: var(--text);
-  border: 1px solid #3f4678;
+  border: 1px solid color-mix(in srgb, var(--glow-purple) 40%, #3f4678);
   border-radius: 8px;
   padding: 10px;
 }
 
 .baluk-mini {
-  border: 1px solid #8f4bff;
-  background: linear-gradient(135deg, #311062, #6e2ee2);
+  border: 1px solid color-mix(in srgb, var(--glow-purple) 80%, #8f4bff);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--glow-purple) 58%, #1f1238), color-mix(in srgb, var(--glow-purple) 88%, #6e2ee2));
   color: #fff;
   font-weight: 700;
   border-radius: 8px;
@@ -116,17 +113,17 @@ body {
 .result-item p { margin:0 0 10px; color:#d5ceee; }
 .result-item a { color:#d9c6ff; text-decoration:none; }
 .result-actions { display:flex; gap:8px; flex-wrap: wrap; }
-.result-actions button:last-child { background: linear-gradient(135deg,#3d1678,#6d2de2); }
+.result-actions button:last-child { background: linear-gradient(135deg, color-mix(in srgb, var(--glow-purple) 65%, #2e1450), color-mix(in srgb, var(--glow-purple) 85%, #6d2de2)); box-shadow: 0 0 14px color-mix(in srgb, var(--glow-purple) 42%, transparent); }
 .searching-status { color: #9d9d9d; position: relative; display: inline-block; }
 .searching-status::after { content:""; position:absolute; inset:0; background:linear-gradient(100deg, transparent, rgba(172,117,255,.55), transparent); transform:translateX(-130%); animation: shimmer 1.6s infinite; }
 
-#siteFrame { width:100%; height: calc(100vh - 145px); border:1px solid rgba(141,69,255,.42); border-radius: 10px; background:white; }
+#siteFrame { width:100%; height: calc(100vh - 145px); border:1px solid color-mix(in srgb, var(--glow-purple) 55%, transparent); border-radius: 10px; background:white; }
 .web-screen { position: relative; }
 
 .ai-panel {
   border-left: 1px solid var(--soft-border);
   background: linear-gradient(180deg, rgba(16, 18, 44, .99), rgba(9, 11, 26, .98));
-  box-shadow: -6px 0 28px rgba(141,69,255,.18);
+  box-shadow: -6px 0 28px color-mix(in srgb, var(--glow-purple) 26%, transparent);
   padding: 14px;
   height: calc(100vh - 63px);
   display:flex;
@@ -135,22 +132,22 @@ body {
 .panel-head { display:flex; justify-content:space-between; align-items:center; margin-bottom:10px; }
 .logo-head { display:flex; align-items:center; gap:8px; }
 .baluk-logo-head { width:42px; height:18px; filter: brightness(2.2) contrast(.7); }
-.profile-card { display:flex; align-items:center; gap:10px; border:1px solid var(--soft-border); border-radius:10px; padding:10px; background:rgba(141,69,255,.1); }
+.profile-card { display:flex; align-items:center; gap:10px; border:1px solid var(--soft-border); border-radius:10px; padding:10px; background:color-mix(in srgb, var(--glow-purple) 18%, transparent); }
 #profileAvatar { width:48px; height:48px; border-radius:50%; object-fit:cover; border:2px solid rgba(255,255,255,.35); }
 #profileMail { margin:2px 0 0; color:#cab9ff; font-size:.85rem; }
 .assistant-layout { height:100%; display:flex; flex-direction:column; gap:10px; }
 .quick-prompts { display:flex; flex-wrap:wrap; gap:8px; }
 .quick-prompts button { background:#222a54; font-size:.82rem; }
 
-.ai-answer { flex:1; overflow:auto; background:rgba(15,20,43,.72); border:1px solid rgba(141,69,255,.25); border-radius:8px; padding:12px; line-height:1.55; }
-.ai-answer .hl { text-decoration: underline 3px #b171ff; font-weight: 700; }
-.thinking-box { display:flex; align-items:center; gap:10px; border:1px solid rgba(141,69,255,.6); border-radius:10px; padding:10px; background:rgba(141,69,255,.12); }
+.ai-answer { flex:1; overflow:auto; background:rgba(15,20,43,.72); border:1px solid color-mix(in srgb, var(--glow-purple) 35%, transparent); border-radius:8px; padding:12px; line-height:1.55; }
+.ai-answer .hl { text-decoration: underline 3px color-mix(in srgb, var(--glow-purple) 78%, #b171ff); font-weight: 700; }
+.thinking-box { display:flex; align-items:center; gap:10px; border:1px solid color-mix(in srgb, var(--glow-purple) 65%, transparent); border-radius:10px; padding:10px; background:color-mix(in srgb, var(--glow-purple) 20%, transparent); }
 .spin-logo { width:40px; height:40px; object-fit:contain; filter:invert(1) brightness(1.8); }
 .spin-logo.active { animation: spin 1.2s linear infinite; }
 #thinkingText { margin:0; color:#ddd; position:relative; }
 #thinkingText::after { content:""; position:absolute; inset:0; background:linear-gradient(120deg, transparent, rgba(172,117,255,.52), transparent); transform:translateX(-120%); animation: shimmer 1.4s infinite; }
 
-.agent-badge { display:flex; align-items:center; justify-content:space-between; gap:8px; border:1px solid rgba(141,69,255,.65); background:rgba(72,42,130,.35); padding:8px 10px; border-radius: 8px; }
+.agent-badge { display:flex; align-items:center; justify-content:space-between; gap:8px; border:1px solid color-mix(in srgb, var(--glow-purple) 70%, transparent); background:color-mix(in srgb, var(--glow-purple) 28%, rgba(72,42,130,.35)); padding:8px 10px; border-radius: 8px; }
 
 .agent-badge-actions { display:flex; gap:6px; }
 .new-pill { font-size: .68rem; background: color-mix(in srgb, var(--glow-purple) 65%, #fff 10%); color:#fff; padding:2px 6px; border-radius:999px; margin-left:6px; }
@@ -158,9 +155,9 @@ body {
 
 .ask-bar { display:grid; grid-template-columns:auto 1fr auto; gap:8px; align-items:center; }
 #aiSoru { min-height:40px; max-height:90px; resize:vertical; }
-.plus-btn { border:1px solid #7045d8; background:#1a1f43; color:#fff; width:40px; height:40px; font-size:1.25rem; border-radius:8px; }
+.plus-btn { border:1px solid color-mix(in srgb, var(--glow-purple) 65%, #7045d8); background:color-mix(in srgb, var(--glow-purple) 18%, #1a1f43); color:#fff; width:40px; height:40px; font-size:1.25rem; border-radius:8px; box-shadow: 0 0 10px color-mix(in srgb, var(--glow-purple) 35%, transparent); }
 .agent-menu { border:1px solid var(--soft-border); border-radius:8px; padding:10px; background:rgba(17,22,45,.95); }
-.web-glow { box-shadow: inset 0 0 110px rgba(141,69,255,.48), inset 0 0 200px rgba(72,100,255,.22); }
+.web-glow { box-shadow: inset 0 0 110px color-mix(in srgb, var(--glow-purple) 55%, transparent), inset 0 0 200px color-mix(in srgb, var(--glow-purple) 18%, rgba(72,100,255,.22)); }
 .tab-item.dragging { opacity: .55; }
 
 .customize-panel {

--- a/style.css
+++ b/style.css
@@ -212,7 +212,6 @@ body {
 
 .customize-panel.editing-active { outline: 1px solid color-mix(in srgb, var(--glow-purple) 70%, transparent); }
 .editing-mode-target {
-  position: absolute !important;
   z-index: 22;
   cursor: move !important;
   border: 1px dashed color-mix(in srgb, var(--glow-purple) 72%, #fff 10%);

--- a/style.css
+++ b/style.css
@@ -3,11 +3,12 @@
   --glow-purple: #8d45ff;
   --text: #f7f6ff;
   --soft-border: rgba(141, 69, 255, 0.32);
+  --theme-font: Inter, Arial, sans-serif;
 }
 * { box-sizing: border-box; }
 body {
   margin: 0;
-  font-family: Inter, Arial, sans-serif;
+  font-family: var(--theme-font);
   color: var(--text);
   background: radial-gradient(circle at top, #2a1454 0%, #0b1130 45%, #05070f 100%);
   min-height: 100vh;
@@ -82,14 +83,22 @@ body {
   font-weight: 700;
   border-radius: 10px;
   padding: 10px 14px;
-  box-shadow: 0 0 20px rgba(141, 69, 255, 0.7), inset 0 0 8px rgba(255,255,255,0.2);
+  box-shadow: 0 0 20px color-mix(in srgb, var(--glow-purple) 70%, transparent), inset 0 0 8px rgba(255,255,255,0.2);
+}
+.customize-btn {
+  border: 1px solid var(--soft-border);
+  background: #161b3e;
+  color: var(--text);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 1.1rem;
 }
 
 .content-grid { display: grid; grid-template-columns: 1fr; min-height: calc(100vh - 63px); transition: grid-template-columns .35s ease; }
 .content-grid.with-panel { grid-template-columns: 1fr 420px; }
 
 .search-screen,.web-screen { padding: 30px 20px; }
-.search-screen h1 { text-align: center; margin-top: 50px; font-size: clamp(2rem,6vw,3.8rem); color:#e1d1ff; text-shadow:0 0 10px rgba(141,69,255,.8),0 0 24px rgba(141,69,255,.6); }
+.search-screen h1 { text-align: center; margin-top: 50px; font-size: clamp(2rem,6vw,3.8rem); color:#e1d1ff; text-shadow:0 0 10px color-mix(in srgb, var(--glow-purple) 80%, transparent),0 0 24px color-mix(in srgb, var(--glow-purple) 60%, transparent); }
 .search-box { max-width: 760px; margin: 16px auto 24px; display:grid; grid-template-columns:1fr auto; gap:10px; }
 .results { max-width: 920px; margin: 0 auto; display: grid; gap: 14px; }
 .result-item { background: linear-gradient(180deg, rgba(19,23,49,.92), rgba(11,15,33,.92)); border:1px solid var(--soft-border); border-radius: 12px; padding:14px; }
@@ -134,6 +143,7 @@ body {
 .agent-badge { display:flex; align-items:center; justify-content:space-between; gap:8px; border:1px solid rgba(141,69,255,.65); background:rgba(72,42,130,.35); padding:8px 10px; border-radius: 8px; }
 
 .agent-badge-actions { display:flex; gap:6px; }
+.new-pill { font-size: .68rem; background: color-mix(in srgb, var(--glow-purple) 65%, #fff 10%); color:#fff; padding:2px 6px; border-radius:999px; margin-left:6px; }
 
 
 .ask-bar { display:grid; grid-template-columns:auto 1fr auto; gap:8px; align-items:center; }
@@ -141,9 +151,64 @@ body {
 .plus-btn { border:1px solid #7045d8; background:#1a1f43; color:#fff; width:40px; height:40px; font-size:1.25rem; border-radius:8px; }
 .agent-menu { border:1px solid var(--soft-border); border-radius:8px; padding:10px; background:rgba(17,22,45,.95); }
 .web-glow { box-shadow: inset 0 0 110px rgba(141,69,255,.48), inset 0 0 200px rgba(72,100,255,.22); }
+.tab-item.dragging { opacity: .55; }
+
+.customize-panel {
+  border-left: 1px solid var(--soft-border);
+  background: rgba(10, 12, 31, .98);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.customize-panel select,
+.customize-panel input {
+  width: 100%;
+  padding: 10px;
+  border-radius: 8px;
+  background: #111735;
+  color: #fff;
+  border: 1px solid var(--soft-border);
+}
+.customize-panel button { border: 1px solid var(--soft-border); background: #1b2148; color:#fff; padding: 10px 12px; border-radius: 8px; }
+.advanced-banner { border:1px solid var(--soft-border); border-radius: 12px; padding: 12px; background: linear-gradient(130deg, rgba(43,26,94,.65), rgba(16,20,42,.7)); display:flex; justify-content:space-between; align-items:center; gap:10px; }
+.advanced-banner p { margin:4px 0 0; font-size:.85rem; color:#d7cff6; }
+
+.theme-anim-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 11000;
+  background: radial-gradient(circle at center, rgba(16,20,38,.35), rgba(2,3,10,.88));
+  overflow: hidden;
+}
+.theme-ball {
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: radial-gradient(circle, color-mix(in srgb, var(--c) 70%, #fff 15%) 0%, var(--c) 75%);
+  box-shadow: 0 0 24px var(--c);
+  animation: ballMerge 2.8s ease-in-out infinite;
+}
+.theme-anim-status {
+  position: absolute;
+  left: 50%;
+  bottom: 42px;
+  transform: translateX(-50%);
+  color: #fff;
+  background: rgba(8,10,22,.8);
+  border: 1px solid var(--soft-border);
+  padding: 10px 14px;
+  border-radius: 999px;
+}
 
 @keyframes spin { to { transform: rotate(360deg);} }
 @keyframes shimmer { to { transform: translateX(130%);} }
+@keyframes ballMerge {
+  0% { transform: scale(.8) translate(0,0); opacity:.65; }
+  50% { transform: scale(1.3) translate(-18vw, -16vh); opacity:1; }
+  100% { transform: scale(.9) translate(0,0); opacity:.75; }
+}
 
 @media (max-width: 1100px) {
   .topbar { grid-template-columns: 1fr; }


### PR DESCRIPTION
### Motivation
- Replace the previous `MemTube` simple layout with a modern single-page „browser + AI assistant“ experience called Baluk Screatch that can search the web and provide contextual AI answers. 
- Provide a compact tabbed browsing model, an AI side panel with an agent mode for UI actions, and persistent user info for a richer local experience. 
- Ship a visual identity and polished UI/UX including an intro overlay, animations and responsive layout. 

### Description
- Added new logo asset at `assets/baluk-logo.svg` and replaced the old homepage markup in `index.html` with a new app shell including topbar, tab strip, address bar, content grid, web iframe and an AI assistant panel. 
- Replaced the old `script.js` logic with a comprehensive client-side controller that manages tab state, navigation history, search integration (`DuckDuckGo` + optional Wikipedia snippets), an AI assistant (`aiForm`) with `Agent Mode 2.0`, thinking UI, simulated agent cursor interactions, and local persistence in `localStorage` under `balukUser`. 
- Rewrote `style.css` to provide new theming variables, layouts, animations and responsive rules for the topbar, tabs, results, AI panel, intro overlay and global styling; includes visual elements such as spin/shimmer animations and web-glow effects. 
- Removed legacy video upload/profile flow and replaced it with login form, assistant UI, quick prompts and contextual site knowledge heuristics stored in `script.js` (`SITE_KNOWLEDGE`, `THINKING_LINES`). 

### Testing
- No automated tests were added or modified in this PR. 
- Existing CI/test configurations were not changed by this patch. 
- Recommend running a browser smoke test to validate interactive flows (tab creation/close, search results, AI panel actions and `Agent Mode 2.0`) as further validation because no automated coverage was introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2edf5b298832ca74a7142ecf54b41)