### PR TITLE
Replace MemTube with Baluk Screatch AI browser UI and assistant

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,52 +1,101 @@
-<!DOCTYPE html>
-<html lang="tr">
-<head>
-  <meta charset="UTF-8">
-  <title>MemTube</title>
-  <link rel="stylesheet" href="style.css">
-</head>
-<body>
+@DOCTYPE html 
+<html lang="tr"> 
+<head> 
+<meta charset="UTF-8"> 
+<meta name="viewport" content="width=device-width, initial-scale=1.0"> 
+<title>Baluk Screatch</title> 
+<link rel="stylesheet" href="style.css"> 
+</head> 
+<body> 
+<div id="introOverlay" class="intro-overlay"> 
+<div class="intro-card" id="introCard"> 
+<div class="intro-glow"></div> 
+<div class="intro-title">✦ Baluk Screatch</div> 
+</div> 
+<p class="intro-subtitle" id="introSubtitle">AI destekli tarayıcı</p> 
 
-  <!-- Kayıt Ekranı -->
-  <div id="girisEkrani">
-    <h2>MemTube'e Giriş</h2>
-    <input type="text" id="kullaniciAdi" placeholder="Takma Ad (zorunlu)">
-    <input type="file" id="profilResmi" accept="image/*">
-    <button onclick="girisYap()">Giriş Yap</button>
-  </div>
+</div> 
 
-  <!-- Ana Ekran -->
-  <div id="anaEkran" class="gizli">
-    <header>
-      <h1>📺 MemTube</h1>
-      <input type="text" id="arama" placeholder="Ara...">
-    </header>
+<div class="app-shell app-hidden" id="appShell"> 
+<header class="topbar"> 
+<div class="tab-row"> 
+<button class="tab active">Yeni Sekme</button> 
+</div> 
+<div class="browser-controls"> 
+<button id="geriBtn" title="Geri">◀</button> 
+<button id="ileriBtn" title="İleri">▶</button> 
+<button id="yenileBtn" title="Yenile">↻</button> 
+<button id="newTabBtn" title="Yeni pencere">＋</button> 
+</div> 
+<input id="adresCubugu" type="text" placeholder="Bağlantı aç (https://...)" /> 
+<button id="balukPanelBtn" class="baluk-mini">✦ Baluk.ai</button> 
+</header> 
 
-    <!-- Ana Sayfa -->
-    <main id="anaSayfa">
-      <div id="videoListe" class="video-galeri"></div>
-    </main>
+<main class="content-grid" id="contentGrid"> 
+<section class="search-screen" id="homeView"> 
+<h1>Baluk Screatch</h1> 
+<form id="aramaForm" class="search-box"> 
+<input id="aramaInput" type="text" placeholder="Web'de ara..." required> 
+<button type="submit">Ara</button> 
+</form> 
+<div id="sonuclar" class="results"></div> 
+</section> 
 
-    <!-- Hesabım Sayfası -->
-    <section id="hesabim" class="gizli">
-      <div id="profil">
-        <img id="profilGorsel" alt="Profil Resmi">
-        <h3 id="kAdi"></h3>
-      </div>
-      <h4>Videolarım</h4>
-      <input type="file" id="videoDosyasi" accept="video/*">
-      <input type="text" id="videoBaslik" placeholder="Video Başlığı">
-      <button onclick="videoYukle()">+ Yükle</button>
-      <div id="videolar" class="video-galeri"></div>
-    </section>
+<section class="web-screen hidden" id="webView"> 
+<iframe id="siteFrame" title="Baluk Screatch görüntüleyici"></iframe> 
+</section> 
 
-    <!-- Alt Menü -->
-    <nav id="altMenu">
-      <button onclick="goAnaSayfa()">🏠</button>
-      <button onclick="goHesabim()">👤</button>
-    </nav>
-  </div>
+<aside class="ai-panel hidden" id="aiPanel"> 
+<div class="panel-head"> 
+<div class="logo-head"> 
+<img src="assets/baluk-logo.svg" alt="Baluk.ai logosu" class="baluk-logo-head"> 
+<h2>Baluk.ai</h2> 
+</div> 
+<button id="closePanelBtn" class="close-panel">✕</button> 
+</div> 
 
-  <script src="script.js"></script>
-</body>
+<div id="authArea"> 
+<p>En iyi cevaplar için oturum açın.</p> 
+<form id="loginForm" class="stacked-form"> 
+<input type="email" id="mail" placeholder="Gmail / Email" required> 
+<input type="text" id="ad" placeholder="İsim" required> 
+<input type="text" id="soyad" placeholder="Soyisim" required> 
+<label>Profil resmi (isteğe bağlı)</label> 
+<input type="file" id="profil" accept="image/*"> 
+<button type="submit">Oturum Aç</button> 
+</form> 
+</div> 
+
+<div id="assistantArea" class="hidden assistant-layout"> 
+<div class="profile-card"> 
+<img id="profileAvatar" alt="Profil" src="" /> 
+<div> 
+<strong id="welcomeText"></strong> 
+<p id="profileMail"></p> 
+</div> 
+</div> 
+
+<div class="thinking-box hidden" id="thinkingBox"> 
+<img src="assets/baluk-logo.svg" alt="Baluk.ai" class="spin-logo" id="spinLogo"> 
+<p id="thinkingText">Baluk.ai düşünüyor...</p> 
+</div> 
+
+<div id="aiCevap" class="ai-answer"></div> 
+
+<form id="aiForm" class="ask-bar"> 
+<button type="button" id="plusBtn" class="plus-btn">＋</button> 
+<textarea id="aiSoru" rows="1" placeholder="Baluk.ai'ye yaz..." required></textarea> 
+<button type="submit" id="sendBtn">Gönder</button> 
+</form> 
+
+<div id="agentMenu" class="agent-menu hidden"> 
+<button type="button" id="agentModeBtn">Agent Mode</button> 
+</div> 
+</div> 
+</aside> 
+</main> 
+</div> 
+
+<script src="script.js"></script> 
+</body> 
 </html>

--- a/index.html
+++ b/index.html
@@ -7,16 +7,7 @@
 <link rel="stylesheet" href="style.css"> 
 </head> 
 <body> 
-<div id="introOverlay" class="intro-overlay"> 
-<div class="intro-card" id="introCard"> 
-<div class="intro-glow"></div> 
-<div class="intro-title">✦ Baluk Screatch</div> 
-</div> 
-<p class="intro-subtitle" id="introSubtitle">AI destekli tarayıcı</p> 
-
-</div> 
-
-<div class="app-shell app-hidden" id="appShell"> 
+<div class="app-shell" id="appShell"> 
 <header class="topbar"> 
 <div class="tab-row"> 
 <button class="tab active">Yeni Sekme</button> 

--- a/script.js
+++ b/script.js
@@ -1,97 +1,902 @@
-window.onload = () => {
-  const k = localStorage.getItem("kullaniciAdi");
-  const p = localStorage.getItem("profilResmi");
+const state = { 
+history: [], 
+index: -1, 
+user: JSON.parse(localStorage.getItem("balukUser") || "null"), 
+thinkingTimer: null, 
+thinkingTicker: null, 
+agentModeActive: false, 
+agentBusy: false, 
 
-  if (k && p) {
-    document.getElementById("girisEkrani").style.display = "none";
-    document.getElementById("anaEkran").classList.remove("gizli");
-    document.getElementById("kAdi").innerText = k;
-    document.getElementById("profilGorsel").src = p;
-    videolariYukle();
-  }
-};
 
-function girisYap() {
-  const k = document.getElementById("kullaniciAdi").value.trim();
-  const p = document.getElementById("profilResmi").files[0];
 
-  if (!k || !p) {
-    alert("Ad ve profil resmi gerekli kaptan!");
-    return;
-  }
+}; 
 
-  const reader = new FileReader();
-  reader.onload = () => {
-    localStorage.setItem("kullaniciAdi", k);
-    localStorage.setItem("profilResmi", reader.result);
-    location.reload();
-  };
-  reader.readAsDataURL(p);
-}
+const THINKING_LINES = [ 
+"Baluk.ai düşünüyor...", 
+"Web sayfasına bakıyorum...", 
+"Arama sonuçlarını inceliyorum...", 
+"Kaynaklardan kısa özet çıkarıyorum...", 
+"Cevabı netleştiriyorum..." 
+]; 
 
-function goAnaSayfa() {
-  document.getElementById("hesabim").classList.add("gizli");
-  document.getElementById("anaSayfa").style.display = "block";
-}
+const SITE_HINTS = { 
+"youtube.com": { name: "YouTube", purpose: "kullanıcıların video izleyip içerik yüklediği bir video paylaşım platformu", company: "Google / Alphabet", year: "2005", wiki: "YouTube" }, 
+"google.com": { name: "Google", purpose: "web araması ve internet servisleri sağlamak", company: "Google / Alphabet", year: "1998", wiki: "Google" }, 
+"wikipedia.org": { name: "Wikipedia", purpose: "özgür ansiklopedi içeriği sağlamak", company: "Wikimedia Foundation", year: "2001", wiki: "Wikipedia" }, 
+"github.com": { name: "GitHub", purpose: "yazılım projelerini Git tabanlı barındırma ve işbirliği", company: "GitHub (Microsoft)", year: "2008", wiki: "GitHub" }, 
+"instagram.com": { name: "Instagram", purpose: "fotoğraf/video paylaşımı ve sosyal etkileşim", company: "Meta", year: "2010", wiki: "Instagram" }, 
+"x.com": { name: "X", purpose: "kısa gönderilerle sosyal paylaşım ve haber akışı", company: "X Corp.", year: "2006", wiki: "Twitter" }, 
+"twitter.com": { name: "Twitter (X)", purpose: "kısa gönderilerle sosyal paylaşım ve haber akışı", company: "X Corp.", year: "2006", wiki: "Twitter" } 
+}; 
 
-function goHesabim() {
-  document.getElementById("anaSayfa").style.display = "none";
-  document.getElementById("hesabim").classList.remove("gizli");
-}
+const el = { 
+contentGrid: document.getElementById("contentGrid"), 
+aramaForm: document.getElementById("aramaForm"), 
+aramaInput: document.getElementById("aramaInput"), 
+sonuclar: document.getElementById("sonuclar"), 
+homeView: document.getElementById("homeView"), 
+webView: document.getElementById("webView"), 
+siteFrame: document.getElementById("siteFrame"), 
+adresCubugu: document.getElementById("adresCubugu"), 
+geriBtn: document.getElementById("geriBtn"), 
+ileriBtn: document.getElementById("ileriBtn"), 
+yenileBtn: document.getElementById("yenileBtn"), 
+newTabBtn: document.getElementById("newTabBtn"), 
+balukPanelBtn: document.getElementById("balukPanelBtn"), 
+aiPanel: document.getElementById("aiPanel"), 
+closePanelBtn: document.getElementById("closePanelBtn"), 
+loginForm: document.getElementById("loginForm"), 
+authArea: document.getElementById("authArea"), 
+assistantArea: document.getElementById("assistantArea"), 
+welcomeText: document.getElementById("welcomeText"), 
+profileMail: document.getElementById("profileMail"), 
+profileAvatar: document.getElementById("profileAvatar"), 
+aiForm: document.getElementById("aiForm"), 
+aiSoru: document.getElementById("aiSoru"), 
+thinkingBox: document.getElementById("thinkingBox"), 
+thinkingText: document.getElementById("thinkingText"), 
+spinLogo: document.getElementById("spinLogo"), 
+aiCevap: document.getElementById("aiCevap"), 
+plusBtn: document.getElementById("plusBtn"), 
+agentMenu: document.getElementById("agentMenu"), 
+agentModeBtn: document.getElementById("agentModeBtn"), 
+introOverlay: document.getElementById("introOverlay"), 
+introCard: document.getElementById("introCard"), 
+introSubtitle: document.getElementById("introSubtitle"), 
+appShell: document.getElementById("appShell"), 
+}; 
 
-function videoYukle() {
-  const dosya = document.getElementById("videoDosyasi").files[0];
-  const baslik = document.getElementById("videoBaslik").value;
-  const kullanici = localStorage.getItem("kullaniciAdi");
+const agentCursor = document.createElement("div"); 
+agentCursor.id = "agentCursor"; 
+agentCursor.style.cssText = "position:fixed;width:18px;height:18px;border:2px solid #b78cff;background:radial-gradient(circle,#6b24dd 0%,#141020 75%);border-radius:50%;box-shadow:0 0 18px rgba(141,69,255,.85);z-index:9999;pointer-events:none;opacity:0;transform:translate(-50%,-50%);transition:left .35s ease, top .35s ease, opacity .2s ease;"; 
+document.body.appendChild(agentCursor); 
 
-  if (!dosya || !baslik) {
-    alert("Video ve başlık eksik!");
-    return;
-  }
 
-  const videoURL = URL.createObjectURL(dosya);
-  const video = { baslik: baslik, url: videoURL, sahip: kullanici };
+function playIntroSound() { 
+try { 
+const audioCtx = new (window.AudioContext || window.webkitAudioContext)(); 
+const oscillator = audioCtx.createOscillator(); 
+const gain = audioCtx.createGain(); 
 
-  const mevcut = JSON.parse(localStorage.getItem("videolar") || "[]");
-  mevcut.push(video);
-  localStorage.setItem("videolar", JSON.stringify(mevcut));
-  videolariYukle();
+oscillator.type = "triangle"; 
+oscillator.frequency.setValueAtTime(180, audioCtx.currentTime); 
+oscillator.frequency.exponentialRampToValueAtTime(520, audioCtx.currentTime + 0.32); 
 
-  document.getElementById("videoDosyasi").value = "";
-  document.getElementById("videoBaslik").value = "";
-}
+gain.gain.setValueAtTime(0.0001, audioCtx.currentTime); 
+gain.gain.exponentialRampToValueAtTime(0.2, audioCtx.currentTime + 0.12); 
+gain.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + 0.82); 
 
-function videolariYukle() {
-  const videolar = JSON.parse(localStorage.getItem("videolar") || "[]");
-  const liste = document.getElementById("videoListe");
-  const hesap = document.getElementById("videolar");
-  const kullanici = localStorage.getItem("kullaniciAdi");
+oscillator.connect(gain); 
+gain.connect(audioCtx.destination); 
+oscillator.start(); 
+oscillator.stop(audioCtx.currentTime + 0.85); 
 
-  liste.innerHTML = "";
-  hesap.innerHTML = "";
+oscillator.onended = () => audioCtx.close(); 
+} catch { 
+// Sessiz geçiş fallback 
+} 
+} 
 
-  videolar.forEach((v, i) => {
-    const div = document.createElement("div");
-    div.className = "video";
-    div.innerHTML = `
-      <video src="${v.url}" controls></video>
-      <p>${v.baslik}</p>
-    `;
-    // Ana sayfaya herkesin videoları
-    liste.appendChild(div.cloneNode(true));
+function runIntro() { 
+const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches; 
+const introDuration = reducedMotion ? 2350 : 4800; 
 
-    // Sadece kendi videolarına silme butonu
-    if (v.sahip === kullanici) {
-      const divHesap = div.cloneNode(true);
-      const silBtn = document.createElement("button");
-      silBtn.innerText = "❌";
-      silBtn.onclick = () => {
-        videolar.splice(i, 1);
-        localStorage.setItem("videolar", JSON.stringify(videolar));
-        videolariYukle();
-      };
-      divHesap.appendChild(silBtn);
-      hesap.appendChild(divHesap);
-    }
-  });
-}
+if (!el.introOverlay || !el.appShell) return; 
+
+playIntroSound(); 
+
+setTimeout(() => { 
+el.introOverlay.classList.add("hidden"); 
+el.appShell.classList.remove("app-hidden"); 
+el.appShell.style.pointerEvents = "auto"; 
+}, introDuration); 
+} 
+
+function escapeHtml(text) { 
+return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#039;"); 
+} 
+
+function sleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); } 
+function ensureUrl(value) { return /^https?:\/\//i.test(value) ? value : `https://${value}`; } 
+
+function setPanel(open) { 
+el.aiPanel.classList.toggle("hidden", !open); 
+el.contentGrid.classList.toggle("with-panel", open); 
+} 
+
+function openUrl(url, addToHistory = true) { 
+if (!url) return; 
+const safe = ensureUrl(url); 
+el.siteFrame.src = safe; 
+el.adresCubugu.value = safe; 
+el.homeView.classList.add("hidden"); 
+el.webView.classList.remove("hidden"); 
+
+if (addToHistory) { 
+state.history = state.history.slice(0, state.index + 1); 
+state.history.push(safe); 
+state.index = state.history.length - 1; 
+} 
+} 
+
+function parseSite(urlCandidate) { 
+let url; 
+try { url = new URL(ensureUrl(urlCandidate)); } catch { return null; } 
+const host = url.hostname.replace(/^www\./, "").toLowerCase(); 
+const matchKey = Object.keys(SITE_HINTS).find((key) => host.endsWith(key)); 
+if (matchKey) return { ...SITE_HINTS[matchKey], host, url: url.href }; 
+
+const base = host.split(".")[0] || "web sitesi"; 
+return { 
+name: base.charAt(0).toUpperCase() + base.slice(1), 
+purpose: "webde bilgi/hizmet sunmak", 
+company: "kesin şirket bilgisi için site hakkında bölümü gerekir", 
+year: "kuruluş yılı net değil", 
+wiki: base 
+}; 
+
+} 
+
+async function fetchWikipediaSnippet(term) { 
+try { 
+const api = `https://tr.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(term)}`; 
+const res = await fetch(api); 
+if (!res.ok) return ""; 
+const data = await res.json(); 
+const text = (data.extract || "").trim(); 
+if (!text) return ""; 
+return text.slice(0, 200); 
+} catch { 
+return ""; 
+} 
+} 
+
+function renderAuth() { 
+if (state.user) { 
+el.authArea.classList.add("hidden"); 
+el.assistantArea.classList.remove("hidden"); 
+el.welcomeText.textContent = `${state.user.ad} ${state.user.soyad}`; 
+el.profileMail.textContent = state.user.email; 
+el.profileAvatar.src = state.user.profil || "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='70' height='70'%3E%3Crect width='100%25' height='100%25' fill='%23212a57'/%3E%3Ctext x='50%25' y='53%25' text-anchor='middle' fill='%23fff' font-size='22' font-family='Arial' dy='.3em'%3EB%3C/text%3E%3C/svg%3E"; 
+} else { 
+el.authArea.classList.remove("hidden"); 
+el.assistantArea.classList.add("hidden"); 
+} 
+} 
+
+function createFallbackResults(query) { 
+const q = encodeURIComponent(query); 
+return [ 
+{ title: `DuckDuckGo: ${query}`, href: `https://duckduckgo.com/?q=${q}`, snippet: "DuckDuckGo sonuç sayfasını açar." }, 
+{ title: `Wikipedia araması: ${query}`, href: `https://tr.wikipedia.org/wiki/Özel:Arama?search=${q}`, snippet: "Wikipedia üzerinden hızlı kaynak taraması." } 
+]; 
+} 
+
+async function getSearchResults(query) { 
+const response = await fetch(`https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_redirect=1&no_html=1`); 
+if (!response.ok) throw new Error("duckduckgo error"); 
+const data = await response.json(); 
+const parsed = []; 
+
+if (data.AbstractURL) parsed.push({ title: data.Heading || query, href: data.AbstractURL, snippet: data.AbstractText || "Özet bilgi" }); 
+
+(data.RelatedTopics || []).forEach((item) => { 
+if (item.FirstURL && item.Text) parsed.push({ title: item.Text.split(" - ")[0], href: item.FirstURL, snippet: item.Text }); 
+(item.Topics || []).forEach((sub) => { 
+if (sub.FirstURL && sub.Text) parsed.push({ title: sub.Text.split(" - ")[0], href: sub.FirstURL, snippet: sub.Text }); 
+}); 
+}); 
+
+return parsed.slice(0, 8); 
+} 
+
+function askAboutSite(url, customQuestion = "") { 
+setPanel(true); 
+if (!state.user) { 
+el.aiCevap.textContent = "Bu siteyi analiz etmek için önce giriş yapman gerekiyor."; 
+return; 
+} 
+const q = customQuestion || `Bu web sitesi ne amaçla kurulmuştur? (${url})`; 
+el.aiSoru.value = q; 
+el.aiForm.requestSubmit(); 
+} 
+
+function renderResults(results, query) { 
+if (!results.length) results = createFallbackResults(query); 
+el.sonuclar.innerHTML = ""; 
+
+results.forEach((item) => { 
+const card = document.createElement("article"); 
+card.className = "result-item"; 
+card.innerHTML = ` 
+<h3><a href="#">${escapeHtml(item.title)}</a></h3> 
+<p>${escapeHtml(item.snippet || "Açıklama yok")}</p> 
+<div class="result-actions"> 
+<button type="button" class="open-link">Bağlantıyı Aç</button> 
+<button type="button" class="ask-link">✦ Baluk.ai'ye Sor</button> 
+</div> 
+`; 
+card.querySelector("a").addEventListener("click", (e) => { e.preventDefault(); openUrl(item.href); }); 
+card.querySelector(".open-link").addEventListener("click", () => openUrl(item.href)); 
+card.querySelector(".ask-link").addEventListener("click", () => askAboutSite(item.href, `${item.title} sitesi ne işe yarar, kim tarafından kuruldu ve ne zaman kuruldu?`)); 
+el.sonuclar.appendChild(card); 
+}); 
+} 
+
+function startThinking() { 
+el.aiCevap.textContent = ""; 
+el.thinkingBox.classList.remove("hidden"); 
+el.spinLogo.classList.add("active"); 
+document.body.classList.add("web-glow"); 
+
+let idx = 0; 
+el.thinkingText.textContent = THINKING_LINES[0]; 
+state.thinkingTicker = setInterval(() => { 
+idx = (idx + 1) % THINKING_LINES.length; 
+el.thinkingText.textContent = THINKING_LINES[idx]; 
+}, 2400); 
+} 
+
+function stopThinking() { 
+clearInterval(state.thinkingTicker); 
+el.thinkingBox.classList.add("hidden"); 
+el.spinLogo.classList.remove("active"); 
+document.body.classList.remove("web-glow"); 
+} 
+
+async function buildAiAnswer(q) { 
+const currentUrl = el.adresCubugu.value || q.match(/https?:\/\/\S+/)?.[0] || ""; 
+const site = parseSite(currentUrl || "example.com"); 
+const siteName = site?.name || "Bu site"; 
+
+if (/kaç yılında|ne zaman/i.test(q)) return `${siteName} için bulduğum bilgi: kuruluş yılı ${site.year}.`; 
+if (/hangi şirket|kim tarafından/i.test(q)) return `${siteName} için şirket/kurucu bilgisi: ${site.company}.`; 
+
+if (/youtube|wikipedia|github|instagram|google|twitter|x\.com|web sitesi|site hakkında|hakkında bilgi|amaç/i.test(q)) { 
+const wiki = await fetchWikipediaSnippet(site.wiki || siteName); 
+if (wiki) { 
+return `${siteName}: ${site.purpose}.\n\nWikipedia özeti (ilk 200 karakter): ${wiki}`; 
+} 
+return `${siteName}: ${site.purpose}. Şirket: ${site.company}. Kuruluş: ${site.year}.`; 
+} 
+
+return `${siteName} özeti: ${site.year} yılında kurulduğu biliniyor, ${site.company} tarafından geliştirildi/işletiliyor ve ana amacı ${site.purpose}.`; 
+} 
+
+function parseAgentCommand(text) { 
+const cleaned = text.toLowerCase().trim(); 
+const searchMatch = cleaned.match(/(?:arat|ara)\s*:?\s*(.+?)(?:\s+çıkan|$)/i) || cleaned.match(/(.+?)\s+arat/i); 
+const query = searchMatch ? searchMatch[1].trim() : text.trim(); 
+
+const indexMatch = cleaned.match(/(\d+)\.?\s*(link|sonuç)/i); 
+const index = indexMatch ? Math.max(1, Number(indexMatch[1])) : 1; 
+
+return { query, index }; 
+} 
+
+function moveCursorTo(element) { 
+const rect = element.getBoundingClientRect(); 
+agentCursor.style.opacity = "1"; 
+agentCursor.style.left = `${rect.left + rect.width / 2}px`; 
+agentCursor.style.top = `${rect.top + rect.height / 2}px`; 
+} 
+
+function hideCursor() { 
+agentCursor.style.opacity = "0"; 
+} 
+
+async function runAgentSearchFlow(commandText) { 
+if (state.agentBusy) return "Agent Mode meşgul, işlem bitmesini bekle."; 
+state.agentBusy = true; 
+
+
+
+try { 
+const { query, index } = parseAgentCommand(commandText); 
+if (!query) return "Agent Mode: Aratılacak ifadeyi anlayamadım."; 
+
+el.homeView.classList.remove("hidden"); 
+el.webView.classList.add("hidden"); 
+
+moveCursorTo(el.aramaInput); 
+await sleep(300); 
+el.aramaInput.focus(); 
+el.aramaInput.value = ""; 
+
+for (const ch of query) { 
+el.aramaInput.value += ch; 
+await sleep(35); 
+
+
+
+
+
+
+
+
+
+
+
+} 
+
+await sleep(240); 
+el.aramaForm.requestSubmit(); 
+await sleep(1300); 
+
+const cards = [...document.querySelectorAll(".result-item")]; 
+if (!cards.length) return `"${query}" için sonuç bulunamadı.`; 
+
+const targetCard = cards[Math.min(index - 1, cards.length - 1)]; 
+const openBtn = targetCard.querySelector(".open-link"); 
+if (!openBtn) return "Hedef bağlantı bulunamadı."; 
+
+moveCursorTo(openBtn); 
+await sleep(420); 
+openBtn.click(); 
+await sleep(420); 
+
+return `Agent Mode tamamlandı: "${query}" aratıldı ve ${Math.min(index, cards.length)}. link açıldı.`; 
+} finally { 
+hideCursor(); 
+state.agentBusy = false; 
+state.agentModeActive = false; 
+} 
+} 
+
+el.aramaForm.addEventListener("submit", async (event) => { 
+event.preventDefault(); 
+const q = el.aramaInput.value.trim(); 
+if (!q) return; 
+el.sonuclar.innerHTML = "Aranıyor..."; 
+
+try { 
+const results = await getSearchResults(q); 
+renderResults(results, q); 
+} catch { 
+renderResults(createFallbackResults(q), q); 
+} 
+}); 
+
+el.adresCubugu.addEventListener("keydown", (e) => { if (e.key === "Enter") openUrl(el.adresCubugu.value); }); 
+el.geriBtn.addEventListener("click", () => { if (state.index > 0) openUrl(state.history[--state.index], false); }); 
+el.ileriBtn.addEventListener("click", () => { if (state.index < state.history.length - 1) openUrl(state.history[++state.index], false); }); 
+el.yenileBtn.addEventListener("click", () => { if (el.siteFrame.src) el.siteFrame.src = el.siteFrame.src; }); 
+el.newTabBtn.addEventListener("click", () => { el.homeView.classList.remove("hidden"); el.webView.classList.add("hidden"); el.adresCubugu.value = ""; }); 
+el.balukPanelBtn.addEventListener("click", () => setPanel(el.aiPanel.classList.contains("hidden"))); 
+el.closePanelBtn.addEventListener("click", () => setPanel(false)); 
+
+el.loginForm.addEventListener("submit", (e) => { 
+e.preventDefault(); 
+const user = { 
+email: document.getElementById("mail").value.trim(), 
+ad: document.getElementById("ad").value.trim(), 
+soyad: document.getElementById("soyad").value.trim() 
+}; 
+const file = document.getElementById("profil").files[0]; 
+if (!user.email || !user.ad || !user.soyad) return; 
+
+if (file) { 
+const reader = new FileReader(); 
+reader.onload = () => { 
+user.profil = reader.result; 
+state.user = user; 
+localStorage.setItem("balukUser", JSON.stringify(user)); 
+renderAuth(); 
+}; 
+reader.readAsDataURL(file); 
+} else { 
+state.user = user; 
+localStorage.setItem("balukUser", JSON.stringify(user)); 
+renderAuth(); 
+} 
+}); 
+
+el.plusBtn.addEventListener("click", () => el.agentMenu.classList.toggle("hidden")); 
+el.agentModeBtn.addEventListener("click", () => { 
+state.agentModeActive = true; 
+el.agentMenu.classList.add("hidden"); 
+el.aiCevap.textContent = "Agent Mode aktif. Komut ver: örn 'youtube arat çıkan 3. linke tıkla'. Link belirtilmezse 1. link açılır."; 
+setPanel(true); 
+}); 
+
+el.aiForm.addEventListener("submit", async (e) => { 
+e.preventDefault(); 
+const q = el.aiSoru.value.trim(); 
+if (!q) return; 
+
+if (state.agentModeActive) { 
+el.aiCevap.textContent = await runAgentSearchFlow(q); 
+el.aiSoru.value = ""; 
+return; 
+} 
+
+startThinking(); 
+clearTimeout(state.thinkingTimer); 
+state.thinkingTimer = setTimeout(async () => { 
+stopThinking(); 
+el.aiCevap.textContent = await buildAiAnswer(q); 
+el.aiSoru.value = ""; 
+}, 20000); 
+}); 
+
+el.aiSoru.addEventListener("keydown", (e) => { 
+if (e.key === "Enter" && !e.shiftKey) { 
+e.preventDefault(); 
+el.aiForm.requestSubmit(); 
+} 
+}); 
+
+renderAuth(); 
+setPanel(false); 
+runIntro();
+const state = { 
+history: [], 
+index: -1, 
+user: JSON.parse(localStorage.getItem("balukUser") || "null"), 
+thinkingTimer: null, 
+thinkingTicker: null, 
+agentModeActive: false, 
+agentBusy: false, 
+
+
+
+}; 
+
+const THINKING_LINES = [ 
+"Baluk.ai düşünüyor...", 
+"Web sayfasına bakıyorum...", 
+"Arama sonuçlarını inceliyorum...", 
+"Kaynaklardan kısa özet çıkarıyorum...", 
+"Cevabı netleştiriyorum..." 
+]; 
+
+const SITE_HINTS = { 
+"youtube.com": { name: "YouTube", purpose: "kullanıcıların video izleyip içerik yüklediği bir video paylaşım platformu", company: "Google / Alphabet", year: "2005", wiki: "YouTube" }, 
+"google.com": { name: "Google", purpose: "web araması ve internet servisleri sağlamak", company: "Google / Alphabet", year: "1998", wiki: "Google" }, 
+"wikipedia.org": { name: "Wikipedia", purpose: "özgür ansiklopedi içeriği sağlamak", company: "Wikimedia Foundation", year: "2001", wiki: "Wikipedia" }, 
+"github.com": { name: "GitHub", purpose: "yazılım projelerini Git tabanlı barındırma ve işbirliği", company: "GitHub (Microsoft)", year: "2008", wiki: "GitHub" }, 
+"instagram.com": { name: "Instagram", purpose: "fotoğraf/video paylaşımı ve sosyal etkileşim", company: "Meta", year: "2010", wiki: "Instagram" }, 
+"x.com": { name: "X", purpose: "kısa gönderilerle sosyal paylaşım ve haber akışı", company: "X Corp.", year: "2006", wiki: "Twitter" }, 
+"twitter.com": { name: "Twitter (X)", purpose: "kısa gönderilerle sosyal paylaşım ve haber akışı", company: "X Corp.", year: "2006", wiki: "Twitter" } 
+}; 
+
+const el = { 
+contentGrid: document.getElementById("contentGrid"), 
+aramaForm: document.getElementById("aramaForm"), 
+aramaInput: document.getElementById("aramaInput"), 
+sonuclar: document.getElementById("sonuclar"), 
+homeView: document.getElementById("homeView"), 
+webView: document.getElementById("webView"), 
+siteFrame: document.getElementById("siteFrame"), 
+adresCubugu: document.getElementById("adresCubugu"), 
+geriBtn: document.getElementById("geriBtn"), 
+ileriBtn: document.getElementById("ileriBtn"), 
+yenileBtn: document.getElementById("yenileBtn"), 
+newTabBtn: document.getElementById("newTabBtn"), 
+balukPanelBtn: document.getElementById("balukPanelBtn"), 
+aiPanel: document.getElementById("aiPanel"), 
+closePanelBtn: document.getElementById("closePanelBtn"), 
+loginForm: document.getElementById("loginForm"), 
+authArea: document.getElementById("authArea"), 
+assistantArea: document.getElementById("assistantArea"), 
+welcomeText: document.getElementById("welcomeText"), 
+profileMail: document.getElementById("profileMail"), 
+profileAvatar: document.getElementById("profileAvatar"), 
+aiForm: document.getElementById("aiForm"), 
+aiSoru: document.getElementById("aiSoru"), 
+thinkingBox: document.getElementById("thinkingBox"), 
+thinkingText: document.getElementById("thinkingText"), 
+spinLogo: document.getElementById("spinLogo"), 
+aiCevap: document.getElementById("aiCevap"), 
+plusBtn: document.getElementById("plusBtn"), 
+agentMenu: document.getElementById("agentMenu"), 
+agentModeBtn: document.getElementById("agentModeBtn"), 
+introOverlay: document.getElementById("introOverlay"), 
+introCard: document.getElementById("introCard"), 
+introSubtitle: document.getElementById("introSubtitle"), 
+appShell: document.getElementById("appShell"), 
+}; 
+
+const agentCursor = document.createElement("div"); 
+agentCursor.id = "agentCursor"; 
+agentCursor.style.cssText = "position:fixed;width:18px;height:18px;border:2px solid #b78cff;background:radial-gradient(circle,#6b24dd 0%,#141020 75%);border-radius:50%;box-shadow:0 0 18px rgba(141,69,255,.85);z-index:9999;pointer-events:none;opacity:0;transform:translate(-50%,-50%);transition:left .35s ease, top .35s ease, opacity .2s ease;"; 
+document.body.appendChild(agentCursor); 
+
+
+function playIntroSound() { 
+try { 
+const audioCtx = new (window.AudioContext || window.webkitAudioContext)(); 
+const oscillator = audioCtx.createOscillator(); 
+const gain = audioCtx.createGain(); 
+
+oscillator.type = "triangle"; 
+oscillator.frequency.setValueAtTime(180, audioCtx.currentTime); 
+oscillator.frequency.exponentialRampToValueAtTime(520, audioCtx.currentTime + 0.32); 
+
+gain.gain.setValueAtTime(0.0001, audioCtx.currentTime); 
+gain.gain.exponentialRampToValueAtTime(0.2, audioCtx.currentTime + 0.12); 
+gain.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + 0.82); 
+
+oscillator.connect(gain); 
+gain.connect(audioCtx.destination); 
+oscillator.start(); 
+oscillator.stop(audioCtx.currentTime + 0.85); 
+
+oscillator.onended = () => audioCtx.close(); 
+} catch { 
+// Sessiz geçiş fallback 
+} 
+} 
+
+function runIntro() { 
+const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches; 
+const introDuration = reducedMotion ? 2350 : 4800; 
+
+if (!el.introOverlay || !el.appShell) return; 
+
+playIntroSound(); 
+
+setTimeout(() => { 
+el.introOverlay.classList.add("hidden"); 
+el.appShell.classList.remove("app-hidden"); 
+el.appShell.style.pointerEvents = "auto"; 
+}, introDuration); 
+} 
+
+function escapeHtml(text) { 
+return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#039;"); 
+} 
+
+function sleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); } 
+function ensureUrl(value) { return /^https?:\/\//i.test(value) ? value : `https://${value}`; } 
+
+function setPanel(open) { 
+el.aiPanel.classList.toggle("hidden", !open); 
+el.contentGrid.classList.toggle("with-panel", open); 
+} 
+
+function openUrl(url, addToHistory = true) { 
+if (!url) return; 
+const safe = ensureUrl(url); 
+el.siteFrame.src = safe; 
+el.adresCubugu.value = safe; 
+el.homeView.classList.add("hidden"); 
+el.webView.classList.remove("hidden"); 
+
+if (addToHistory) { 
+state.history = state.history.slice(0, state.index + 1); 
+state.history.push(safe); 
+state.index = state.history.length - 1; 
+} 
+} 
+
+function parseSite(urlCandidate) { 
+let url; 
+try { url = new URL(ensureUrl(urlCandidate)); } catch { return null; } 
+const host = url.hostname.replace(/^www\./, "").toLowerCase(); 
+const matchKey = Object.keys(SITE_HINTS).find((key) => host.endsWith(key)); 
+if (matchKey) return { ...SITE_HINTS[matchKey], host, url: url.href }; 
+
+const base = host.split(".")[0] || "web sitesi"; 
+return { 
+name: base.charAt(0).toUpperCase() + base.slice(1), 
+purpose: "webde bilgi/hizmet sunmak", 
+company: "kesin şirket bilgisi için site hakkında bölümü gerekir", 
+year: "kuruluş yılı net değil", 
+wiki: base 
+}; 
+
+} 
+
+async function fetchWikipediaSnippet(term) { 
+try { 
+const api = `https://tr.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(term)}`; 
+const res = await fetch(api); 
+if (!res.ok) return ""; 
+const data = await res.json(); 
+const text = (data.extract || "").trim(); 
+if (!text) return ""; 
+return text.slice(0, 200); 
+} catch { 
+return ""; 
+} 
+} 
+
+function renderAuth() { 
+if (state.user) { 
+el.authArea.classList.add("hidden"); 
+el.assistantArea.classList.remove("hidden"); 
+el.welcomeText.textContent = `${state.user.ad} ${state.user.soyad}`; 
+el.profileMail.textContent = state.user.email; 
+el.profileAvatar.src = state.user.profil || "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='70' height='70'%3E%3Crect width='100%25' height='100%25' fill='%23212a57'/%3E%3Ctext x='50%25' y='53%25' text-anchor='middle' fill='%23fff' font-size='22' font-family='Arial' dy='.3em'%3EB%3C/text%3E%3C/svg%3E"; 
+} else { 
+el.authArea.classList.remove("hidden"); 
+el.assistantArea.classList.add("hidden"); 
+} 
+} 
+
+function createFallbackResults(query) { 
+const q = encodeURIComponent(query); 
+return [ 
+{ title: `DuckDuckGo: ${query}`, href: `https://duckduckgo.com/?q=${q}`, snippet: "DuckDuckGo sonuç sayfasını açar." }, 
+{ title: `Wikipedia araması: ${query}`, href: `https://tr.wikipedia.org/wiki/Özel:Arama?search=${q}`, snippet: "Wikipedia üzerinden hızlı kaynak taraması." } 
+]; 
+} 
+
+async function getSearchResults(query) { 
+const response = await fetch(`https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_redirect=1&no_html=1`); 
+if (!response.ok) throw new Error("duckduckgo error"); 
+const data = await response.json(); 
+const parsed = []; 
+
+if (data.AbstractURL) parsed.push({ title: data.Heading || query, href: data.AbstractURL, snippet: data.AbstractText || "Özet bilgi" }); 
+
+(data.RelatedTopics || []).forEach((item) => { 
+if (item.FirstURL && item.Text) parsed.push({ title: item.Text.split(" - ")[0], href: item.FirstURL, snippet: item.Text }); 
+(item.Topics || []).forEach((sub) => { 
+if (sub.FirstURL && sub.Text) parsed.push({ title: sub.Text.split(" - ")[0], href: sub.FirstURL, snippet: sub.Text }); 
+}); 
+}); 
+
+return parsed.slice(0, 8); 
+} 
+
+function askAboutSite(url, customQuestion = "") { 
+setPanel(true); 
+if (!state.user) { 
+el.aiCevap.textContent = "Bu siteyi analiz etmek için önce giriş yapman gerekiyor."; 
+return; 
+} 
+const q = customQuestion || `Bu web sitesi ne amaçla kurulmuştur? (${url})`; 
+el.aiSoru.value = q; 
+el.aiForm.requestSubmit(); 
+} 
+
+function renderResults(results, query) { 
+if (!results.length) results = createFallbackResults(query); 
+el.sonuclar.innerHTML = ""; 
+
+results.forEach((item) => { 
+const card = document.createElement("article"); 
+card.className = "result-item"; 
+card.innerHTML = ` 
+<h3><a href="#">${escapeHtml(item.title)}</a></h3> 
+<p>${escapeHtml(item.snippet || "Açıklama yok")}</p> 
+<div class="result-actions"> 
+<button type="button" class="open-link">Bağlantıyı Aç</button> 
+<button type="button" class="ask-link">✦ Baluk.ai'ye Sor</button> 
+</div> 
+`; 
+card.querySelector("a").addEventListener("click", (e) => { e.preventDefault(); openUrl(item.href); }); 
+card.querySelector(".open-link").addEventListener("click", () => openUrl(item.href)); 
+card.querySelector(".ask-link").addEventListener("click", () => askAboutSite(item.href, `${item.title} sitesi ne işe yarar, kim tarafından kuruldu ve ne zaman kuruldu?`)); 
+el.sonuclar.appendChild(card); 
+}); 
+} 
+
+function startThinking() { 
+el.aiCevap.textContent = ""; 
+el.thinkingBox.classList.remove("hidden"); 
+el.spinLogo.classList.add("active"); 
+document.body.classList.add("web-glow"); 
+
+let idx = 0; 
+el.thinkingText.textContent = THINKING_LINES[0]; 
+state.thinkingTicker = setInterval(() => { 
+idx = (idx + 1) % THINKING_LINES.length; 
+el.thinkingText.textContent = THINKING_LINES[idx]; 
+}, 2400); 
+} 
+
+function stopThinking() { 
+clearInterval(state.thinkingTicker); 
+el.thinkingBox.classList.add("hidden"); 
+el.spinLogo.classList.remove("active"); 
+document.body.classList.remove("web-glow"); 
+} 
+
+async function buildAiAnswer(q) { 
+const currentUrl = el.adresCubugu.value || q.match(/https?:\/\/\S+/)?.[0] || ""; 
+const site = parseSite(currentUrl || "example.com"); 
+const siteName = site?.name || "Bu site"; 
+
+if (/kaç yılında|ne zaman/i.test(q)) return `${siteName} için bulduğum bilgi: kuruluş yılı ${site.year}.`; 
+if (/hangi şirket|kim tarafından/i.test(q)) return `${siteName} için şirket/kurucu bilgisi: ${site.company}.`; 
+
+if (/youtube|wikipedia|github|instagram|google|twitter|x\.com|web sitesi|site hakkında|hakkında bilgi|amaç/i.test(q)) { 
+const wiki = await fetchWikipediaSnippet(site.wiki || siteName); 
+if (wiki) { 
+return `${siteName}: ${site.purpose}.\n\nWikipedia özeti (ilk 200 karakter): ${wiki}`; 
+} 
+return `${siteName}: ${site.purpose}. Şirket: ${site.company}. Kuruluş: ${site.year}.`; 
+} 
+
+return `${siteName} özeti: ${site.year} yılında kurulduğu biliniyor, ${site.company} tarafından geliştirildi/işletiliyor ve ana amacı ${site.purpose}.`; 
+} 
+
+function parseAgentCommand(text) { 
+const cleaned = text.toLowerCase().trim(); 
+const searchMatch = cleaned.match(/(?:arat|ara)\s*:?\s*(.+?)(?:\s+çıkan|$)/i) || cleaned.match(/(.+?)\s+arat/i); 
+const query = searchMatch ? searchMatch[1].trim() : text.trim(); 
+
+const indexMatch = cleaned.match(/(\d+)\.?\s*(link|sonuç)/i); 
+const index = indexMatch ? Math.max(1, Number(indexMatch[1])) : 1; 
+
+return { query, index }; 
+} 
+
+function moveCursorTo(element) { 
+const rect = element.getBoundingClientRect(); 
+agentCursor.style.opacity = "1"; 
+agentCursor.style.left = `${rect.left + rect.width / 2}px`; 
+agentCursor.style.top = `${rect.top + rect.height / 2}px`; 
+} 
+
+function hideCursor() { 
+agentCursor.style.opacity = "0"; 
+} 
+
+async function runAgentSearchFlow(commandText) { 
+if (state.agentBusy) return "Agent Mode meşgul, işlem bitmesini bekle."; 
+state.agentBusy = true; 
+
+
+
+try { 
+const { query, index } = parseAgentCommand(commandText); 
+if (!query) return "Agent Mode: Aratılacak ifadeyi anlayamadım."; 
+
+el.homeView.classList.remove("hidden"); 
+el.webView.classList.add("hidden"); 
+
+moveCursorTo(el.aramaInput); 
+await sleep(300); 
+el.aramaInput.focus(); 
+el.aramaInput.value = ""; 
+
+for (const ch of query) { 
+el.aramaInput.value += ch; 
+await sleep(35); 
+
+
+
+
+
+
+
+
+
+
+
+} 
+
+await sleep(240); 
+el.aramaForm.requestSubmit(); 
+await sleep(1300); 
+
+const cards = [...document.querySelectorAll(".result-item")]; 
+if (!cards.length) return `"${query}" için sonuç bulunamadı.`; 
+
+const targetCard = cards[Math.min(index - 1, cards.length - 1)]; 
+const openBtn = targetCard.querySelector(".open-link"); 
+if (!openBtn) return "Hedef bağlantı bulunamadı."; 
+
+moveCursorTo(openBtn); 
+await sleep(420); 
+openBtn.click(); 
+await sleep(420); 
+
+return `Agent Mode tamamlandı: "${query}" aratıldı ve ${Math.min(index, cards.length)}. link açıldı.`; 
+} finally { 
+hideCursor(); 
+state.agentBusy = false; 
+state.agentModeActive = false; 
+} 
+} 
+
+el.aramaForm.addEventListener("submit", async (event) => { 
+event.preventDefault(); 
+const q = el.aramaInput.value.trim(); 
+if (!q) return; 
+el.sonuclar.innerHTML = "Aranıyor..."; 
+
+try { 
+const results = await getSearchResults(q); 
+renderResults(results, q); 
+} catch { 
+renderResults(createFallbackResults(q), q); 
+} 
+}); 
+
+el.adresCubugu.addEventListener("keydown", (e) => { if (e.key === "Enter") openUrl(el.adresCubugu.value); }); 
+el.geriBtn.addEventListener("click", () => { if (state.index > 0) openUrl(state.history[--state.index], false); }); 
+el.ileriBtn.addEventListener("click", () => { if (state.index < state.history.length - 1) openUrl(state.history[++state.index], false); }); 
+el.yenileBtn.addEventListener("click", () => { if (el.siteFrame.src) el.siteFrame.src = el.siteFrame.src; }); 
+el.newTabBtn.addEventListener("click", () => { el.homeView.classList.remove("hidden"); el.webView.classList.add("hidden"); el.adresCubugu.value = ""; }); 
+el.balukPanelBtn.addEventListener("click", () => setPanel(el.aiPanel.classList.contains("hidden"))); 
+el.closePanelBtn.addEventListener("click", () => setPanel(false)); 
+
+el.loginForm.addEventListener("submit", (e) => { 
+e.preventDefault(); 
+const user = { 
+email: document.getElementById("mail").value.trim(), 
+ad: document.getElementById("ad").value.trim(), 
+soyad: document.getElementById("soyad").value.trim() 
+}; 
+const file = document.getElementById("profil").files[0]; 
+if (!user.email || !user.ad || !user.soyad) return; 
+
+if (file) { 
+const reader = new FileReader(); 
+reader.onload = () => { 
+user.profil = reader.result; 
+state.user = user; 
+localStorage.setItem("balukUser", JSON.stringify(user)); 
+renderAuth(); 
+}; 
+reader.readAsDataURL(file); 
+} else { 
+state.user = user; 
+localStorage.setItem("balukUser", JSON.stringify(user)); 
+renderAuth(); 
+} 
+}); 
+
+el.plusBtn.addEventListener("click", () => el.agentMenu.classList.toggle("hidden")); 
+el.agentModeBtn.addEventListener("click", () => { 
+state.agentModeActive = true; 
+el.agentMenu.classList.add("hidden"); 
+el.aiCevap.textContent = "Agent Mode aktif. Komut ver: örn 'youtube arat çıkan 3. linke tıkla'. Link belirtilmezse 1. link açılır."; 
+setPanel(true); 
+}); 
+
+el.aiForm.addEventListener("submit", async (e) => { 
+e.preventDefault(); 
+const q = el.aiSoru.value.trim(); 
+if (!q) return; 
+
+if (state.agentModeActive) { 
+el.aiCevap.textContent = await runAgentSearchFlow(q); 
+el.aiSoru.value = ""; 
+return; 
+} 
+
+startThinking(); 
+clearTimeout(state.thinkingTimer); 
+state.thinkingTimer = setTimeout(async () => { 
+stopThinking(); 
+el.aiCevap.textContent = await buildAiAnswer(q); 
+el.aiSoru.value = ""; 
+}, 20000); 
+}); 
+
+el.aiSoru.addEventListener("keydown", (e) => { 
+if (e.key === "Enter" && !e.shiftKey) { 
+e.preventDefault(); 
+el.aiForm.requestSubmit(); 
+} 
+}); 
+
+renderAuth(); 
+setPanel(false); 
+runIntro();

--- a/style.css
+++ b/style.css
@@ -1,108 +1,562 @@
-body {
-  margin: 0;
-  font-family: Arial, sans-serif;
-  background-color: #0d0d0d;
-  color: white;
-}
+:root { 
+--night: #080b18; 
+--glow-purple: #8d45ff; 
+--text: #f7f6ff; 
+--soft-border: rgba(141, 69, 255, 0.32); 
+} 
+* { box-sizing: border-box; } 
+body { 
+margin: 0; 
+font-family: Inter, Arial, sans-serif; 
+color: var(--text); 
+background: radial-gradient(circle at top, #2a1454 0%, #0b1130 45%, #05070f 100%); 
+min-height: 100vh; 
+transition: box-shadow 0.4s ease; 
+} 
+.hidden { display: none !important; } 
 
-.gizli {
-  display: none;
-}
+.topbar { 
+display: grid; 
+grid-template-columns: auto auto 1fr auto; 
+gap: 10px; 
+align-items: center; 
+padding: 10px 14px; 
+background: rgba(8, 11, 24, 0.88); 
+border-bottom: 1px solid var(--soft-border); 
+position: sticky; 
+top: 0; 
+z-index: 10; 
+backdrop-filter: blur(6px); 
+} 
+.tab { background: #1d2140; border: 1px solid #31386d; color: #ded4ff; border-radius: 10px; padding: 8px 14px; } 
 
-#girisEkrani {
-  text-align: center;
-  padding: 40px;
-}
+.browser-controls button, 
+.search-box button, 
+.stacked-form button, 
+#sendBtn, 
+.agent-menu button, 
+.close-panel, 
+.result-actions button { 
+border: 1px solid #5a3fa0; 
+background: #1c2146; 
+color: var(--text); 
+border-radius: 10px; 
+padding: 8px 12px; 
+cursor: pointer; 
+} 
 
-#girisEkrani input, #girisEkrani button {
-  display: block;
-  margin: 10px auto;
-  padding: 10px;
-  width: 80%;
-}
+#adresCubugu, 
+.search-box input, 
+.stacked-form input, 
+#aiSoru { 
+width: 100%; 
+background: #0f1431; 
+color: var(--text); 
+border: 1px solid #3f4678; 
+border-radius: 10px; 
+padding: 10px; 
 
-header {
-  background-color: #1a1a1a;
-  padding: 10px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
+} 
 
-#arama {
-  padding: 8px;
-  border-radius: 5px;
-  border: none;
-}
+.baluk-mini { 
+border: 1px solid #8f4bff; 
+background: linear-gradient(135deg, #311062, #6e2ee2); 
+color: #fff; 
+font-weight: 700; 
+border-radius: 12px; 
+padding: 10px 14px; 
+box-shadow: 0 0 20px rgba(141, 69, 255, 0.7), inset 0 0 8px rgba(255,255,255,0.2); 
+} 
 
-.video-galeri {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 15px;
-  justify-content: center;
-  padding: 20px;
-}
+.content-grid { 
+display: grid; 
+grid-template-columns: 1fr; 
+min-height: calc(100vh - 69px); 
+transition: grid-template-columns .35s ease; 
+} 
+.content-grid.with-panel { grid-template-columns: 1fr 350px; } 
 
-.video {
-  background: #1a1a1a;
-  padding: 10px;
-  border-radius: 10px;
-  width: 200px;
-  text-align: center;
-  position: relative;
-}
+.search-screen, 
+.web-screen { padding: 38px 20px; } 
+.search-screen h1 { 
+text-align: center; 
+margin-top: 60px; 
+font-size: clamp(2rem, 6vw, 3.8rem); 
+color: #e1d1ff; 
+text-shadow: 0 0 10px rgba(141, 69, 255, 0.8), 0 0 24px rgba(141, 69, 255, 0.6); 
+} 
 
-.video video {
-  width: 100%;
-  border-radius: 5px;
-}
+.search-box { 
+max-width: 760px; 
+margin: 16px auto 24px; 
+display: grid; 
+grid-template-columns: 1fr auto; 
+gap: 10px; 
+} 
+.results { 
+max-width: 920px; 
+margin: 0 auto; 
+display: grid; 
+gap: 14px; 
+} 
+.result-item { 
+background: linear-gradient(180deg, rgba(19, 23, 49, 0.92), rgba(11, 15, 33, 0.92)); 
+border: 1px solid var(--soft-border); 
+border-radius: 16px; 
+padding: 14px; 
+} 
+.result-item h3 { margin: 0 0 6px; } 
+.result-item p { margin: 0 0 10px; color: #d5ceee; } 
+.result-item a { color: #d9c6ff; text-decoration: none; } 
+.result-actions { display: flex; gap: 8px; } 
+.result-actions button:last-child { 
+background: linear-gradient(135deg, #3d1678, #6d2de2); 
+border-color: #a77eff; 
+box-shadow: 0 0 12px rgba(141,69,255,.45); 
+} 
 
-.video button {
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  background: red;
-  color: white;
-  border: none;
-  border-radius: 50%;
-  padding: 5px;
-  cursor: pointer;
-}
+#siteFrame { 
+width: 100%; 
+height: calc(100vh - 150px); 
+border: 1px solid rgba(141, 69, 255, 0.42); 
+border-radius: 14px; 
+background: white; 
+} 
 
-#profil {
-  text-align: center;
-  margin-top: 20px;
-}
+.ai-panel { 
+border-left: 1px solid var(--soft-border); 
+background: linear-gradient(180deg, rgba(14, 16, 38, 0.99), rgba(8, 10, 21, 0.98)); 
+padding: 14px; 
+height: calc(100vh - 69px); 
+display: flex; 
+flex-direction: column; 
 
-#profil img {
-  width: 100px;
-  height: 100px;
-  border-radius: 50%;
-  object-fit: cover;
-  background-color: white;
-}
 
-#videoDosyasi, #videoBaslik {
-  display: block;
-  margin: 10px auto;
-  padding: 8px;
-  width: 80%;
-}
 
-nav#altMenu {
-  position: fixed;
-  bottom: 0;
-  width: 100%;
-  background: #111;
-  display: flex;
-  justify-content: space-around;
-  padding: 10px 0;
-}
+} 
+.panel-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; } 
+.logo-head { display: flex; align-items: center; gap: 8px; } 
+.baluk-logo-head { width: 42px; height: 18px; object-fit: contain; filter: brightness(2.2) contrast(0.7); } 
 
-nav button {
-  background: none;
-  border: none;
-  color: white;
-  font-size: 24px;
-  cursor: pointer;
-}
+.profile-card { 
+display: flex; 
+align-items: center; 
+gap: 10px; 
+border: 1px solid var(--soft-border); 
+border-radius: 12px; 
+padding: 10px; 
+background: rgba(141, 69, 255, 0.1); 
+} 
+#profileAvatar { 
+width: 52px; height: 52px; border-radius: 50%; object-fit: cover; 
+border: 2px solid rgba(255,255,255,0.35); background: #1e254e; 
+} 
+#profileMail { margin: 2px 0 0; color: #cab9ff; font-size: .85rem; } 
+
+.assistant-layout { height: 100%; display: flex; flex-direction: column; gap: 12px; } 
+.ai-answer { 
+flex: 1; 
+overflow: auto; 
+background: rgba(15, 20, 43, 0.72); 
+border: 1px solid rgba(141,69,255,0.25); 
+border-radius: 12px; 
+padding: 12px; 
+line-height: 1.5; 
+} 
+.thinking-box { 
+display: flex; 
+align-items: center; 
+gap: 10px; 
+border: 1px solid rgba(141, 69, 255, 0.6); 
+border-radius: 12px; 
+padding: 10px; 
+background: rgba(141, 69, 255, 0.12); 
+box-shadow: 0 0 16px rgba(141, 69, 255, 0.35); 
+} 
+.spin-logo { width: 42px; height: 42px; object-fit: contain; filter: invert(1) brightness(1.8); } 
+.spin-logo.active { animation: spin 1.2s linear infinite; } 
+#thinkingText { margin: 0; position: relative; font-weight: 600; } 
+#thinkingText::after { 
+content: ""; 
+position: absolute; 
+inset: 0; 
+background: linear-gradient(120deg, transparent 0%, rgba(255,255,255,.55) 50%, transparent 100%); 
+transform: translateX(-130%); 
+animation: shimmer 1.4s infinite; 
+} 
+
+.ask-bar { display: grid; grid-template-columns: auto 1fr auto; gap: 8px; align-items: center; } 
+#aiSoru { min-height: 42px; max-height: 90px; resize: vertical; } 
+.plus-btn { 
+border-radius: 10px; 
+border: 1px solid #7045d8; 
+background: #1a1f43; 
+color: #fff; 
+width: 40px; 
+height: 40px; 
+font-size: 1.25rem; 
+} 
+.agent-menu { 
+border: 1px solid var(--soft-border); 
+border-radius: 10px; 
+padding: 10px; 
+background: rgba(17, 22, 45, 0.95); 
+} 
+.web-glow { box-shadow: inset 0 0 110px rgba(141,69,255,0.48), inset 0 0 200px rgba(72,100,255,0.22); } 
+
+@keyframes spin { to { transform: rotate(360deg);} } 
+@keyframes shimmer { to { transform: translateX(130%);} } 
+
+@media (max-width: 980px) { 
+.topbar { grid-template-columns: 1fr; } 
+.content-grid, .content-grid.with-panel { grid-template-columns: 1fr; } 
+.ai-panel { border-left: none; border-top: 1px solid var(--soft-border); height: auto; } 
+} 
+
+.app-hidden { 
+opacity: 0; 
+pointer-events: none; 
+} 
+
+.intro-overlay { 
+position: fixed; 
+inset: 0; 
+z-index: 12000; 
+display: grid; 
+place-content: center; 
+gap: 18px; 
+background: radial-gradient(circle at center, rgba(95, 41, 182, 0.42) 0%, rgba(6, 8, 17, 0.96) 62%, #03040a 100%); 
+transition: opacity .7s ease, visibility .7s ease; 
+} 
+
+.intro-overlay.hidden { 
+opacity: 0; 
+visibility: hidden; 
+} 
+
+.intro-card { 
+position: relative; 
+min-width: min(860px, 92vw); 
+padding: clamp(18px, 3vw, 30px) clamp(24px, 5vw, 60px); 
+border-radius: 999px; 
+border: 2px solid rgba(180, 140, 255, 0.92); 
+background: linear-gradient(140deg, rgba(90, 37, 176, .95), rgba(23, 20, 72, .94) 56%, rgba(10, 16, 58, .95)); 
+box-shadow: 0 0 26px rgba(141,69,255,.9), inset 0 0 22px rgba(236,226,255,.2), 0 0 70px rgba(89, 18, 180, 0.65); 
+transform: scale(.58) translateY(24px); 
+opacity: 0; 
+animation: introZoom .9s cubic-bezier(.15,.8,.22,1) forwards; 
+} 
+
+.intro-title { 
+position: relative; 
+text-align: center; 
+font-size: clamp(2rem, 5.5vw, 5rem); 
+letter-spacing: .8px; 
+font-weight: 800; 
+color: #eddcff; 
+text-shadow: 0 0 10px rgba(255,255,255,.3), 0 0 24px rgba(176,112,255,.72); 
+} 
+
+.intro-glow { 
+position: absolute; 
+inset: 4px; 
+border-radius: 999px; 
+pointer-events: none; 
+background: linear-gradient(110deg, rgba(255,255,255,.1), transparent 35%, rgba(255,255,255,.22) 50%, transparent 66%, rgba(255,255,255,.08)); 
+filter: blur(1px); 
+animation: introSheen 1.8s ease-in-out .25s 2; 
+} 
+
+.intro-subtitle { 
+margin: 0; 
+text-align: center; 
+color: #d8c0ff; 
+font-size: clamp(1rem, 2vw, 1.45rem); 
+opacity: 0; 
+transform: translateY(12px); 
+animation: subtitleIn .75s ease .75s forwards; 
+} 
+
+@keyframes introZoom { 
+to { transform: scale(1) translateY(0); opacity: 1; } 
+:root { 
+--night: #080b18; 
+--glow-purple: #8d45ff; 
+--text: #f7f6ff; 
+--soft-border: rgba(141, 69, 255, 0.32); 
+} 
+* { box-sizing: border-box; } 
+body { 
+margin: 0; 
+font-family: Inter, Arial, sans-serif; 
+color: var(--text); 
+background: radial-gradient(circle at top, #2a1454 0%, #0b1130 45%, #05070f 100%); 
+min-height: 100vh; 
+transition: box-shadow 0.4s ease; 
+} 
+.hidden { display: none !important; } 
+
+.topbar { 
+display: grid; 
+grid-template-columns: auto auto 1fr auto; 
+gap: 10px; 
+align-items: center; 
+padding: 10px 14px; 
+background: rgba(8, 11, 24, 0.88); 
+border-bottom: 1px solid var(--soft-border); 
+position: sticky; 
+top: 0; 
+z-index: 10; 
+backdrop-filter: blur(6px); 
+} 
+.tab { background: #1d2140; border: 1px solid #31386d; color: #ded4ff; border-radius: 10px; padding: 8px 14px; } 
+
+.browser-controls button, 
+.search-box button, 
+.stacked-form button, 
+#sendBtn, 
+.agent-menu button, 
+.close-panel, 
+.result-actions button { 
+border: 1px solid #5a3fa0; 
+background: #1c2146; 
+color: var(--text); 
+border-radius: 10px; 
+padding: 8px 12px; 
+cursor: pointer; 
+} 
+
+#adresCubugu, 
+.search-box input, 
+.stacked-form input, 
+#aiSoru { 
+width: 100%; 
+background: #0f1431; 
+color: var(--text); 
+border: 1px solid #3f4678; 
+border-radius: 10px; 
+padding: 10px; 
+
+} 
+
+.baluk-mini { 
+border: 1px solid #8f4bff; 
+background: linear-gradient(135deg, #311062, #6e2ee2); 
+color: #fff; 
+font-weight: 700; 
+border-radius: 12px; 
+padding: 10px 14px; 
+box-shadow: 0 0 20px rgba(141, 69, 255, 0.7), inset 0 0 8px rgba(255,255,255,0.2); 
+} 
+
+.content-grid { 
+display: grid; 
+grid-template-columns: 1fr; 
+min-height: calc(100vh - 69px); 
+transition: grid-template-columns .35s ease; 
+} 
+.content-grid.with-panel { grid-template-columns: 1fr 350px; } 
+
+.search-screen, 
+.web-screen { padding: 38px 20px; } 
+.search-screen h1 { 
+text-align: center; 
+margin-top: 60px; 
+font-size: clamp(2rem, 6vw, 3.8rem); 
+color: #e1d1ff; 
+text-shadow: 0 0 10px rgba(141, 69, 255, 0.8), 0 0 24px rgba(141, 69, 255, 0.6); 
+} 
+
+.search-box { 
+max-width: 760px; 
+margin: 16px auto 24px; 
+display: grid; 
+grid-template-columns: 1fr auto; 
+gap: 10px; 
+} 
+.results { 
+max-width: 920px; 
+margin: 0 auto; 
+display: grid; 
+gap: 14px; 
+} 
+.result-item { 
+background: linear-gradient(180deg, rgba(19, 23, 49, 0.92), rgba(11, 15, 33, 0.92)); 
+border: 1px solid var(--soft-border); 
+border-radius: 16px; 
+padding: 14px; 
+} 
+.result-item h3 { margin: 0 0 6px; } 
+.result-item p { margin: 0 0 10px; color: #d5ceee; } 
+.result-item a { color: #d9c6ff; text-decoration: none; } 
+.result-actions { display: flex; gap: 8px; } 
+.result-actions button:last-child { 
+background: linear-gradient(135deg, #3d1678, #6d2de2); 
+border-color: #a77eff; 
+box-shadow: 0 0 12px rgba(141,69,255,.45); 
+} 
+
+#siteFrame { 
+width: 100%; 
+height: calc(100vh - 150px); 
+border: 1px solid rgba(141, 69, 255, 0.42); 
+border-radius: 14px; 
+background: white; 
+} 
+
+.ai-panel { 
+border-left: 1px solid var(--soft-border); 
+background: linear-gradient(180deg, rgba(14, 16, 38, 0.99), rgba(8, 10, 21, 0.98)); 
+padding: 14px; 
+height: calc(100vh - 69px); 
+display: flex; 
+flex-direction: column; 
+
+
+
+} 
+.panel-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; } 
+.logo-head { display: flex; align-items: center; gap: 8px; } 
+.baluk-logo-head { width: 42px; height: 18px; object-fit: contain; filter: brightness(2.2) contrast(0.7); } 
+
+.profile-card { 
+display: flex; 
+align-items: center; 
+gap: 10px; 
+border: 1px solid var(--soft-border); 
+border-radius: 12px; 
+padding: 10px; 
+background: rgba(141, 69, 255, 0.1); 
+} 
+#profileAvatar { 
+width: 52px; height: 52px; border-radius: 50%; object-fit: cover; 
+border: 2px solid rgba(255,255,255,0.35); background: #1e254e; 
+} 
+#profileMail { margin: 2px 0 0; color: #cab9ff; font-size: .85rem; } 
+
+.assistant-layout { height: 100%; display: flex; flex-direction: column; gap: 12px; } 
+.ai-answer { 
+flex: 1; 
+overflow: auto; 
+background: rgba(15, 20, 43, 0.72); 
+border: 1px solid rgba(141,69,255,0.25); 
+border-radius: 12px; 
+padding: 12px; 
+line-height: 1.5; 
+} 
+.thinking-box { 
+display: flex; 
+align-items: center; 
+gap: 10px; 
+border: 1px solid rgba(141, 69, 255, 0.6); 
+border-radius: 12px; 
+padding: 10px; 
+background: rgba(141, 69, 255, 0.12); 
+box-shadow: 0 0 16px rgba(141, 69, 255, 0.35); 
+} 
+.spin-logo { width: 42px; height: 42px; object-fit: contain; filter: invert(1) brightness(1.8); } 
+.spin-logo.active { animation: spin 1.2s linear infinite; } 
+#thinkingText { margin: 0; position: relative; font-weight: 600; } 
+#thinkingText::after { 
+content: ""; 
+position: absolute; 
+inset: 0; 
+background: linear-gradient(120deg, transparent 0%, rgba(255,255,255,.55) 50%, transparent 100%); 
+transform: translateX(-130%); 
+animation: shimmer 1.4s infinite; 
+} 
+
+.ask-bar { display: grid; grid-template-columns: auto 1fr auto; gap: 8px; align-items: center; } 
+#aiSoru { min-height: 42px; max-height: 90px; resize: vertical; } 
+.plus-btn { 
+border-radius: 10px; 
+border: 1px solid #7045d8; 
+background: #1a1f43; 
+color: #fff; 
+width: 40px; 
+height: 40px; 
+font-size: 1.25rem; 
+} 
+.agent-menu { 
+border: 1px solid var(--soft-border); 
+border-radius: 10px; 
+padding: 10px; 
+background: rgba(17, 22, 45, 0.95); 
+} 
+.web-glow { box-shadow: inset 0 0 110px rgba(141,69,255,0.48), inset 0 0 200px rgba(72,100,255,0.22); } 
+
+@keyframes spin { to { transform: rotate(360deg);} } 
+@keyframes shimmer { to { transform: translateX(130%);} } 
+
+@media (max-width: 980px) { 
+.topbar { grid-template-columns: 1fr; } 
+.content-grid, .content-grid.with-panel { grid-template-columns: 1fr; } 
+.ai-panel { border-left: none; border-top: 1px solid var(--soft-border); height: auto; } 
+} 
+
+.app-hidden { 
+opacity: 0; 
+pointer-events: none; 
+} 
+
+.intro-overlay { 
+position: fixed; 
+inset: 0; 
+z-index: 12000; 
+display: grid; 
+place-content: center; 
+gap: 18px; 
+background: radial-gradient(circle at center, rgba(95, 41, 182, 0.42) 0%, rgba(6, 8, 17, 0.96) 62%, #03040a 100%); 
+transition: opacity .7s ease, visibility .7s ease; 
+} 
+
+.intro-overlay.hidden { 
+opacity: 0; 
+visibility: hidden; 
+} 
+
+.intro-card { 
+position: relative; 
+min-width: min(860px, 92vw); 
+padding: clamp(18px, 3vw, 30px) clamp(24px, 5vw, 60px); 
+border-radius: 999px; 
+border: 2px solid rgba(180, 140, 255, 0.92); 
+background: linear-gradient(140deg, rgba(90, 37, 176, .95), rgba(23, 20, 72, .94) 56%, rgba(10, 16, 58, .95)); 
+box-shadow: 0 0 26px rgba(141,69,255,.9), inset 0 0 22px rgba(236,226,255,.2), 0 0 70px rgba(89, 18, 180, 0.65); 
+transform: scale(.58) translateY(24px); 
+opacity: 0; 
+animation: introZoom .9s cubic-bezier(.15,.8,.22,1) forwards; 
+} 
+
+.intro-title { 
+position: relative; 
+text-align: center; 
+font-size: clamp(2rem, 5.5vw, 5rem); 
+letter-spacing: .8px; 
+font-weight: 800; 
+color: #eddcff; 
+text-shadow: 0 0 10px rgba(255,255,255,.3), 0 0 24px rgba(176,112,255,.72); 
+} 
+
+.intro-glow { 
+position: absolute; 
+inset: 4px; 
+border-radius: 999px; 
+pointer-events: none; 
+background: linear-gradient(110deg, rgba(255,255,255,.1), transparent 35%, rgba(255,255,255,.22) 50%, transparent 66%, rgba(255,255,255,.08)); 
+filter: blur(1px); 
+animation: introSheen 1.8s ease-in-out .25s 2; 
+} 
+
+.intro-subtitle { 
+margin: 0; 
+text-align: center; 
+color: #d8c0ff; 
+font-size: clamp(1rem, 2vw, 1.45rem); 
+opacity: 0; 
+transform: translateY(12px); 
+animation: subtitleIn .75s ease .75s forwards; 
+} 
+
+@keyframes introZoom { 
+to { transform: scale(1) translateY(0); opacity: 1; } 


### PR DESCRIPTION
### Motivation
- Replace the previous simple video-sharing UI with an AI-first mini browser experience to provide web search, page inspection and an assistant panel.
- Provide a guided intro, persistent user profile storage and an interactive AI assistant with an "Agent Mode" that can automate searches and open links.
- Improve visual design and responsiveness with a modern dark theme and animated components.

### Description
- Overhauled `index.html` to a new layout for "Baluk Screatch" including an intro overlay, topbar, address bar, search/home view, web iframe view and an AI side panel with auth and assistant areas. 
- Rewrote `script.js` to implement application state, history navigation, DuckDuckGo search integration, AI response building (`buildAiAnswer`), site parsing (`parseSite`), Wikipedia snippet fetching, an animated intro (`runIntro`), and an interactive Agent Mode (`runAgentSearchFlow`).
- Replaced old localStorage keys and user handling with `balukUser`, added a custom cursor for agent actions, a thinking UI with rotating hints, and safe URL handling via `ensureUrl` and `openUrl`.
- Replaced `style.css` with a comprehensive new stylesheet providing theming, responsive grid layout, panel behavior, animations, and styles for all new components including the intro card and AI panel.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7c1eb1db8832c82130ff2b03b4448)